### PR TITLE
enhance: useCache() accepts Endpoints with sideEffects

### DIFF
--- a/.changeset/five-flies-help.md
+++ b/.changeset/five-flies-help.md
@@ -1,0 +1,5 @@
+---
+"@data-client/react": minor
+---
+
+useCache() accepts Endpoints with sideEffects

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import {
+import type {
   EndpointInterface,
   DenormalizeNullable,
   Schema,
@@ -20,7 +20,11 @@ import useController from '../hooks/useController.js';
  */
 export default function useCache<
   E extends Pick<
-    EndpointInterface<FetchFunction, Schema | undefined, undefined | false>,
+    EndpointInterface<
+      FetchFunction,
+      Schema | undefined,
+      undefined | false | true
+    >,
     'key' | 'schema' | 'invalidIfStale'
   >,
   Args extends readonly [...Parameters<E['key']>] | readonly [null],
@@ -84,7 +88,8 @@ export default function useCache<
     }
     return data;
     // key substitutes args + endpoint
+    // we only need cacheResults, as entities are not used in this case
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, controller, data, wouldSuspend, state]);
+  }, [key, controller, data, wouldSuspend, cacheResults]);
   /*********************** end block *****************************/
 }

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -111,7 +111,7 @@ declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema |
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | false>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | false | true>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
 
 type ErrorTypes = NetworkError | UnknownError;
 type UseErrorReturn<P> = P extends [null] ? undefined : ErrorTypes | undefined;

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -1614,7 +1614,7 @@ declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Sche
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false | true>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
 
 type ErrorTypes = NetworkError$2 | UnknownError$1;
 type UseErrorReturn<P> = P extends [null] ? undefined : ErrorTypes | undefined;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Accessing mutation endpoints can be useful

[useCache()](https://dataclient.io/docs/api/useCache) does not call fetch, so there's no reason to restrict it to only [side-effect ](https://dataclient.io/rest/api/Endpoint#sideeffect)free endpoints.
