### PR TITLE
enhance: Improve compatibility by forcing app directive in commonjs build

### DIFF
--- a/.changeset/stupid-flies-yell.md
+++ b/.changeset/stupid-flies-yell.md
@@ -1,0 +1,5 @@
+---
+'@data-client/react': patch
+---
+
+CommonJS build includes NextJS App Directive compatibility

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "rimraf": "^5.0.0",
     "rollup": "2.79.1",
     "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-banner2": "^1.2.2",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-filesize": "^9.1.2",

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,4 +1,5 @@
 import babel from 'rollup-plugin-babel';
+import banner from 'rollup-plugin-banner2';
 import commonjs from 'rollup-plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
 import json from 'rollup-plugin-json';
@@ -76,6 +77,8 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
         replace({ 'process.env.CJS': 'true' }),
         resolve({ extensions: nativeExtensions }),
         commonjs({ extensions: nativeExtensions }),
+        // for nextjs 13 compatibility in node https://nextjs.org/docs/app/building-your-application/rendering
+        banner(() => "'use client';\n"),
       ],
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -18438,7 +18438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.25.1, magic-string@npm:^0.25.2":
+"magic-string@npm:^0.25.1, magic-string@npm:^0.25.2, magic-string@npm:^0.25.7":
   version: 0.25.9
   resolution: "magic-string@npm:0.25.9"
   dependencies:
@@ -25684,6 +25684,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup-plugin-banner2@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "rollup-plugin-banner2@npm:1.2.2"
+  dependencies:
+    magic-string: ^0.25.7
+  checksum: 6647602b31d35d5f925920254e70fa9f0d272fda2a3eae0a749a500f32c78ce82f3f48200c5b6cc0f983fe412471b749b53333d87f9e430bd8b2a95637648347
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-commonjs@npm:^10.1.0":
   version: 10.1.0
   resolution: "rollup-plugin-commonjs@npm:10.1.0"
@@ -25872,6 +25881,7 @@ __metadata:
     rimraf: ^5.0.0
     rollup: 2.79.1
     rollup-plugin-babel: ^4.4.0
+    rollup-plugin-banner2: ^1.2.2
     rollup-plugin-commonjs: ^10.1.0
     rollup-plugin-dts: ^5.0.0
     rollup-plugin-filesize: ^9.1.2


### PR DESCRIPTION
Fixes #2822

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
NextJS app router does not support any concept of state or server side rendering. It forces a directive to even run. We include these in our ESM, but rollup removes the directives, so our commonjs output is missing these.


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Rollup issue: https://github.com/rollup/rollup/issues/4699 we found:
Copied https://github.com/inokawa/virtua/pull/103/files that simply pastes it to the top.