### PR TITLE
fix: Properly vary cache when nested pk is a number

### DIFF
--- a/.changeset/mean-mayflies-sleep.md
+++ b/.changeset/mean-mayflies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@data-client/normalizr": patch
+---
+
+fix: Missing nested entities should appear once they are present (When nesting pk was a number type)

--- a/.changeset/serious-dogs-battle.md
+++ b/.changeset/serious-dogs-battle.md
@@ -1,0 +1,48 @@
+---
+"@data-client/normalizr": patch
+'@data-client/endpoint': patch
+---
+
+Always normalize pk to string type
+
+Warning: This will affect contents of the store state (some numbers will appear as strings)
+
+Before:
+
+```json
+{
+  "Article": {
+    "123": {
+      "author": 8472,
+      "id": 123,
+      "title": "A Great Article",
+    },
+  },
+  "User": {
+    "8472": {
+      "id": 8472,
+      "name": "Paul",
+    },
+  },
+}
+```
+
+After:
+
+```json
+{
+  "Article": {
+    "123": {
+      "author": "8472",
+      "id": 123,
+      "title": "A Great Article",
+    },
+  },
+  "User": {
+    "8472": {
+      "id": 8472,
+      "name": "Paul",
+    },
+  },
+}
+```

--- a/.changeset/tough-panthers-compare.md
+++ b/.changeset/tough-panthers-compare.md
@@ -2,5 +2,5 @@
 "@data-client/normalizr": patch
 ---
 
-fix: Missing nested entities should appear once they are present \
+fix: Missing nested entities should appear once they are present
 

--- a/.changeset/two-foxes-explode.md
+++ b/.changeset/two-foxes-explode.md
@@ -1,0 +1,29 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+---
+
+Allow pk() to return numbers
+
+Before:
+
+```ts
+class MyEntity extends Entity {
+  id = 0;
+  pk() {
+    return `${this.id}`;
+  }
+}
+```
+
+After:
+
+```ts
+class MyEntity extends Entity {
+  id = 0;
+  pk() {
+    return this.id;
+  }
+}
+```

