### PR TITLE
enhance: Improve .extend() typing for loose types case

### DIFF
--- a/.changeset/neat-moose-applaud.md
+++ b/.changeset/neat-moose-applaud.md
@@ -1,0 +1,5 @@
+---
+"@data-client/rest": patch
+---
+
+Improve .extend() typing when using loose null checks and no body parameter

--- a/packages/rest/src/RestEndpointTypes.ts
+++ b/packages/rest/src/RestEndpointTypes.ts
@@ -493,26 +493,7 @@ export type RestType<
   } = { path: string; paginationField: string },
   // eslint-disable-next-line @typescript-eslint/ban-types
 > = IfTypeScriptLooseNull<
-  RestInstance<
-    keyof UrlParams extends never ?
-      (this: EndpointInstanceInterface, body?: Body) => Promise<R>
-    : // even with loose null, this will only be true when all members are optional
-    {} extends UrlParams ?
-      | ((this: EndpointInstanceInterface, body?: Body) => Promise<R>)
-      | ((
-          this: EndpointInstanceInterface,
-          params: UrlParams,
-          body?: Body,
-        ) => Promise<R>)
-    : (
-        this: EndpointInstanceInterface,
-        params: UrlParams,
-        body?: Body,
-      ) => Promise<R>,
-    S,
-    M,
-    O
-  >,
+  RestInstance<RestFetch<UrlParams, Body, R>, S, M, O>,
   Body extends {} ? RestTypeWithBody<UrlParams, S, M, Body, R, O>
   : RestTypeNoBody<UrlParams, S, M, R, O>
 >;

--- a/packages/rest/src/__tests__/createResource.test.ts
+++ b/packages/rest/src/__tests__/createResource.test.ts
@@ -205,6 +205,9 @@ describe('createResource()', () => {
     expect(user.username).toBe('newbob');
     expect(user).toBeInstanceOf(User);
     expect(user.isAdmin).toBe(false);
+
+    // check types
+    () => controller.getResponse(UserResource.current, controller.getState());
   });
 
   it('can override endpoint options', async () => {

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -1254,7 +1254,7 @@ type RestType<UrlParams = any, Body = any, S extends Schema | undefined = Schema
 } = {
     path: string;
     paginationField: string;
-}> = IfTypeScriptLooseNull<RestInstance<keyof UrlParams extends never ? (this: EndpointInstanceInterface, body?: Body) => Promise<R> : {} extends UrlParams ? ((this: EndpointInstanceInterface, body?: Body) => Promise<R>) | ((this: EndpointInstanceInterface, params: UrlParams, body?: Body) => Promise<R>) : (this: EndpointInstanceInterface, params: UrlParams, body?: Body) => Promise<R>, S, M, O>, Body extends {} ? RestTypeWithBody<UrlParams, S, M, Body, R, O> : RestTypeNoBody<UrlParams, S, M, R, O>>;
+}> = IfTypeScriptLooseNull<RestInstance<RestFetch<UrlParams, Body, R>, S, M, O>, Body extends {} ? RestTypeWithBody<UrlParams, S, M, Body, R, O> : RestTypeNoBody<UrlParams, S, M, R, O>>;
 type RestTypeWithBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined, Body = any, R = any, O extends {
     path: string;
     body?: any;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Ensure both consistency, and better accuracy when using Parameters<> on a [RestEndpoint](https://dataclient.io/rest/api/RestEndpoint).

Previously under loose types:

```ts
const getThing = new RestEndpoint({ path: '/test' });
const getThingExtended = getThing.extend({ path: '/test2' });

// [] | [undefined]
type A = Parameters<typeof getThing>;
// [undefined]
type V = Parameters<typeof getThingExtended>;
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Previously when simply using the constructor, types were actively and robustly produced using `RestFetch<>`. We now employ this also for the extend case