### PR TITLE
internal: Do not globally install corepack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
       - run:
           name: yarn install
           command: |
-            sudo npm install -g corepack
             sudo corepack enable
             YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn workspace todo-app add @data-client/endpoint@workspace:^ @data-client/react@workspace:^ @data-client/rest@workspace:^
             YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn workspace github-app add @data-client/graphql@workspace:^ @data-client/hooks@workspace:^ @data-client/react@workspace:^ @data-client/rest@workspace:^

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,6 @@ jobs:
         cache: 'yarn'
     - name: Install packages
       run: |
-        npm install -g corepack
         corepack enable
         yarn install --immutable
     - name: Build packages


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Recent version of corepack breaks due to https://github.com/nodejs/corepack/issues/379

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Now that we're on the latest node in CI, corepack is preinstalled so just use that version.