### PR TITLE
fix: Missing nested entities should appear once they are present

### DIFF
--- a/.changeset/tough-panthers-compare.md
+++ b/.changeset/tough-panthers-compare.md
@@ -1,0 +1,6 @@
+---
+"@data-client/normalizr": patch
+---
+
+fix: Missing nested entities should appear once they are present \
+

--- a/packages/normalizr/src/WeakEntityMap.ts
+++ b/packages/normalizr/src/WeakEntityMap.ts
@@ -1,3 +1,4 @@
+import { UNDEF } from './denormalize/UNDEF.js';
 import { isImmutable } from './schemas/ImmutableUtils.js';
 import { Path } from './types.js';
 
@@ -14,7 +15,8 @@ export default class WeakEntityMap<K extends object = object, V = any> {
     let curLink = this.next.get(entity);
     if (!curLink) return EMPTY;
     while (curLink.nextPath) {
-      const nextEntity = getEntity(curLink.nextPath);
+      // we cannot perform lookups with `undefined`, so we use a special object to represent undefined
+      const nextEntity = getEntity(curLink.nextPath) ?? UNDEF;
       curLink = curLink.next.get(nextEntity as any);
       if (!curLink) return EMPTY;
     }

--- a/packages/normalizr/src/__tests__/denormalizeCached.js
+++ b/packages/normalizr/src/__tests__/denormalizeCached.js
@@ -390,11 +390,57 @@ describe('denormalize with global cache', () => {
       );
 
       expect(first).not.toBe(second);
-      expect(first.title).toBe(second.title);
+      expect(first.data.title).toBe(second.data.title);
       expect(first.data.author).toBe(second.data.author);
       expect(second.data.comments[0].comment).toEqual('Updated comment!');
       expect(first.data.comments[0]).not.toBe(second.data.comments[0]);
       expect(first.data.comments[0].user).toBe(second.data.comments[0].user);
+    });
+
+    test('nested entity becomes present in entity table', () => {
+      const entityCache = {};
+      const resultCache = new WeakEntityMap();
+
+      const result = { data: '123' };
+      const emptyEntities = {
+        ...entities,
+        // no Users exist
+        User: {},
+      };
+      const { data: first } = denormalize(
+        result,
+        { data: Article },
+        emptyEntities,
+        entityCache,
+        resultCache,
+      );
+
+      const { data: second } = denormalize(
+        result,
+        { data: Article },
+        emptyEntities,
+        entityCache,
+        resultCache,
+      );
+
+      const { data: third } = denormalize(
+        result,
+        { data: Article },
+        // now has users
+        entities,
+        entityCache,
+        resultCache,
+      );
+
+      expect(first.data.title).toBe(third.data.title);
+      expect(first.data.author).toBeUndefined();
+      // maintain cache when nested value is undefined
+      expect(first.data).toBe(second.data);
+      expect(first).toBe(second);
+      // update value when nested value becomes defined
+      expect(third.data.author).toBeDefined();
+      expect(third.data.author.name).toEqual(expect.any(String));
+      expect(first).not.toBe(third);
     });
   });
 

--- a/packages/normalizr/src/denormalize/UNDEF.ts
+++ b/packages/normalizr/src/denormalize/UNDEF.ts
@@ -1,0 +1,1 @@
+export const UNDEF = {};


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Support resolving nested entities from a distinct fetch (client-side joins): https://dataclient.io/rest/api/Query#client-side-joins

In the case where:
- nested pk is valid
- but the entity is not present in cache

We currently won't bust the cache when those nested entities show up later (due to racing fetches). This means the above example will not show the nested members if they resolve *after* the top-level entity fetch.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

When we have both a valid pk, and the entity from store is `undefined` we will add it to the dependency paths with a special `UNDEF` constant. This constant is needed so it can be used as a key in WeakMap (as only objects are tracked). In this sense, we simulate the value of `undefined` by having a special value for it that does not change.