--- a/docs/rest/api/Query.md
+++ b/docs/rest/api/Query.md
@@ -295,6 +295,7 @@ function TodosPage() {
   useFetch(TodoResource.getList);
   const todos = useCache(todosWithUser, { userId: 1 });
   if (!todos) return <div>No Todos in cache yet</div>;
+  if (!todos.length) return <div>No Todos match user</div>;
   return (
     <div>
       {todos.map(todo => (

--- a/docs/rest/api/schema.Entity.md
+++ b/docs/rest/api/schema.Entity.md
@@ -55,7 +55,7 @@ class UserEntity extends schema.Entity(User, {
 
 </TypeScriptEditor>
 
-### pk: string | (value, parent?, key?, args?) => string | undefined = 'id' {#pk}
+### pk: string | (value, parent?, key?, args?) => string | number | undefined = 'id' {#pk}
 
 Specifies the [Entity.pk](./Entity.md#pk)
 

--- a/packages/endpoint/src-4.0-types/schemas/Entity.d.ts
+++ b/packages/endpoint/src-4.0-types/schemas/Entity.d.ts
@@ -6,7 +6,7 @@ declare const Entity_base: import('./EntitySchema.js').IEntityClass<
       parent?: any,
       key?: string | undefined,
       args?: readonly any[] | undefined,
-    ): string | undefined;
+    ): string | number | undefined;
   }
 > &
   (new (...args: any[]) => {
@@ -14,7 +14,7 @@ declare const Entity_base: import('./EntitySchema.js').IEntityClass<
       parent?: any,
       key?: string | undefined,
       args?: readonly any[] | undefined,
-    ): string | undefined;
+    ): string | number | undefined;
   });
 /**
  * Represents data that should be deduped by specifying a primary key.
@@ -33,7 +33,7 @@ export default abstract class Entity extends Entity_base {
     parent?: any,
     key?: string,
     args?: readonly any[],
-  ): string | undefined;
+  ): string | number | undefined;
 
   /** Control how automatic schema validation is handled
    *
@@ -68,7 +68,7 @@ export default abstract class Entity extends Entity_base {
     parent?: any,
     key?: string,
     args?: any[],
-  ) => string | undefined;
+  ) => string | number | undefined;
 
   /** Do any transformations when first receiving input
    *

--- a/packages/endpoint/src-4.0-types/schemas/EntitySchema.d.ts
+++ b/packages/endpoint/src-4.0-types/schemas/EntitySchema.d.ts
@@ -6,7 +6,11 @@ export type IDClass = new (...args: any[]) => {
   id: string | number | undefined;
 };
 export type PKClass = new (...args: any[]) => {
-  pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+  pk(
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | number | undefined;
 };
 type ValidSchemas<TInstance> = {
   [k in keyof TInstance]?: Schema;
@@ -14,7 +18,11 @@ type ValidSchemas<TInstance> = {
 export type EntityOptions<TInstance extends {}> = {
   readonly schema?: ValidSchemas<TInstance>;
   readonly pk?:
-    | ((value: TInstance, parent?: any, key?: string) => string | undefined)
+    | ((
+        value: TInstance,
+        parent?: any,
+        key?: string,
+      ) => string | number | undefined)
     | keyof TInstance;
   readonly key?: string;
 } & {
@@ -33,7 +41,11 @@ export type EntityOptions<TInstance extends {}> = {
 export interface RequiredPKOptions<TInstance extends {}>
   extends EntityOptions<TInstance> {
   readonly pk:
-    | ((value: TInstance, parent?: any, key?: string) => string | undefined)
+    | ((
+        value: TInstance,
+        parent?: any,
+        key?: string,
+      ) => string | number | undefined)
     | keyof TInstance;
 }
 export default function EntitySchema<TBase extends Constructor>(
@@ -84,7 +96,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
     parent?: any,
     key?: string,
     args?: any[],
-  ): string | undefined;
+  ): string | number | undefined;
   /** Return true to merge incoming data; false keeps existing entity
    *
    * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
@@ -235,6 +247,10 @@ export interface IEntityInstance {
    * @param [key] When normalizing, the key where this entity was found
    * @param [args] ...args sent to Endpoint
    */
-  pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+  pk(
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | number | undefined;
 }
 export {};

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -48,7 +48,12 @@ export interface SchemaClass<T = any, N = T | undefined>
 
 export interface EntityInterface<T = any> extends SchemaSimple {
   createIfValid(props: any): any;
-  pk(params: any, parent?: any, key?: string, args?: any[]): string | undefined;
+  pk(
+    params: any,
+    parent?: any,
+    key?: string,
+    args?: any[],
+  ): string | number | undefined;
   readonly key: string;
   merge(existing: any, incoming: any): any;
   mergeWithStore(

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -351,7 +351,7 @@ export function Entity<TBase extends Constructor>(
   Base: TBase,
   opt?: EntityOptions<keyof InstanceType<TBase>>,
 ): (abstract new (...args: any[]) => {
-  pk(parent?: any, key?: string): string | undefined;
+  pk(parent?: any, key?: string): string | number | undefined;
 }) &
   IEntityClass<TBase> &
   TBase;

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -4,7 +4,11 @@ import { AbstractInstanceType } from '../normal.js';
 import { Entity as EntitySchema } from '../schema.js';
 
 const EmptyBase = class {} as any as abstract new (...args: any[]) => {
-  pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+  pk(
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | number | undefined;
 };
 
 /**
@@ -24,7 +28,7 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
     parent?: any,
     key?: string,
     args?: readonly any[],
-  ): string | undefined;
+  ): string | number | undefined;
 
   /** Control how automatic schema validation is handled
    *
@@ -61,7 +65,7 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
     parent?: any,
     key?: string,
     args?: any[],
-  ) => string | undefined;
+  ) => string | number | undefined;
 
   /** Do any transformations when first receiving input
    *

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -8,7 +8,11 @@ export type IDClass = abstract new (...args: any[]) => {
   id: string | number | undefined;
 };
 export type PKClass = abstract new (...args: any[]) => {
-  pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+  pk(
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | number | undefined;
 };
 
 // TODO: Figure out what Schema must be for each key
@@ -17,7 +21,11 @@ type ValidSchemas<TInstance> = { [k in keyof TInstance]?: Schema };
 export type EntityOptions<TInstance extends {}> = {
   readonly schema?: ValidSchemas<TInstance>;
   readonly pk?:
-    | ((value: TInstance, parent?: any, key?: string) => string | undefined)
+    | ((
+        value: TInstance,
+        parent?: any,
+        key?: string,
+      ) => string | number | undefined)
     | keyof TInstance;
   readonly key?: string;
 } & {
@@ -37,7 +45,11 @@ export type EntityOptions<TInstance extends {}> = {
 export interface RequiredPKOptions<TInstance extends {}>
   extends EntityOptions<TInstance> {
   readonly pk:
-    | ((value: TInstance, parent?: any, key?: string) => string | undefined)
+    | ((
+        value: TInstance,
+        parent?: any,
+        key?: string,
+      ) => string | number | undefined)
     | keyof TInstance;
 }
 
@@ -77,7 +89,7 @@ export default function EntitySchema<TBase extends Constructor>(
       parent?: any,
       key?: string,
       args?: readonly any[],
-    ): string | undefined;
+    ): string | number | undefined;
 
     /** Returns the globally unique identifier for the static Entity */
     declare static key: string;
@@ -101,7 +113,7 @@ export default function EntitySchema<TBase extends Constructor>(
       parent?: any,
       key?: string,
       args?: readonly any[],
-    ): string | undefined {
+    ): string | number | undefined {
       return this.prototype.pk.call(value, parent, key, args);
     }
 
@@ -281,6 +293,8 @@ export default function EntitySchema<TBase extends Constructor>(
           (error as any).status = 400;
           throw error;
         }
+      } else {
+        id = `${id}`;
       }
       const entityType = this.key;
 
@@ -523,7 +537,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
     parent?: any,
     key?: string,
     args?: any[],
-  ): string | undefined;
+  ): string | number | undefined;
   /** Return true to merge incoming data; false keeps existing entity
    *
    * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
@@ -672,7 +686,11 @@ export interface IEntityInstance {
    * @param [key] When normalizing, the key where this entity was found
    * @param [args] ...args sent to Endpoint
    */
-  pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+  pk(
+    parent?: any,
+    key?: string,
+    args?: readonly any[],
+  ): string | number | undefined;
 }
 
 function inferId(schema: any, args: readonly any[], indexes: NormalizedIndex) {

--- a/packages/endpoint/src/schemas/Invalidate.ts
+++ b/packages/endpoint/src/schemas/Invalidate.ts
@@ -40,7 +40,7 @@ export default class Invalidate<
     visitedEntities: Record<string, any>,
     storeEntities: Record<string, any>,
     args?: any[],
-  ): string | undefined {
+  ): string | number | undefined {
     // TODO: what's store needs to be a differing type from fromJS
     const processedEntity = this._entity.process(input, parent, key, args);
     const id = this._entity.pk(processedEntity, parent, key, args);

--- a/packages/endpoint/typescript-tests/relationships.ts
+++ b/packages/endpoint/typescript-tests/relationships.ts
@@ -12,7 +12,7 @@ export class IDEntity extends Entity {
    * @param [parent] When normalizing, the object which included the entity
    * @param [key] When normalizing, the key where this entity was found
    */
-  pk(parent?: any, key?: string): string | undefined {
+  pk(parent?: any, key?: string): string | number | undefined {
     return `${this.id}`;
   }
 }

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -394,7 +394,7 @@ exports[`normalize can use fully custom entity classes 1`] = `
     "Food": {
       "1234": {
         "children": [
-          4,
+          "4",
         ],
         "name": "tacos",
         "uuid": "1234",
@@ -421,6 +421,24 @@ exports[`normalize can use fully custom entity classes 1`] = `
   "result": {
     "schema": "Food",
     "uuid": "1234",
+  },
+}
+`;
+
+exports[`normalize handles number ids when nesting 1`] = `
+{
+  "Article": {
+    "123": {
+      "author": "8472",
+      "id": 123,
+      "title": "A Great Article",
+    },
+  },
+  "User": {
+    "8472": {
+      "id": 8472,
+      "name": "Paul",
+    },
   },
 }
 `;

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -60,7 +60,7 @@ describe('normalize', () => {
   });
 
   test('passthrough with id in place of entity', () => {
-    const input = { taco: 5 };
+    const input = { taco: '5' };
     expect(normalize(input, { taco: Tacos }).result).toStrictEqual(input);
   });
 
@@ -272,6 +272,25 @@ describe('normalize', () => {
       }),
     });
     expect(() => normalize(input, Article)).not.toThrow();
+  });
+
+  test('handles number ids when nesting', () => {
+    class User extends IDEntity {}
+    class Article extends IDEntity {
+      title = '';
+      static schema = {
+        author: User,
+      };
+    }
+    const input = Object.freeze({
+      id: 123,
+      title: 'A Great Article',
+      author: {
+        id: 8472,
+        name: 'Paul',
+      },
+    });
+    expect(normalize(input, Article).entities).toMatchSnapshot();
   });
 
   test('ignores null values', () => {

--- a/packages/normalizr/src/__tests__/inferResults.ts
+++ b/packages/normalizr/src/__tests__/inferResults.ts
@@ -305,7 +305,7 @@ describe('inferResults()', () => {
         entities: any,
       ) {
         if (!args[0]) return;
-        let id: undefined | string;
+        let id: undefined | number | string;
         if (['string', 'number'].includes(typeof args[0])) {
           id = `${args[0]}`;
         } else {

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -49,7 +49,7 @@ export interface EntityInterface<T = any> extends SchemaSimple {
     parent?: any,
     key?: string,
     args?: readonly any[],
-  ): string | undefined;
+  ): string | number | undefined;
   readonly key: string;
   merge(existing: any, incoming: any): any;
   mergeWithStore(

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -23,7 +23,10 @@ const visit = (
   }
 
   if (schema.normalize && typeof schema.normalize === 'function') {
-    if (typeof value !== 'object') return value;
+    if (typeof value !== 'object') {
+      if (schema.pk) return `${value}`;
+      return value;
+    }
     return schema.normalize(
       value,
       parent,

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -13,7 +13,7 @@ interface SchemaSimple<T = any> {
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
-    pk(params: any, parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(params: any, parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     readonly key: string;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -121,7 +121,7 @@ interface SchemaClass<T = any, N = T | undefined> extends SchemaSimple<T> {
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
-    pk(params: any, parent?: any, key?: string, args?: any[]): string | undefined;
+    pk(params: any, parent?: any, key?: string, args?: any[]): string | number | undefined;
     readonly key: string;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;
@@ -241,20 +241,20 @@ type IDClass = abstract new (...args: any[]) => {
     id: string | number | undefined;
 };
 type PKClass = abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
 };
 type ValidSchemas<TInstance> = {
     [k in keyof TInstance]?: Schema;
 };
 type EntityOptions<TInstance extends {}> = {
     readonly schema?: ValidSchemas<TInstance>;
-    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
     readonly key?: string;
 } & {
     readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
-    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
 }
 interface IEntityClass<TBase extends Constructor = any> {
     toJSON(): {
@@ -290,7 +290,7 @@ interface IEntityClass<TBase extends Constructor = any> {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | undefined;
+    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
      * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
@@ -386,7 +386,7 @@ interface IEntityInstance {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
 }
 
 /**
@@ -403,7 +403,7 @@ declare class Invalidate<E extends EntityInterface & {
     constructor(entity: E);
     get key(): string;
     /** Normalize lifecycles **/
-    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: Record<string, any>, args?: any[]): string | undefined;
+    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: Record<string, any>, args?: any[]): string | number | undefined;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;
     mergeMetaWithStore(existingMeta: {
@@ -879,9 +879,9 @@ declare namespace schema_d {
 }
 
 declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
+    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | number | undefined;
 }> & (abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
+    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | number | undefined;
 });
 /**
  * Represents data that should be deduped by specifying a primary key.
@@ -896,7 +896,7 @@ declare abstract class Entity extends Entity_base {
      * @param [args] ...args sent to Endpoint
      * @see https://dataclient.io/rest/api/Entity#pk
      */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -920,7 +920,7 @@ declare abstract class Entity extends Entity_base {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]) => string | undefined;
+    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]) => string | number | undefined;
     /** Do any transformations when first receiving input
      *
      * @see https://dataclient.io/rest/api/Entity#process

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -121,7 +121,7 @@ interface SchemaClass<T = any, N = T | undefined> extends SchemaSimple<T> {
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
-    pk(params: any, parent?: any, key?: string, args?: any[]): string | undefined;
+    pk(params: any, parent?: any, key?: string, args?: any[]): string | number | undefined;
     readonly key: string;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;
@@ -241,20 +241,20 @@ type IDClass = abstract new (...args: any[]) => {
     id: string | number | undefined;
 };
 type PKClass = abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
 };
 type ValidSchemas<TInstance> = {
     [k in keyof TInstance]?: Schema;
 };
 type EntityOptions<TInstance extends {}> = {
     readonly schema?: ValidSchemas<TInstance>;
-    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
     readonly key?: string;
 } & {
     readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
-    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
 }
 interface IEntityClass<TBase extends Constructor = any> {
     toJSON(): {
@@ -290,7 +290,7 @@ interface IEntityClass<TBase extends Constructor = any> {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | undefined;
+    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
      * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
@@ -386,7 +386,7 @@ interface IEntityInstance {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
 }
 
 /**
@@ -403,7 +403,7 @@ declare class Invalidate<E extends EntityInterface & {
     constructor(entity: E);
     get key(): string;
     /** Normalize lifecycles **/
-    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: Record<string, any>, args?: any[]): string | undefined;
+    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: Record<string, any>, args?: any[]): string | number | undefined;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;
     mergeMetaWithStore(existingMeta: {
@@ -879,9 +879,9 @@ declare namespace schema_d {
 }
 
 declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
+    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | number | undefined;
 }> & (abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
+    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | number | undefined;
 });
 /**
  * Represents data that should be deduped by specifying a primary key.
@@ -896,7 +896,7 @@ declare abstract class Entity extends Entity_base {
      * @param [args] ...args sent to Endpoint
      * @see https://dataclient.io/rest/api/Entity#pk
      */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -920,7 +920,7 @@ declare abstract class Entity extends Entity_base {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]) => string | undefined;
+    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]) => string | number | undefined;
     /** Do any transformations when first receiving input
      *
      * @see https://dataclient.io/rest/api/Entity#process

--- a/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
@@ -17,7 +17,7 @@ interface SchemaClass<T = any, N = T | undefined> extends SchemaSimple<T> {
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
-    pk(params: any, parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(params: any, parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     readonly key: string;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -123,7 +123,7 @@ interface SchemaClass<T = any, N = T | undefined> extends SchemaSimple<T> {
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
-    pk(params: any, parent?: any, key?: string, args?: any[]): string | undefined;
+    pk(params: any, parent?: any, key?: string, args?: any[]): string | number | undefined;
     readonly key: string;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;
@@ -239,20 +239,20 @@ type IDClass = abstract new (...args: any[]) => {
     id: string | number | undefined;
 };
 type PKClass = abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
 };
 type ValidSchemas<TInstance> = {
     [k in keyof TInstance]?: Schema;
 };
 type EntityOptions<TInstance extends {}> = {
     readonly schema?: ValidSchemas<TInstance>;
-    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+    readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
     readonly key?: string;
 } & {
     readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
-    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | undefined) | keyof TInstance;
+    readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
 }
 interface IEntityClass<TBase extends Constructor = any> {
     toJSON(): {
@@ -288,7 +288,7 @@ interface IEntityClass<TBase extends Constructor = any> {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | undefined;
+    pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
      * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
@@ -384,7 +384,7 @@ interface IEntityInstance {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
 }
 
 /**
@@ -401,7 +401,7 @@ declare class Invalidate<E extends EntityInterface & {
     constructor(entity: E);
     get key(): string;
     /** Normalize lifecycles **/
-    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: Record<string, any>, args?: any[]): string | undefined;
+    normalize(input: any, parent: any, key: string | undefined, visit: (...args: any) => any, addEntity: (...args: any) => any, visitedEntities: Record<string, any>, storeEntities: Record<string, any>, args?: any[]): string | number | undefined;
     merge(existing: any, incoming: any): any;
     mergeWithStore(existingMeta: any, incomingMeta: any, existing: any, incoming: any): any;
     mergeMetaWithStore(existingMeta: {
@@ -877,9 +877,9 @@ declare namespace schema_d {
 }
 
 declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
+    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | number | undefined;
 }> & (abstract new (...args: any[]) => {
-    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | undefined;
+    pk(parent?: any, key?: string | undefined, args?: readonly any[] | undefined): string | number | undefined;
 });
 /**
  * Represents data that should be deduped by specifying a primary key.
@@ -894,7 +894,7 @@ declare abstract class Entity extends Entity_base {
      * @param [args] ...args sent to Endpoint
      * @see https://dataclient.io/rest/api/Entity#pk
      */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | undefined;
+    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -918,7 +918,7 @@ declare abstract class Entity extends Entity_base {
      * @param [key] When normalizing, the key where this entity was found
      * @param [args] ...args sent to Endpoint
      */
-    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]) => string | undefined;
+    static pk: <T extends typeof Entity>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]) => string | number | undefined;
     /** Do any transformations when first receiving input
      *
      * @see https://dataclient.io/rest/api/Entity#process


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Followup to #2956

The previous solution did not handle cases where the nested members appeared as numbers rather than strings.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`unvisit` check for `entityOrId` as 'id' compares type to 'object' rather than string, so it will match on the 'number' case.

#### Allow pk() to return numbers

Before:

```ts
class MyEntity extends Entity {
  id = 0;
  pk() {
    return `${this.id}`;
  }
}
```

After:

```ts
class MyEntity extends Entity {
  id = 0;
  pk() {
    return this.id;
  }
}
```

#### Normalize converts all `pk` fields to string

Before:

```json
{
  "Article": {
    "123": {
      "author": 8472,
      "id": 123,
      "title": "A Great Article",
    },
  },
  "User": {
    "8472": {
      "id": 8472,
      "name": "Paul",
    },
  },
}
```

After:

```json
{
  "Article": {
    "123": {
      "author": "8472",
      "id": 123,
      "title": "A Great Article",
    },
  },
  "User": {
    "8472": {
      "id": 8472,
      "name": "Paul",
    },
  },
}
```