### PR TITLE
enhance: state.results -> state.endpoints

### DIFF
--- a/.changeset/nasty-items-count.md
+++ b/.changeset/nasty-items-count.md
@@ -1,0 +1,5 @@
+---
+"@data-client/normalizr": minor
+---
+
+type ResultCache -> EndpointCache

--- a/.changeset/violet-numbers-pump.md
+++ b/.changeset/violet-numbers-pump.md
@@ -1,0 +1,6 @@
+---
+"@data-client/react": minor
+"@data-client/core": minor
+---
+
+BREAKING: Internal state.results -> state.endpoints

--- a/examples/benchmark/core.js
+++ b/examples/benchmark/core.js
@@ -113,7 +113,7 @@ export default function addReducerSuite(suite) {
       .add('getResponse (clear cache)', () => {
         controller.globalCache = {
           entities: {},
-          results: {},
+          endpoints: {},
           queries: new Map(),
           inputEndpointCache: {},
           infer: new WeakEntityMap(),

--- a/examples/benchmark/normalizr.js
+++ b/examples/benchmark/normalizr.js
@@ -45,7 +45,7 @@ const actionMeta = {
 export default function addNormlizrSuite(suite) {
   let denormCache = {
     entities: {},
-    results: {
+    endpoints: {
       '/fake': new WeakEntityMap(),
       '/fakeQuery': new WeakEntityMap(),
     },
@@ -56,7 +56,7 @@ export default function addNormlizrSuite(suite) {
     ProjectSchema,
     entities,
     denormCache.entities,
-    denormCache.results['/fake'],
+    denormCache.endpoints['/fake'],
     [],
   );
   denormalizeCached(
@@ -64,7 +64,7 @@ export default function addNormlizrSuite(suite) {
     ProjectQuery,
     queryState.entities,
     denormCache.entities,
-    denormCache.results['/fakeQuery'],
+    denormCache.endpoints['/fakeQuery'],
     [],
   );
   %OptimizeFunctionOnNextCall(denormalizeCached);
@@ -109,7 +109,7 @@ export default function addNormlizrSuite(suite) {
     })
     .add('denormalizeShort 500x withCache', () => {
       for (let i = 0; i < 500; ++i) {
-        denormalizeCached('gnoff', User, githubState.entities,denormCache.entities,denormCache.results['/user'], []);
+        denormalizeCached('gnoff', User, githubState.entities,denormCache.entities,denormCache.endpoints['/user'], []);
       }
     })
     .add('denormalizeLong with mixin Entity', () => {
@@ -121,7 +121,7 @@ export default function addNormlizrSuite(suite) {
         ProjectSchema,
         entities,
         denormCache.entities,
-        denormCache.results['/fake'],
+        denormCache.endpoints['/fake'],
         [],
       );
     })
@@ -145,7 +145,7 @@ export default function addNormlizrSuite(suite) {
         ProjectQuery,
         queryState.entities,
         denormCache.entities,
-        denormCache.results['/fakeQuery'],
+        denormCache.endpoints['/fakeQuery'],
         [],
       );
     })
@@ -155,7 +155,7 @@ export default function addNormlizrSuite(suite) {
         ProjectQuerySorted,
         queryState.entities,
         denormCache.entities,
-        denormCache.results['/fakeQuery'],
+        denormCache.endpoints['/fakeQuery'],
         [],
       );
     })

--- a/examples/benchmark/old-normalizr/normalizr.js
+++ b/examples/benchmark/old-normalizr/normalizr.js
@@ -17,7 +17,7 @@ let githubState = normalize(userData, User);
 const state = {
   ...initialState,
   entities: githubState.entities,
-  results: { github: githubState.result },
+  endpoints: { github: githubState.result },
 };
 
 function mergeWithStore({ entities, result }, storeState) {
@@ -38,7 +38,7 @@ function mergeWithStore({ entities, result }, storeState) {
   return {
     ...storeState,
     entities: newEntities,
-    results: { ...storeState.results, ...{ abc: result } },
+    endpoints: { ...storeState.endpoints, ...{ abc: result } },
   };
 }
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,7 +31,7 @@ function useSuspense(endpoint, ...args)
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = key && state.results[key];
+  const cacheResults = key && state.endpoints[key];
   const meta = state.meta[key];
 
   // Compute denormalized value

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -137,7 +137,7 @@ export interface ResetAction {
 export interface GCAction {
   type: typeof GC_TYPE;
   entities: [string, string][];
-  results: string[];
+  endpoints: string[];
 }
 
 export type ActionTypes =

--- a/packages/core/src/controller/__tests__/Controller.ts
+++ b/packages/core/src/controller/__tests__/Controller.ts
@@ -43,7 +43,7 @@ describe('Controller', () => {
       const state = {
         ...initialState,
         entities,
-        results: {
+        endpoints: {
           [fetchKey]: result,
         },
         entityMeta: createEntityMeta(entities),
@@ -80,7 +80,7 @@ describe('Controller', () => {
       const state = {
         ...initialState,
         entities,
-        results: {
+        endpoints: {
           [fetchKey]: result,
         },
         entityMeta: createEntityMeta(entities),

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -39,7 +39,7 @@ describe('Controller.getResponse()', () => {
     const state = {
       ...initialState,
       entities,
-      results: {
+      endpoints: {
         [ep.key()]: {
           data: ['1', '2'],
         },
@@ -84,7 +84,7 @@ describe('Controller.getResponse()', () => {
     const state = {
       ...initialState,
       entities,
-      results: {
+      endpoints: {
         [ep.key()]: {
           data: ['1', '2'],
         },

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`reducer should set error in meta for "set" 1`] = `
 {
+  "endpoints": {},
   "entities": {},
   "entityMeta": {},
   "indexes": {},
@@ -15,12 +16,14 @@ exports[`reducer should set error in meta for "set" 1`] = `
     },
   },
   "optimistic": [],
-  "results": {},
 }
 `;
 
 exports[`reducer singles should update state correctly 1`] = `
 {
+  "endpoints": {
+    "http://test.com/article/20": "20",
+  },
   "entities": {
     "Article": {
       "20": {
@@ -49,8 +52,5 @@ exports[`reducer singles should update state correctly 1`] = `
     },
   },
   "optimistic": [],
-  "results": {
-    "http://test.com/article/20": "20",
-  },
 }
 `;

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -207,7 +207,7 @@ describe('reducer', () => {
     });
   });
 
-  it('mutate should never change results', () => {
+  it('mutate should never change endpoints', () => {
     const id = 20;
     const payload = { id, title: 'hi', content: 'this is the content' };
     const action: SetAction = {
@@ -224,10 +224,10 @@ describe('reducer', () => {
     };
     const iniState = {
       ...initialState,
-      results: { abc: '5', [ArticleResource.get.key(payload)]: `${id}` },
+      endpoints: { abc: '5', [ArticleResource.get.key(payload)]: `${id}` },
     };
     const newState = reducer(iniState, action);
-    expect(newState.results).toStrictEqual(iniState.results);
+    expect(newState.endpoints).toStrictEqual(iniState.endpoints);
   });
   it('purge should delete entities', () => {
     const id = 20;
@@ -256,10 +256,10 @@ describe('reducer', () => {
         },
         '5': undefined,
       },
-      results: { abc: '20' },
+      endpoints: { abc: '20' },
     };
     const newState = reducer(iniState, action);
-    expect(newState.results.abc).toBe(iniState.results.abc);
+    expect(newState.endpoints.abc).toBe(iniState.endpoints.abc);
     const expectedEntities = { ...iniState.entities[Article.key] };
     expectedEntities['20'] = INVALID;
     expect(newState.entities[Article.key]).toEqual(expectedEntities);
@@ -277,8 +277,8 @@ describe('reducer', () => {
             '10': PaginatedArticle.fromJS({ id: 10 }),
           },
         },
-        results: {
-          [PaginatedArticleResource.getList.key({})]: { results: ['10'] },
+        endpoints: {
+          [PaginatedArticleResource.getList.key({})]: { endpoints: ['10'] },
         },
       };
 
@@ -301,7 +301,7 @@ describe('reducer', () => {
         );
         const newState = reducer(iniState, action);
         expect(
-          newState.results[PaginatedArticleResource.getList.key({})],
+          newState.endpoints[PaginatedArticleResource.getList.key({})],
         ).toStrictEqual({
           results: ['10', '11', '12'],
         });
@@ -328,7 +328,7 @@ describe('reducer', () => {
           ),
         );
         expect(
-          newState.results[PaginatedArticleResource.getList.key({})],
+          newState.endpoints[PaginatedArticleResource.getList.key({})],
         ).toStrictEqual({
           results: ['11', '12', '10'],
         });
@@ -342,7 +342,7 @@ describe('reducer', () => {
               '10': PaginatedArticle.fromJS({ id: 10 }),
             },
           },
-          results: {
+          endpoints: {
             [PaginatedArticleResource.getList.key({ admin: true })]: {
               results: ['10'],
             },
@@ -369,7 +369,7 @@ describe('reducer', () => {
           ),
         );
         expect(
-          newState.results[
+          newState.endpoints[
             PaginatedArticleResource.getList.key({ admin: true })
           ],
         ).toStrictEqual({
@@ -400,7 +400,7 @@ describe('reducer', () => {
         },
         '5': undefined,
       },
-      results: { abc: '20' },
+      endpoints: { abc: '20' },
       meta: {
         '20': {
           expiresAt: 500,
@@ -411,7 +411,7 @@ describe('reducer', () => {
       },
     };
     const newState = reducer(iniState, action);
-    expect(newState.results).toEqual(iniState.results);
+    expect(newState.endpoints).toEqual(iniState.endpoints);
     expect(newState.entities).toBe(iniState.entities);
     const expectedMeta = { ...iniState.meta };
     expectedMeta['20'] = { expiresAt: 0, invalidated: true };
@@ -481,7 +481,7 @@ describe('reducer', () => {
           [id]: Article.fromJS({}),
         },
       },
-      results: {
+      endpoints: {
         [ArticleResource.get.url({ id })]: id,
       },
     };
@@ -509,7 +509,7 @@ describe('reducer', () => {
       };
       const iniState = {
         ...initialState,
-        results: { abc: '5' },
+        endpoints: { abc: '5' },
       };
       const newState = reducer(iniState, action);
       expect(newState).toBe(iniState);
@@ -524,7 +524,7 @@ describe('reducer', () => {
     };
     const iniState = {
       ...initialState,
-      results: { abc: '5' },
+      endpoints: { abc: '5' },
     };
     const newState = reducer(iniState, action);
     expect(newState).toBe(iniState);
@@ -556,10 +556,10 @@ describe('reducer', () => {
           },
           '5': undefined,
         },
-        results: { abc: '20' },
+        endpoints: { abc: '20' },
       };
       const newState = reducer(iniState, action);
-      expect(newState.results).toEqual({});
+      expect(newState.endpoints).toEqual({});
       expect(newState.meta).toEqual({});
       expect(newState.entities).toEqual({});
     });
@@ -591,7 +591,7 @@ describe('reducer', () => {
             '250': { date: 0, expiresAt: 10000, fetchedAt: 0 },
           },
         },
-        results: { abc: '20' },
+        endpoints: { abc: '20' },
       };
     });
 
@@ -599,13 +599,13 @@ describe('reducer', () => {
       const action: GCAction = {
         type: GC_TYPE,
         entities: [],
-        results: [],
+        endpoints: [],
       };
 
       const newState = reducer(iniState, action);
       expect(newState).toBe(iniState);
       expect(Object.keys(newState.entities[Article.key] ?? {}).length).toBe(4);
-      expect(Object.keys(newState.results).length).toBe(1);
+      expect(Object.keys(newState.endpoints).length).toBe(1);
     });
 
     it('empty deleting entities should work', () => {
@@ -615,7 +615,7 @@ describe('reducer', () => {
           [Article.key, '10'],
           [Article.key, '250'],
         ],
-        results: ['abc'],
+        endpoints: ['abc'],
       };
 
       const newState = reducer(iniState, action);
@@ -624,7 +624,7 @@ describe('reducer', () => {
       expect(Object.keys(newState.entityMeta[Article.key] ?? {}).length).toBe(
         2,
       );
-      expect(Object.keys(newState.results).length).toBe(0);
+      expect(Object.keys(newState.endpoints).length).toBe(0);
     });
 
     it('empty deleting nonexistant things should passthrough', () => {
@@ -634,13 +634,13 @@ describe('reducer', () => {
           [Article.key, '100000000'],
           ['sillythings', '10'],
         ],
-        results: [],
+        endpoints: [],
       };
 
       const newState = reducer(iniState, action);
       expect(newState).toBe(iniState);
       expect(Object.keys(newState.entities[Article.key] ?? {}).length).toBe(4);
-      expect(Object.keys(newState.results).length).toBe(1);
+      expect(Object.keys(newState.endpoints).length).toBe(1);
     });
   });
 });

--- a/packages/core/src/state/reducer/createReducer.ts
+++ b/packages/core/src/state/reducer/createReducer.ts
@@ -28,8 +28,8 @@ export default function createReducer(controller: Controller): ReducerType {
           delete (state as any).entities[key]?.[pk];
           delete (state as any).entityMeta[key]?.[pk];
         });
-        action.results.forEach(fetchKey => {
-          delete (state as any).results[fetchKey];
+        action.endpoints.forEach(fetchKey => {
+          delete (state as any).endpoints[fetchKey];
           delete (state as any).meta[fetchKey];
         });
         return state;
@@ -62,7 +62,7 @@ export default function createReducer(controller: Controller): ReducerType {
 export const initialState: State<unknown> = {
   entities: {},
   indexes: {},
-  results: {},
+  endpoints: {},
   meta: {},
   entityMeta: {},
   optimistic: [],

--- a/packages/core/src/state/reducer/invalidateReducer.ts
+++ b/packages/core/src/state/reducer/invalidateReducer.ts
@@ -9,10 +9,10 @@ export function invalidateReducer(
   state: State<unknown>,
   action: InvalidateAction | InvalidateAllAction,
 ) {
-  const results = { ...state.results };
+  const endpoints = { ...state.endpoints };
   const meta = { ...state.meta };
   const invalidateKey = (key: string) => {
-    delete results[key];
+    delete endpoints[key];
     const itemMeta = {
       ...meta[key],
       expiresAt: 0,
@@ -24,7 +24,7 @@ export function invalidateReducer(
   if (action.type === INVALIDATE_TYPE) {
     invalidateKey(action.meta.key);
   } else {
-    Object.keys(results).forEach(key => {
+    Object.keys(endpoints).forEach(key => {
       if (action.testKey(key)) {
         invalidateKey(key);
       }
@@ -33,7 +33,7 @@ export function invalidateReducer(
 
   return {
     ...state,
-    results,
+    endpoints,
     meta,
   };
 }

--- a/packages/core/src/state/reducer/setReducer.ts
+++ b/packages/core/src/state/reducer/setReducer.ts
@@ -45,15 +45,15 @@ export function setReducer(
       state.entityMeta,
       action.meta,
     );
-    const results = {
-      ...state.results,
+    const endpoints = {
+      ...state.endpoints,
       [action.meta.key]: result,
     };
     try {
       if (action.endpoint.update) {
         const updaters = action.endpoint.update(result, ...action.meta.args);
         Object.keys(updaters).forEach(key => {
-          results[key] = updaters[key](results[key]);
+          endpoints[key] = updaters[key](endpoints[key]);
         });
       }
       // no reason to completely fail because of user-code error
@@ -67,7 +67,7 @@ export function setReducer(
     return {
       entities,
       indexes,
-      results,
+      endpoints,
       entityMeta,
       meta: {
         ...state.meta,
@@ -80,7 +80,7 @@ export function setReducer(
       optimistic: filterOptimistic(state, action),
       lastReset: state.lastReset,
     };
-    // reducer must update the state, so in case of processing errors we simply compute the results inline
+    // reducer must update the state, so in case of processing errors we simply compute the endpoints inline
   } catch (error: any) {
     if (typeof error === 'object') {
       error.message = `Error processing ${

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,7 +22,9 @@ export interface State<T> {
     readonly [entityKey: string]: { readonly [pk: string]: T } | undefined;
   };
   readonly indexes: NormalizedIndex;
-  readonly results: { readonly [key: string]: unknown | PK[] | PK | undefined };
+  readonly endpoints: {
+    readonly [key: string]: unknown | PK[] | PK | undefined;
+  };
   readonly meta: {
     readonly [key: string]: {
       readonly date: number;
@@ -48,7 +50,7 @@ export interface State<T> {
 
 export interface DenormalizeCache {
   entities: EntityCache;
-  results: {
+  endpoints: {
     [key: string]: ResultCache;
   };
 }

--- a/packages/normalizr/src/__tests__/denormalizeCached.js
+++ b/packages/normalizr/src/__tests__/denormalizeCached.js
@@ -239,7 +239,7 @@ describe('denormalize with global cache', () => {
         static key = 'Article';
       }
       const entityCache = {};
-      // we have different result caches because they are keyed based on the endpoint
+      // we have different endpoints caches because they are keyed based on the endpoint
       const resultCacheA = new WeakEntityMap();
       const resultCacheB = new WeakEntityMap();
       const resultCacheC = new WeakEntityMap();

--- a/packages/normalizr/src/denormalize/denormalizeCached.ts
+++ b/packages/normalizr/src/denormalize/denormalizeCached.ts
@@ -5,7 +5,7 @@ import type {
   DenormalizeNullable,
   EntityCache,
   Path,
-  ResultCache,
+  EndpointsCache,
 } from '../types.js';
 import WeakEntityMap, { getEntities } from '../WeakEntityMap.js';
 
@@ -15,7 +15,7 @@ export function denormalize<S extends Schema>(
   schema: S | undefined,
   entities: any,
   entityCache: EntityCache = {},
-  resultCache: ResultCache = new WeakEntityMap(),
+  resultCache: EndpointsCache = new WeakEntityMap(),
   args: readonly any[] = [],
 ): {
   data: DenormalizeNullable<S> | symbol;

--- a/packages/normalizr/src/denormalize/globalCache.ts
+++ b/packages/normalizr/src/denormalize/globalCache.ts
@@ -1,6 +1,6 @@
 import type Cache from './cache.js';
 import type { EntityInterface } from '../interface.js';
-import type { EntityCache, Path, ResultCache } from '../types.js';
+import type { EntityCache, Path, EndpointsCache } from '../types.js';
 import WeakEntityMap, {
   type Dep,
   type GetEntity,
@@ -19,12 +19,12 @@ export default class GlobalCache implements Cache {
   ) => WeakEntityMap<object, any>;
 
   private declare _getEntity: GetEntity;
-  private declare resultCache: ResultCache;
+  private declare resultCache: EndpointsCache;
 
   constructor(
     getEntity: GetEntity,
     entityCache: EntityCache,
-    resultCache: ResultCache,
+    resultCache: EndpointsCache,
   ) {
     this._getEntity = getEntity;
     this.getCache = getEntityCaches(entityCache);
@@ -49,7 +49,7 @@ export default class GlobalCache implements Cache {
       if (cachePath) {
         localCacheKey[pk] = cacheValue.value;
         // TODO: can we store the cache values instead of tracking *all* their sources?
-        // this is only used for setting results cache correctly. if we got this far we will def need to set as we would have already tried getting it
+        // this is only used for setting endpoints cache correctly. if we got this far we will def need to set as we would have already tried getting it
         this.dependencies.push(...cacheValue.dependencies);
         return cacheValue.value;
       }

--- a/packages/normalizr/src/index.ts
+++ b/packages/normalizr/src/index.ts
@@ -15,7 +15,7 @@ export type {
   NormalizeReturnType,
   NormalizedSchema,
   EntityCache,
-  ResultCache,
+  EndpointsCache as ResultCache,
   Path,
   Denormalize,
   DenormalizeNullable,

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -59,7 +59,7 @@ export interface EntityCache {
     [pk: string]: WeakMap<EntityInterface, WeakEntityMap<object, any>>;
   };
 }
-export type ResultCache = WeakEntityMap<object, any>;
+export type EndpointsCache = WeakEntityMap<object, any>;
 
 export type DenormalizeNullableNestedSchema<S extends NestedSchemaClass> =
   keyof S['schema'] extends never ?

--- a/packages/react/src/__tests__/hooks-endpoint.web.tsx
+++ b/packages/react/src/__tests__/hooks-endpoint.web.tsx
@@ -359,7 +359,7 @@ describe('useController().getState', () => {
       // @ts-expect-error
       expect(result.current[0].lafsjlfd).toBeUndefined();
       expect(
-        Object.keys(result.current[1].getState().results).length,
+        Object.keys(result.current[1].getState().endpoints).length,
       ).toBeGreaterThanOrEqual(1);
       // === guarantee
       expect(

--- a/packages/react/src/components/__tests__/__snapshots__/provider.native.tsx.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/provider.native.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`<CacheProvider /> should change state 1`] = `
 {
+  "endpoints": {
+    "GET http://test.com/article-cooler/5": "5",
+  },
   "entities": {
     "CoolerArticle": {
       "5": {
@@ -30,9 +33,6 @@ exports[`<CacheProvider /> should change state 1`] = `
     },
   },
   "optimistic": [],
-  "results": {
-    "GET http://test.com/article-cooler/5": "5",
-  },
 }
 `;
 

--- a/packages/react/src/components/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/provider.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`<CacheProvider /> should change state 1`] = `
 {
+  "endpoints": {
+    "GET http://test.com/article-cooler/5": "5",
+  },
   "entities": {
     "CoolerArticle": {
       "5": {
@@ -30,9 +33,6 @@ exports[`<CacheProvider /> should change state 1`] = `
     },
   },
   "optimistic": [],
-  "results": {
-    "GET http://test.com/article-cooler/5": "5",
-  },
 }
 `;
 

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -40,7 +40,7 @@ export default function useCache<
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = key && state.results[key];
+  const cacheResults = key && state.endpoints[key];
   const meta = state.meta[key];
 
   // Compute denormalized value

--- a/packages/react/src/hooks/useDLE.ts
+++ b/packages/react/src/hooks/useDLE.ts
@@ -57,7 +57,7 @@ export default function useDLE<
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = args[0] !== null && state.results[key];
+  const cacheResults = args[0] !== null && state.endpoints[key];
 
   // Compute denormalized value
   // eslint-disable-next-line prefer-const

--- a/packages/react/src/hooks/useFetch.native.ts
+++ b/packages/react/src/hooks/useFetch.native.ts
@@ -29,7 +29,7 @@ export default function useFetch<
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = key && state.results[key];
+  const cacheResults = key && state.endpoints[key];
   const meta = state.meta[key];
 
   // Compute denormalized value

--- a/packages/react/src/hooks/useFetch.ts
+++ b/packages/react/src/hooks/useFetch.ts
@@ -27,7 +27,7 @@ export default function useFetch<
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = key && state.results[key];
+  const cacheResults = key && state.endpoints[key];
   const meta = state.meta[key];
 
   // Compute denormalized value

--- a/packages/react/src/hooks/useSuspense.native.ts
+++ b/packages/react/src/hooks/useSuspense.native.ts
@@ -39,7 +39,7 @@ export default function useSuspense<
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = key && state.results[key];
+  const cacheResults = key && state.endpoints[key];
   const meta = state.meta[key];
 
   // Compute denormalized value

--- a/packages/react/src/hooks/useSuspense.ts
+++ b/packages/react/src/hooks/useSuspense.ts
@@ -33,7 +33,7 @@ export default function useSuspense<
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = key && state.results[key];
+  const cacheResults = key && state.endpoints[key];
   const meta = state.meta[key];
 
   // Compute denormalized value

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -99,7 +99,7 @@ interface EntityCache {
         [pk: string]: WeakMap<EntityInterface, WeakEntityMap<object, any>>;
     };
 }
-type ResultCache = WeakEntityMap<object, any>;
+type EndpointsCache = WeakEntityMap<object, any>;
 type DenormalizeNullableNestedSchema<S extends NestedSchemaClass> = keyof S['schema'] extends never ? S['prototype'] : string extends keyof S['schema'] ? S['prototype'] : S['prototype'];
 type NormalizeReturnType<T> = T extends (...args: any) => infer R ? R : never;
 type Denormalize<S> = S extends EntityInterface<infer U> ? U : S extends RecordClass ? AbstractInstanceType<S> : S extends {
@@ -333,7 +333,7 @@ interface ResetAction {
 interface GCAction {
     type: typeof GC_TYPE;
     entities: [string, string][];
-    results: string[];
+    endpoints: string[];
 }
 type ActionTypes = FetchAction | OptimisticAction | SetAction | SubscribeAction | UnsubscribeAction | InvalidateAction | InvalidateAllAction | ExpireAllAction | ResetAction | GCAction;
 
@@ -358,7 +358,7 @@ interface State<T> {
         } | undefined;
     };
     readonly indexes: NormalizedIndex;
-    readonly results: {
+    readonly endpoints: {
         readonly [key: string]: unknown | PK[] | PK | undefined;
     };
     readonly meta: {
@@ -385,8 +385,8 @@ interface State<T> {
 }
 interface DenormalizeCache {
     entities: EntityCache;
-    results: {
-        [key: string]: ResultCache;
+    endpoints: {
+        [key: string]: EndpointsCache;
     };
 }
 
@@ -431,14 +431,14 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
      */
     fetch: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>;
+    }>(endpoint: E, ...args_0: Parameters<E>) => E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
     /**
      * Fetches only if endpoint is considered 'stale'; otherwise returns undefined
      * @see https://dataclient.io/docs/api/Controller#fetchIfStale
      */
     fetchIfStale: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<E>) => E["schema"] extends null | undefined ? ReturnType<E> | ResolveType<E> : Denormalize<E["schema"]> | Promise<Denormalize<E["schema"]>>;
+    }>(endpoint: E, ...args_0: Parameters<E>) => E['schema'] extends undefined | null ? ReturnType<E> | ResolveType<E> : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']>;
     /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://dataclient.io/docs/api/Controller#invalidate
@@ -500,12 +500,12 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
      * Marks a new subscription to a given Endpoint.
      * @see https://dataclient.io/docs/api/Controller#subscribe
      */
-    subscribe: <E extends EndpointInterface<FetchFunction, Schema | undefined, false | undefined>>(endpoint: E, ...args: readonly [null] | readonly [...Parameters<E>]) => Promise<void>;
+    subscribe: <E extends EndpointInterface<FetchFunction, Schema | undefined, false | undefined>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) => Promise<void>;
     /**
      * Marks completion of subscription to a given Endpoint.
      * @see https://dataclient.io/docs/api/Controller#unsubscribe
      */
-    unsubscribe: <E extends EndpointInterface<FetchFunction, Schema | undefined, false | undefined>>(endpoint: E, ...args: readonly [null] | readonly [...Parameters<E>]) => Promise<void>;
+    unsubscribe: <E extends EndpointInterface<FetchFunction, Schema | undefined, false | undefined>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) => Promise<void>;
     /*************** More ***************/
     /**
      * Gets a snapshot (https://dataclient.io/docs/api/Snapshot)
@@ -1029,4 +1029,4 @@ declare class DevToolsManager implements Manager {
     getMiddleware(): Middleware;
 }
 
-export { AbstractInstanceType, ActionTypes, ConnectionListener, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeCache, DenormalizeNullable, DevToolsConfig, DevToolsManager, Dispatch$1 as Dispatch, EndpointExtraOptions, EndpointInterface, EndpointUpdateFunction, EntityCache, EntityInterface, ErrorTypes, ExpireAllAction, ExpiryStatus, FetchAction, FetchFunction, FetchMeta, GCAction, GenericDispatch, InvalidateAction, InvalidateAllAction, LogoutManager, Manager, Middleware$2 as Middleware, MiddlewareAPI$1 as MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, OptimisticAction, PK, PollingSubscription, Queryable, ResetAction, ResetError, ResolveType, ResultCache, ResultEntry, Schema, SchemaArgs, SetAction, SetActionError, SetActionSuccess, SetMeta, SetTypes, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, internal_d as __INTERNAL__, actionTypes_d as actionTypes, applyManager, createFetch, createReducer, createSet, initialState };
+export { AbstractInstanceType, ActionTypes, ConnectionListener, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeCache, DenormalizeNullable, DevToolsConfig, DevToolsManager, Dispatch$1 as Dispatch, EndpointExtraOptions, EndpointInterface, EndpointUpdateFunction, EntityCache, EntityInterface, ErrorTypes, ExpireAllAction, ExpiryStatus, FetchAction, FetchFunction, FetchMeta, GCAction, GenericDispatch, InvalidateAction, InvalidateAllAction, LogoutManager, Manager, Middleware$2 as Middleware, MiddlewareAPI$1 as MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, OptimisticAction, PK, PollingSubscription, Queryable, ResetAction, ResetError, ResolveType, EndpointsCache as ResultCache, ResultEntry, Schema, SchemaArgs, SetAction, SetActionError, SetActionSuccess, SetMeta, SetTypes, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, internal_d as __INTERNAL__, actionTypes_d as actionTypes, applyManager, createFetch, createReducer, createSet, initialState };

--- a/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
@@ -103,7 +103,7 @@ interface EntityCache {
         [pk: string]: WeakMap<EntityInterface, WeakEntityMap<object, any>>;
     };
 }
-type ResultCache = WeakEntityMap<object, any>;
+type EndpointsCache = WeakEntityMap<object, any>;
 type DenormalizeNullableNestedSchema<S extends NestedSchemaClass> = keyof S['schema'] extends never ? S['prototype'] : string extends keyof S['schema'] ? S['prototype'] : S['prototype'];
 type NormalizeReturnType<T> = T extends (...args: any) => infer R ? R : never;
 type Denormalize<S> = S extends EntityInterface<infer U> ? U : S extends RecordClass ? AbstractInstanceType<S> : S extends {
@@ -146,14 +146,14 @@ type SchemaArgs<S extends Queryable> = S extends EntityInterface<infer U> ? [Ent
 
 declare function denormalize$1<S extends Schema>(input: any, schema: S | undefined, entities: any, args?: readonly any[]): DenormalizeNullable<S> | symbol;
 
-declare function denormalize<S extends Schema>(input: unknown, schema: S | undefined, entities: any, entityCache?: EntityCache, resultCache?: ResultCache, args?: readonly any[]): {
+declare function denormalize<S extends Schema>(input: unknown, schema: S | undefined, entities: any, entityCache?: EntityCache, resultCache?: EndpointsCache, args?: readonly any[]): {
     data: DenormalizeNullable<S> | symbol;
     paths: Path[];
 };
 
 declare function isEntity(schema: Schema): schema is EntityInterface;
 
-declare const normalize: <S extends Schema = Schema, E extends Record<string, Record<string, any> | undefined> = Record<string, Record<string, any>>, R = NormalizeNullable<S>>(input: any, schema?: S | undefined, args?: any[], storeEntities?: Readonly<E>, storeIndexes?: Readonly<NormalizedIndex>, storeEntityMeta?: {
+declare const normalize: <S extends Schema = Schema, E extends Record<string, Record<string, any> | undefined> = Record<string, Record<string, any>>, R = NormalizeNullable<S>>(input: any, schema?: S, args?: any[], storeEntities?: Readonly<E>, storeIndexes?: Readonly<NormalizedIndex>, storeEntityMeta?: {
     readonly [entityKey: string]: {
         readonly [pk: string]: {
             readonly date: number;
@@ -268,4 +268,4 @@ type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Pr
 
 declare const INVALID: unique symbol;
 
-export { AbstractInstanceType, ArrayElement, Denormalize, DenormalizeNullable, EndpointExtraOptions, EndpointInterface, EntityCache, EntityInterface, EntityTable, ErrorTypes, ExpiryStatus, ExpiryStatusInterface, FetchFunction, INVALID, IndexInterface, IndexParams, InferReturn, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, NormalizeReturnType, NormalizedIndex, NormalizedSchema, OptimisticUpdateParams, Path, Queryable, ReadEndpoint, ResolveType, ResultCache, Schema, SchemaArgs, SchemaClass, SchemaSimple, Serializable, SnapshotInterface, UnknownError, UpdateFunction, WeakEntityMap, denormalize$1 as denormalize, denormalize as denormalizeCached, inferResults, isEntity, normalize, validateInference };
+export { AbstractInstanceType, ArrayElement, Denormalize, DenormalizeNullable, EndpointExtraOptions, EndpointInterface, EntityCache, EntityInterface, EntityTable, ErrorTypes, ExpiryStatus, ExpiryStatusInterface, FetchFunction, INVALID, IndexInterface, IndexParams, InferReturn, MutateEndpoint, NetworkError, Normalize, NormalizeNullable, NormalizeReturnType, NormalizedIndex, NormalizedSchema, OptimisticUpdateParams, Path, Queryable, ReadEndpoint, ResolveType, EndpointsCache as ResultCache, Schema, SchemaArgs, SchemaClass, SchemaSimple, Serializable, SnapshotInterface, UnknownError, UpdateFunction, WeakEntityMap, denormalize$1 as denormalize, denormalize as denormalizeCached, inferResults, isEntity, normalize, validateInference };

--- a/website/src/components/Playground/editor-types/react.d.ts
+++ b/website/src/components/Playground/editor-types/react.d.ts
@@ -189,6 +189,7 @@ declare namespace React {
      * <div ref="myRef" />
      * ```
      */
+    // TODO: Remove the string ref special case from `PropsWithRef` once we remove LegacyRef
     type LegacyRef<T> = string | Ref<T>;
 
     /**
@@ -217,9 +218,10 @@ declare namespace React {
     > =
         // need to check first if `ref` is a valid prop for ts@3.0
         // otherwise it will infer `{}` instead of `never`
-        "ref" extends keyof ComponentPropsWithRef<C> ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends Ref<
+        "ref" extends keyof ComponentPropsWithRef<C>
+            ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends RefAttributes<
                 infer Instance
-            > ? Instance
+            >["ref"] ? Instance
             : never
             : never;
 
@@ -232,9 +234,55 @@ declare namespace React {
      */
     type Key = string | number | bigint;
 
+    /**
+     * @internal The props any component can receive.
+     * You don't have to add this type. All components automatically accept these props.
+     * ```tsx
+     * const Component = () => <div />;
+     * <Component key="one" />
+     * ```
+     *
+     * WARNING: The implementation of a component will never have access to these attributes.
+     * The following example would be incorrect usage because {@link Component} would never have access to `key`:
+     * ```tsx
+     * const Component = (props: React.Attributes) => props.key;
+     * ```
+     */
     interface Attributes {
         key?: Key | null | undefined;
     }
+    /**
+     * The props any component accepting refs can receive.
+     * Class components, built-in browser components (e.g. `div`) and forwardRef components can receive refs and automatically accept these props.
+     * ```tsx
+     * const Component = forwardRef(() => <div />);
+     * <Component ref={(current) => console.log(current)} />
+     * ```
+     *
+     * You only need this type if you manually author the types of props that need to be compatible with legacy refs.
+     * ```tsx
+     * interface Props extends React.RefAttributes<HTMLDivElement> {}
+     * declare const Component: React.FunctionComponent<Props>;
+     * ```
+     *
+     * Otherwise it's simpler to directly use {@link Ref} since you can safely use the
+     * props type to describe to props that a consumer can pass to the component
+     * as well as describing the props the implementation of a component "sees".
+     * {@link RefAttributes} is generally not safe to describe both consumer and seen props.
+     *
+     * ```tsx
+     * interface Props extends {
+     *   ref?: React.Ref<HTMLDivElement> | undefined;
+     * }
+     * declare const Component: React.FunctionComponent<Props>;
+     * ```
+     *
+     * WARNING: The implementation of a component will not have access to the same type in versions of React supporting string refs.
+     * The following example would be incorrect usage because {@link Component} would never have access to a `ref` with type `string`
+     * ```tsx
+     * const Component = (props: React.RefAttributes) => props.ref;
+     * ```
+     */
     interface RefAttributes<T> extends Attributes {
         /**
          * Allows getting a ref to the component instance.
@@ -243,21 +291,13 @@ declare namespace React {
          *
          * @see {@link https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom React Docs}
          */
-        ref?: Ref<T> | undefined;
+        ref?: LegacyRef<T> | undefined;
     }
 
     /**
      * Represents the built-in attributes available to class components.
      */
-    interface ClassAttributes<T> extends Attributes {
-        /**
-         * Allows getting a ref to the component instance.
-         * Once the component unmounts, React will set `ref.current` to `null`
-         * (or call the ref with `null` if you passed a callback ref).
-         *
-         * @see {@link https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom React Docs}
-         */
-        ref?: LegacyRef<T> | undefined;
+    interface ClassAttributes<T> extends RefAttributes<T> {
     }
 
     /**
@@ -385,7 +425,8 @@ declare namespace React {
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     /**
-     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     * WARNING: Not related to `React.Fragment`.
+     * @deprecated This type is not relevant when using React. Inline the type instead to make the intent clear.
      */
     type ReactFragment = Iterable<ReactNode>;
 
@@ -715,6 +756,8 @@ declare namespace React {
      * ```
      */
     function createContext<T>(
+        // If you thought this should be optional, see
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382213106
         defaultValue: T,
     ): Context<T>;
 
@@ -1522,6 +1565,7 @@ declare namespace React {
         P extends any ? ("ref" extends keyof P ? Omit<P, "ref"> : P) : P;
     /** Ensures that the props do not include string ref, which cannot be forwarded */
     type PropsWithRef<P> =
+        // Note: String refs can be forwarded. We can't fix this bug without breaking a bunch of libraries now though.
         // Just "P extends { ref?: infer R }" looks sufficient, but R will infer as {} if P is {}.
         "ref" extends keyof P
             ? P extends { ref?: infer R | undefined }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Improve clarity by consistent naming

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
The store's `state.results` contains the endpoint-level caching keyed by endpoint key. Thus, it makes more sense to change this to 'endpoints' so its naming is consistent with the 'state.entities' part. We also updating globalCache references in normalizr package.

state.results -> state.endpoints.