### PR TITLE
feat: Add RestEndpoint.searchToString()

### DIFF
--- a/.changeset/chilly-mugs-work.md
+++ b/.changeset/chilly-mugs-work.md
@@ -1,0 +1,7 @@
+---
+"@data-client/rest": minor
+---
+
+Add exports getUrlBase, getUrlTokens used to construct URLs
+
+This enables custom RestEndpoint.url() implementations

--- a/.changeset/lemon-zoos-relax.md
+++ b/.changeset/lemon-zoos-relax.md
@@ -1,0 +1,20 @@
+---
+"@data-client/rest": minor
+---
+
+Add RestEndpoint.searchToString()
+
+For example:
+
+To encode complex objects in the searchParams, you can use the [qs](https://github.com/ljharb/qs) library.
+
+```typescript
+import { RestEndpoint, RestGenerics } from '@data-client/rest';
+import qs from 'qs';
+
+class MyEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
+  searchToString(searchParams) {
+    return qs.stringify(searchParams);
+  }
+}
+```

--- a/docs/rest/diagrams/_restendpoint_lifecycle.mdx
+++ b/docs/rest/diagrams/_restendpoint_lifecycle.mdx
@@ -8,7 +8,8 @@ flowchart TB
         direction BT
         urlPrefix-->url("url(urlParams)")
         path-->url
-        searchParams-->url
+        searchToString("searchToString()")-->url
+        searchParams-->searchToString("searchToString()")
       end
       subgraph INIT
       direction BT
@@ -22,6 +23,7 @@ flowchart TB
     parse-->process("process()")
     end
     click url "/rest/api/RestEndpoint#url"
+    click searchToString "/rest/api/RestEndpoint#searchToString"
     click searchParams "/rest/api/RestEndpoint#searchParams"
     click urlPrefix "/rest/api/RestEndpoint#urlPrefix"
     click path "/rest/api/RestEndpoint#path"

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -76,9 +76,14 @@ export default class RestEndpoint extends Endpoint {
       }
     });
     if (Object.keys(searchParams).length) {
-      return `${this.urlPrefix}${urlBase}?${paramsToString(searchParams)}`;
+      return `${this.urlPrefix}${urlBase}?${this.searchToString(searchParams)}`;
     }
     return `${this.urlPrefix}${urlBase}`;
+  }
+
+  /** Encode the url searchParams */
+  searchToString(searchParams) {
+    return paramsToString(searchParams);
   }
 
   getHeaders(headers) {

--- a/packages/rest/src/RestEndpointTypes.ts
+++ b/packages/rest/src/RestEndpointTypes.ts
@@ -42,31 +42,53 @@ export interface RestInstanceBase<
    */
   readonly urlPrefix: string;
   readonly requestInit: RequestInit;
-  /** @see https://dataclient.io/rest/api/RestEndpoint#method */
+  /** HTTP request method
+   * @see https://dataclient.io/rest/api/RestEndpoint#method
+   */
   readonly method: (O & { method: string })['method'];
   readonly signal: AbortSignal | undefined;
+  /** @see https://dataclient.io/rest/api/RestEndpoint#paginationField */
   readonly paginationField?: string;
 
   /* fetch lifecycles */
   /* before-fetch */
+  /** Builds the URL to fetch
+   * @see https://dataclient.io/rest/api/RestEndpoint#url
+   */
   url(...args: Parameters<F>): string;
-  /** @see https://dataclient.io/rest/api/RestEndpoint#getRequestInit */
+  /** Encode the searchParams component of the url
+   * @see https://dataclient.io/rest/api/RestEndpoint#searchToString
+   */
+  searchToString(searchParams: Record<string, any>): string;
+  /** Prepares RequestInit used in fetch. This is sent to fetchResponse()
+   * @see https://dataclient.io/rest/api/RestEndpoint#getRequestInit
+   */
   getRequestInit(
     this: any,
     body?: RequestInit['body'] | Record<string, unknown>,
   ): Promise<RequestInit> | RequestInit;
-  /** @see https://dataclient.io/rest/api/RestEndpoint#getHeaders */
+  /** Called by getRequestInit to determine HTTP Headers
+   * @see https://dataclient.io/rest/api/RestEndpoint#getHeaders
+   */
   getHeaders(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
   /* after-fetch */
-  /** @see https://dataclient.io/rest/api/RestEndpoint#fetchResponse */
+  /** Performs the fetch call
+   * @see https://dataclient.io/rest/api/RestEndpoint#fetchResponse
+   */
   fetchResponse(input: RequestInfo, init: RequestInit): Promise<Response>;
-  /** @see https://dataclient.io/rest/api/RestEndpoint#parseResponse */
+  /** Takes the Response and parses via .text() or .json()
+   * @see https://dataclient.io/rest/api/RestEndpoint#parseResponse
+   */
   parseResponse(response: Response): Promise<any>;
-  /** @see https://dataclient.io/rest/api/RestEndpoint#process */
+  /** Perform any transforms with the parsed result.
+   * @see https://dataclient.io/rest/api/RestEndpoint#process
+   */
   process(value: any, ...args: Parameters<F>): ResolveType<F>;
 
   /* utilities */
-  /** @see https://dataclient.io/rest/api/RestEndpoint#testKey */
+  /** Returns true if the provided (fetch) key matches this endpoint.
+   * @see https://dataclient.io/rest/api/RestEndpoint#testKey
+   */
   testKey(key: string): boolean;
 
   /* extenders */

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -20,6 +20,7 @@ export type {
   PaginationFieldEndpoint,
   PaginationEndpoint,
 } from './RestEndpoint.js';
+export { getUrlBase, getUrlTokens } from './RestHelpers.js';
 export { default as createResource } from './createResource.js';
 export type { Resource } from './resourceTypes.js';
 export type { ResourceOptions, ResourceGenerics } from './resourceTypes.js';

--- a/packages/rest/src/paramsToString.native.ts
+++ b/packages/rest/src/paramsToString.native.ts
@@ -1,5 +1,10 @@
 export default function paramsToString(
-  searchParams: Readonly<Record<string, string | number>>,
+  searchParams?:
+    | string
+    | URLSearchParams
+    | Record<string, string>
+    | string[][]
+    | undefined,
 ) {
   const params = new URLSearchParams(searchParams as any);
   try {

--- a/packages/rest/src/paramsToString.ts
+++ b/packages/rest/src/paramsToString.ts
@@ -1,7 +1,12 @@
 export default function paramsToString(
-  searchParams: Readonly<Record<string, string | number | boolean>>,
+  searchParams?:
+    | string
+    | URLSearchParams
+    | Record<string, string>
+    | string[][]
+    | undefined,
 ) {
-  const params = new URLSearchParams(searchParams as any);
+  const params = new URLSearchParams(searchParams);
   params.sort();
   return params.toString();
 }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2917 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Enable usage of complex objects in [searchParams](https://dataclient.io/rest/api/RestEndpoint#searchParams)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add [RestEndpoint.searchToString()](https://dataclient.io/rest/api/RestEndpoint#searchToString) to enable more easy customization of the serialization:

```typescript
import { RestEndpoint, RestGenerics } from '@data-client/rest';
import qs from 'qs';

class MyEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
  searchToString(searchParams) {
    return qs.stringify(searchParams);
  }
}
```

Also export `getUrlBase`, and `getUrlTokens`, to make it possible to customize the [url](https://dataclient.io/rest/api/RestEndpoint#url) method as well.