### PR TITLE
fix: unpkg bundle holds everything needed and refers to peers correctly

### DIFF
--- a/.changeset/afraid-phones-sip.md
+++ b/.changeset/afraid-phones-sip.md
@@ -1,0 +1,28 @@
+---
+'@data-client/use-enhanced-reducer': patch
+'@data-client/normalizr': patch
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/hooks': patch
+'@data-client/react': patch
+'@data-client/redux': patch
+'@data-client/core': patch
+'@data-client/rest': patch
+'@data-client/img': patch
+'@data-client/ssr': patch
+---
+
+Fix unpkg bundles and update names
+
+- Client packages namespace into RDC
+  - @data-client/react - RDC
+  - @data-client/core - RDC.Core
+  - @data-client/redux - RDC.Redux
+- Definition packages namespace top level
+  - @data-client/rest - Rest
+  - @data-client/graphql - GraphQL
+  - @data-client/img - Img
+  - @data-client/endpoint - Endpoint
+- Utility
+  - @data-client/normalizr - normalizr
+  - @data-client/use-enhanced-reducer - EnhancedReducer

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -27,7 +27,7 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   configs.push({
     input: 'lib/index.js',
     external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientCore' }],
+    output: [{ file: pkg.unpkg, format: 'umd', name: 'RDC.Core' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/endpoint/rollup.config.js
+++ b/packages/endpoint/rollup.config.js
@@ -27,7 +27,7 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   configs.push({
     input: 'lib/index.js',
     external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientEndpoint' }],
+    output: [{ file: pkg.unpkg, format: 'umd', name: 'Endpoint' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/graphql/rollup.config.js
+++ b/packages/graphql/rollup.config.js
@@ -25,8 +25,7 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   // browser-friendly UMD build
   configs.push({
     input: 'lib/index.js',
-    external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientRest' }],
+    output: [{ file: pkg.unpkg, format: 'umd', name: 'GraphQL' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/hooks/rollup.config.js
+++ b/packages/hooks/rollup.config.js
@@ -12,6 +12,7 @@ import pkg from './package.json';
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
   .filter(dep => !['@babel/runtime'].includes(dep));
+const peers = Object.keys(pkg.peerDependencies);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 const nativeExtensions = ['.native.ts', ...extensions];
@@ -32,8 +33,8 @@ export default [
   // browser-friendly UMD build
   {
     input: 'lib/index.js',
-    external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientHooks' }],
+    external: id => peers.some(dep => dep === id || id.startsWith(dep)),
+    output: [{ file: pkg.unpkg, format: 'umd', name: 'RDC.Hooks' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/img/rollup.config.js
+++ b/packages/img/rollup.config.js
@@ -11,6 +11,7 @@ import pkg from './package.json';
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
   .filter(dep => !['@babel/runtime'].includes(dep));
+const peers = Object.keys(pkg.peerDependencies);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 const nativeExtensions = ['.native.ts', ...extensions];
@@ -25,8 +26,17 @@ export default [
   // browser-friendly UMD build
   {
     input: 'lib/index.js',
-    external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientImg' }],
+    external: id => peers.some(dep => dep === id || id.startsWith(dep)),
+    output: [
+      {
+        file: pkg.unpkg,
+        format: 'umd',
+        name: 'Img',
+        globals: {
+          '@data-client/react': 'RDC',
+        },
+      },
+    ],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/normalizr/rollup.config.js
+++ b/packages/normalizr/rollup.config.js
@@ -1,11 +1,11 @@
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
+import dts from 'rollup-plugin-dts';
 import filesize from 'rollup-plugin-filesize';
 import resolve from 'rollup-plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
-import dts from 'rollup-plugin-dts';
 
-import { name } from './package.json';
+const name = 'normalizr';
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -15,6 +15,7 @@ const dependencies = Object.keys(pkg.dependencies)
     dep =>
       !['@data-client/use-enhanced-reducer', '@babel/runtime'].includes(dep),
   );
+const peers = Object.keys(pkg.peerDependencies);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node', '.jsx'];
 const nativeExtensions = ['.native.ts', ...extensions];
@@ -29,12 +30,12 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   // browser-friendly UMD build
   configs.push({
     input: 'lib/index.js',
-    external: isExternal,
+    external: id => peers.some(dep => dep === id || id.startsWith(dep)),
     output: [
       {
         file: pkg.unpkg,
         format: 'umd',
-        name: 'dataClientCore',
+        name: 'RDC',
         inlineDynamicImports: true,
       },
     ],

--- a/packages/redux/rollup.config.js
+++ b/packages/redux/rollup.config.js
@@ -12,6 +12,7 @@ import { typeConfig } from '../../scripts/rollup-utils';
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
   .filter(dep => !['@babel/runtime'].includes(dep));
+const peers = Object.keys(pkg.peerDependencies);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node', '.jsx'];
 const nativeExtensions = ['.native.ts', ...extensions];
@@ -26,8 +27,19 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   // browser-friendly UMD build
   configs.push({
     input: 'lib/index.js',
-    external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientCore' }],
+    external: id => peers.some(dep => dep === id || id.startsWith(dep)),
+    output: [
+      {
+        file: pkg.unpkg,
+        format: 'umd',
+        name: 'RDC.Redux',
+        globals: {
+          '@data-client/react': 'RDC',
+          redux: 'Redux',
+          react: 'React',
+        },
+      },
+    ],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/rest/rollup.config.js
+++ b/packages/rest/rollup.config.js
@@ -26,8 +26,7 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   // browser-friendly UMD build
   configs.push({
     input: 'lib/index.js',
-    external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientRest' }],
+    output: [{ file: pkg.unpkg, format: 'umd', name: 'Rest' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/ssr/rollup.config.js
+++ b/packages/ssr/rollup.config.js
@@ -12,6 +12,7 @@ const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
   .concat(['@data-client/core', 'data-client'])
   .filter(dep => !['@babel/runtime'].includes(dep));
+const peers = Object.keys(pkg.peerDependencies);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 const nativeExtensions = ['.native.ts', ...extensions];
@@ -25,8 +26,20 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   // browser-friendly UMD build
   configs.push({
     input: 'lib/index.js',
-    external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClientRest' }],
+    external: id => peers.some(dep => dep === id || id.startsWith(dep)),
+    output: [
+      {
+        file: pkg.unpkg,
+        format: 'umd',
+        name: 'RDC.SSR',
+        globals: {
+          '@data-client/react': 'RDC',
+          '@data-client/redux': 'RDC.Redux',
+          redux: 'Redux',
+          react: 'React',
+        },
+      },
+    ],
     plugins: [
       babel({
         exclude: ['node_modules/**', '/**__tests__/**'],

--- a/packages/use-enhanced-reducer/rollup.config.js
+++ b/packages/use-enhanced-reducer/rollup.config.js
@@ -31,7 +31,7 @@ export default [
   {
     input: 'lib/index.js',
     external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'dataClient' }],
+    output: [{ file: pkg.unpkg, format: 'umd', name: 'EnhancedReducer' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '**/__tests__/**'],


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Stackoverflow example embeds can utilize umd well

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### Globals naming

- Client packages namespace into RDC
  - @data-client/react - RDC
  - @data-client/core - RDC.Core
  - @data-client/redux - RDC.Redux
- Definition packages namespace top level
  - @data-client/rest - Rest
  - @data-client/graphql - GraphQL
  - @data-client/img - Img
  - @data-client/endpoint - Endpoint
- Utility
  - @data-client/normalizr - normalizr
  - @data-client/use-enhanced-reducer - EnhancedReducer
  - @data-client/test - [does not have an unpkg]

#### Configuration fixes

- unpkg (UMD) builds should bundle all non-peers (update externals specifically to only be listed peers)
- update names to above
- Add [output.globals](https://rollupjs.org/configuration-options/#output-globals) to correctly map the peerdeps to their unpkg name