### PR TITLE
enhance: Entity.useIncoming -> Entity.shouldUpdate

### DIFF
--- a/.changeset/sharp-ears-think.md
+++ b/.changeset/sharp-ears-think.md
@@ -1,0 +1,35 @@
+---
+"@data-client/endpoint": minor
+"@data-client/rest": minor
+"@data-client/graphql": minor
+---
+
+BREAKING: Entity.useIncoming → [Entity.shouldUpdate](https://dataclient.io/rest/api/Entity#shouldupdate))
+
+```ts title="Before"
+class MyEntity extends Entity {
+  // highlight-next-line
+  static useIncoming(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return !deepEquals(existing, incoming);
+  }
+}
+```
+
+```ts title="After"
+class MyEntity extends Entity {
+  // highlight-next-line
+  static shouldUpdate(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return !deepEquals(existing, incoming);
+  }
+}
+```

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -47,7 +47,7 @@ export class VisSettings extends Entity implements Vis {
     return `${this.id}`;
   }
 
-  static useIncoming(
+  static shouldUpdate(
     existingMeta: { date: number },
     incomingMeta: { date: number },
     existing: any,

--- a/docs/graphql/api/GQLEntity.md
+++ b/docs/graphql/api/GQLEntity.md
@@ -128,14 +128,14 @@ static mergeWithStore(
   existing: any,
   incoming: any,
 ) {
-  const useIncoming = this.useIncoming(
+  const shouldUpdate = this.shouldUpdate(
     existingMeta,
     incomingMeta,
     existing,
     incoming,
   );
 
-  if (useIncoming) {
+  if (shouldUpdate) {
     // distinct types are not mergeable (like delete symbol), so just replace
     if (typeof incoming !== typeof existing) {
       return incoming;
@@ -157,12 +157,12 @@ static mergeWithStore(
 
 `mergeWithStore()` is called during normalization when a processed entity is already found in the store.
 
-This calls [useIncoming()](#useincoming), [shouldReorder()](#shouldreorder) and potentially [merge()](#merge)
+This calls [shouldUpdate()](#shouldupdate), [shouldReorder()](#shouldreorder) and potentially [merge()](#merge)
 
-### static useIncoming(existingMeta, incomingMeta, existing, incoming): boolean {#useincoming}
+### static shouldUpdate(existingMeta, incomingMeta, existing, incoming): boolean {#shouldupdate}
 
 ```typescript
-static useIncoming(
+static shouldUpdate(
   existingMeta: { date: number; fetchedAt: number },
   incomingMeta: { date: number; fetchedAt: number },
   existing: any,
@@ -174,7 +174,7 @@ static useIncoming(
 
 #### Preventing updates
 
-useIncoming can also be used to short-circuit an entity update.
+shouldUpdate can also be used to short-circuit an entity update.
 
 ```typescript
 import deepEqual from 'deep-equal';
@@ -184,7 +184,7 @@ class Article extends GQLEntity {
   content = '';
   published = false;
 
-  static useIncoming(
+  static shouldUpdate(
     existingMeta: { date: number; fetchedAt: number },
     incomingMeta: { date: number; fetchedAt: number },
     existing: any,

--- a/docs/graphql/diagrams/_entity_lifecycle.mdx
+++ b/docs/graphql/diagrams/_entity_lifecycle.mdx
@@ -22,7 +22,7 @@ flowchart BT
     subgraph INSTORE["Found In Store"]
       subgraph Entity.mergeWithStore
         direction TB
-        useincoming("Entity.useIncoming()")---shouldreorder("Entity.shouldReorder()")
+        shouldupdate("Entity.shouldUpdate()")---shouldreorder("Entity.shouldReorder()")
         shouldreorder---merge("Entity.merge()")
       end
       Entity.mergeWithStore---mergeMetaWithStore("Entity.mergeMetaWithStore()")
@@ -35,7 +35,7 @@ flowchart BT
   click validate "/rest/api/Entity#validate"
   click validate2 "/rest/api/Entity#validate"
   click mergeMetaWithStore "/rest/api/Entity#mergeMetaWithStore"
-  click useincoming "/rest/api/Entity#useincoming"
+  click shouldupdate "/rest/api/Entity#shouldupdate"
   click shouldreorder "/rest/api/Entity#shouldreorder"
   click mergewithstore "/rest/api/Entity#mergeWithStore"
   click merge "/rest/api/Entity#merge"

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -220,14 +220,14 @@ static mergeWithStore(
   existing: any,
   incoming: any,
 ) {
-  const useIncoming = this.useIncoming(
+  const shouldUpdate = this.shouldUpdate(
     existingMeta,
     incomingMeta,
     existing,
     incoming,
   );
 
-  if (useIncoming) {
+  if (shouldUpdate) {
     // distinct types are not mergeable (like delete symbol), so just replace
     if (typeof incoming !== typeof existing) {
       return incoming;
@@ -249,12 +249,12 @@ static mergeWithStore(
 
 `mergeWithStore()` is called during normalization when a processed entity is already found in the store.
 
-This calls [useIncoming()](#useincoming), [shouldReorder()](#shouldreorder) and potentially [merge()](#merge)
+This calls [shouldUpdate()](#shouldupdate), [shouldReorder()](#shouldreorder) and potentially [merge()](#merge)
 
-### static useIncoming(existingMeta, incomingMeta, existing, incoming): boolean {#useincoming}
+### static shouldUpdate(existingMeta, incomingMeta, existing, incoming): boolean {#shouldupdate}
 
 ```typescript
-static useIncoming(
+static shouldUpdate(
   existingMeta: { date: number; fetchedAt: number },
   incomingMeta: { date: number; fetchedAt: number },
   existing: any,
@@ -266,7 +266,7 @@ static useIncoming(
 
 #### Preventing updates
 
-useIncoming can also be used to short-circuit an entity update.
+shouldUpdate can also be used to short-circuit an entity update.
 
 ```typescript
 import deepEqual from 'deep-equal';
@@ -277,7 +277,7 @@ class Article extends Entity {
   content = '';
   published = false;
 
-  static useIncoming(
+  static shouldUpdate(
     existingMeta: { date: number; fetchedAt: number },
     incomingMeta: { date: number; fetchedAt: number },
     existing: any,

--- a/docs/rest/diagrams/_entity_lifecycle.mdx
+++ b/docs/rest/diagrams/_entity_lifecycle.mdx
@@ -22,7 +22,7 @@ flowchart BT
     subgraph INSTORE["Found In Store"]
       subgraph Entity.mergeWithStore
         direction TB
-        useincoming("Entity.useIncoming()")---shouldreorder("Entity.shouldReorder()")
+        shouldupdate("Entity.shouldUpdate()")---shouldreorder("Entity.shouldReorder()")
         shouldreorder---merge("Entity.merge()")
       end
       Entity.mergeWithStore---mergeMetaWithStore("Entity.mergeMetaWithStore()")
@@ -35,7 +35,7 @@ flowchart BT
   click validate "/rest/api/Entity#validate"
   click validate2 "/rest/api/Entity#validate"
   click mergeMetaWithStore "/rest/api/Entity#mergeMetaWithStore"
-  click useincoming "/rest/api/Entity#useincoming"
+  click shouldupdate "/rest/api/Entity#shouldupdate"
   click shouldreorder "/rest/api/Entity#shouldreorder"
   click mergewithstore "/rest/api/Entity#mergeWithStore"
   click merge "/rest/api/Entity#merge"

--- a/packages/endpoint/src-4.0-types/schemas/EntitySchema.d.ts
+++ b/packages/endpoint/src-4.0-types/schemas/EntitySchema.d.ts
@@ -35,7 +35,7 @@ export type EntityOptions<TInstance extends {}> = {
     | 'mergeWithStore'
     | 'validate'
     | 'shouldReorder'
-    | 'useIncoming'
+    | 'shouldUpdate'
   >]?: IEntityClass<new (...args: any[]) => TInstance>[K];
 };
 export interface RequiredPKOptions<TInstance extends {}>
@@ -99,9 +99,9 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): string | number | undefined;
   /** Return true to merge incoming data; false keeps existing entity
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
+   * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
    */
-  useIncoming(
+  shouldUpdate(
     existingMeta: {
       date: number;
       fetchedAt: number;

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -38,7 +38,7 @@ export type EntityOptions<TInstance extends {}> = {
     | 'mergeWithStore'
     | 'validate'
     | 'shouldReorder'
-    | 'useIncoming'
+    | 'shouldUpdate'
   >]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 
@@ -119,9 +119,9 @@ export default function EntitySchema<TBase extends Constructor>(
 
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
+     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
      */
-    static useIncoming(
+    static shouldUpdate(
       existingMeta: { date: number; fetchedAt: number },
       incomingMeta: { date: number; fetchedAt: number },
       existing: any,
@@ -168,14 +168,14 @@ export default function EntitySchema<TBase extends Constructor>(
       existing: any,
       incoming: any,
     ) {
-      const useIncoming = this.useIncoming(
+      const shouldUpdate = this.shouldUpdate(
         existingMeta,
         incomingMeta,
         existing,
         incoming,
       );
 
-      if (useIncoming) {
+      if (shouldUpdate) {
         // distinct types are not mergeable (like delete symbol), so just replace
         if (typeof incoming !== typeof existing) {
           return incoming;
@@ -540,9 +540,9 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): string | number | undefined;
   /** Return true to merge incoming data; false keeps existing entity
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
+   * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
    */
-  useIncoming(
+  shouldUpdate(
     existingMeta: {
       date: number;
       fetchedAt: number;

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -85,11 +85,11 @@ describe(`${Entity.name} normalization`, () => {
     ).toMatchSnapshot();
   });
 
-  test('normalizes does not change value when useIncoming() returns false', () => {
+  test('normalizes does not change value when shouldUpdate() returns false', () => {
     class MyEntity extends IDEntity {
       id = '';
       title = '';
-      static useIncoming() {
+      static shouldUpdate() {
         return false;
       }
     }

--- a/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
@@ -329,13 +329,13 @@ describe(`${schema.Entity.name} normalization`, () => {
     ).toMatchSnapshot();
   });
 
-  test('normalizes does not change value when useIncoming() returns false', () => {
+  test('normalizes does not change value when shouldUpdate() returns false', () => {
     class MyData {
       id = '';
       title = '';
     }
     class MyEntity extends schema.Entity(MyData) {
-      static useIncoming() {
+      static shouldUpdate() {
         return false;
       }
     }

--- a/website/blog/2024-03-15-v0.11-queries-querable-usequery.md
+++ b/website/blog/2024-03-15-v0.11-queries-querable-usequery.md
@@ -50,6 +50,7 @@ const bob = snapshot.get(User, { username: 'bob' });
 - [new Query -> new schema.Query](/blog/2024/03/15/v0.11-queries-querable-usequery#query-migration)
   - useCache(myQuery) -> useQuery(myQuery)
 - [new AbortOptimistic() -> snapshot.abort](/blog/2024/03/15/v0.11-queries-querable-usequery#snap.abort)
+- [Entity.useIncoming → Entity.shouldUpdate](/blog/2024/03/15/v0.11-queries-querable-usequery#shouldupdate)
 
 [**Other Highlights:**](/blog/2024/03/15/v0.11-queries-querable-usequery#other-improvements)
 
@@ -216,6 +217,7 @@ const usersInGroup = useQuery(UserCollection, { groupId: '5' });
   class MyEntity extends Entity {
     id = 0;
     pk() {
+      // highlight-next-line
       return `${this.id}`;
     }
   }
@@ -224,6 +226,7 @@ const usersInGroup = useQuery(UserCollection, { groupId: '5' });
   class MyEntity extends Entity {
     id = 0;
     pk() {
+      // highlight-next-line
       return this.id;
     }
   }
@@ -272,6 +275,7 @@ const bob = useQuery(User, { username: 'bob' });
 [Query](/rest/api/Query) is now a schema; used with [useQuery](/docs/api/useQuery)
 
 ```jsx title="Before"
+// highlight-next-line
 const getUserCount = new Query(
   new schema.All(User),
   (entries, { isAdmin } = {}) => {
@@ -286,6 +290,7 @@ const adminCount = useCache(getUserCount, { isAdmin: true });
 ```
 
 ```jsx title="After"
+// highlight-next-line
 const getUserCount = new schema.Query(
   new schema.All(User),
   (entries, { isAdmin } = {}) => {
@@ -306,6 +311,7 @@ const adminCount = useQuery(getUserCount, { isAdmin: true });
 ```ts title="Before"
 getOptimisticResponse(snapshot, { id }) {
   const { data } = snapshot.getResponse(Base.get, { id });
+  // highlight-next-line
   if (!data) throw new AbortOptimistic();
   return {
     id,
@@ -317,11 +323,44 @@ getOptimisticResponse(snapshot, { id }) {
 ```ts title="After"
 getOptimisticResponse(snapshot, { id }) {
   const { data } = snapshot.getResponse(Base.get, { id });
+  // highlight-next-line
   if (!data) throw snapshot.abort;
   return {
     id,
     votes: data.votes + 1,
   };
+}
+```
+
+### Entity.useIncoming → Entity.shouldUpdate {#shouldupdate}
+
+Make [Entity.shouldUpdate](/rest/api/Entity#shouldupdate) name consistent with [Entity.shouldReorder](/rest/api/Entity#shouldreorder) [#2972](https://github.com/reactive/data-client/pull/2972)
+
+```ts title="Before"
+class MyEntity extends Entity {
+  // highlight-next-line
+  static useIncoming(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return !deepEquals(existing, incoming);
+  }
+}
+```
+
+```ts title="After"
+class MyEntity extends Entity {
+  // highlight-next-line
+  static shouldUpdate(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return !deepEquals(existing, incoming);
+  }
 }
 ```
 
@@ -336,6 +375,7 @@ directly.
 {
   "Article": {
     "123": {
+      // highlight-next-line
       "author": 8472,
       "id": 123,
       "title": "A Great Article"
@@ -354,6 +394,7 @@ directly.
 {
   "Article": {
     "123": {
+      // highlight-next-line
       "author": "8472",
       "id": 123,
       "title": "A Great Article"
@@ -365,6 +406,47 @@ directly.
       "name": "Paul"
     }
   }
+}
+```
+
+#### state.results -> state.endpoints [#2971](https://github.com/reactive/data-client/pull/2971)
+
+This will only likely matter when consuming [@data-client/core](https://www.npmjs.com/package/@data-client/core ) directly as internal state is structure
+is opaque to [@data-client/react](https://www.npmjs.com/package/@data-client/react).
+
+```json "Before"
+{
+  "entities": {
+    "CoolerArticle": {
+      "5": {
+        "content": "more things here",
+        "id": 5,
+        "title": "hi",
+      },
+    },
+  },
+  // highlight-next-line
+  "results": {
+    "GET http://test.com/article-cooler/5": "5",
+  },
+}
+```
+
+```json "After"
+{
+  "entities": {
+    "CoolerArticle": {
+      "5": {
+        "content": "more things here",
+        "id": 5,
+        "title": "hi",
+      },
+    },
+  },
+  // highlight-next-line
+  "endpoints": {
+    "GET http://test.com/article-cooler/5": "5",
+  },
 }
 ```
 

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -277,7 +277,7 @@ type EntityOptions<TInstance extends {}> = {
     readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
     readonly key?: string;
 } & {
-    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
+    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'shouldUpdate'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
@@ -319,9 +319,9 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
+     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
      */
-    useIncoming(existingMeta: {
+    shouldUpdate(existingMeta: {
         date: number;
         fetchedAt: number;
     }, incomingMeta: {

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -277,7 +277,7 @@ type EntityOptions<TInstance extends {}> = {
     readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
     readonly key?: string;
 } & {
-    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
+    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'shouldUpdate'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
@@ -319,9 +319,9 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
+     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
      */
-    useIncoming(existingMeta: {
+    shouldUpdate(existingMeta: {
         date: number;
         fetchedAt: number;
     }, incomingMeta: {

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -275,7 +275,7 @@ type EntityOptions<TInstance extends {}> = {
     readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
     readonly key?: string;
 } & {
-    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
+    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'shouldUpdate'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
@@ -317,9 +317,9 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
+     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
      */
-    useIncoming(existingMeta: {
+    shouldUpdate(existingMeta: {
         date: number;
         fetchedAt: number;
     }, incomingMeta: {

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -279,7 +279,7 @@ type EntityOptions<TInstance extends {}> = {
     readonly pk?: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
     readonly key?: string;
 } & {
-    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'useIncoming'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
+    readonly [K in Extract<keyof IEntityClass, 'process' | 'merge' | 'expiresAt' | 'createIfValid' | 'mergeWithStore' | 'validate' | 'shouldReorder' | 'shouldUpdate'>]?: IEntityClass<abstract new (...args: any[]) => TInstance>[K];
 };
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
@@ -321,9 +321,9 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#useIncoming
+     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
      */
-    useIncoming(existingMeta: {
+    shouldUpdate(existingMeta: {
         date: number;
         fetchedAt: number;
     }, incomingMeta: {

--- a/website/src/components/Playground/resources/TodoResource.ts
+++ b/website/src/components/Playground/resources/TodoResource.ts
@@ -13,7 +13,7 @@ export class Todo extends PlaceholderEntity {
 
   static key = 'Todo';
 
-  static useIncoming(
+  static shouldUpdate(
     existingMeta: { date: number; fetchedAt: number },
     incomingMeta: { date: number; fetchedAt: number },
     existing: { updatedAt: number },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Make [Entity.shouldUpdate](/rest/api/Entity#shouldupdate) name consistent with [Entity.shouldReorder](/rest/api/Entity#shouldreorder)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

```ts title="Before"
class MyEntity extends Entity {
  // highlight-next-line
  static useIncoming(
    existingMeta: { date: number },
    incomingMeta: { date: number },
    existing: any,
    incoming: any,
  ) {
    return !deepEquals(existing, incoming);
  }
}
```

```ts title="After"
class MyEntity extends Entity {
  // highlight-next-line
  static shouldUpdate(
    existingMeta: { date: number },
    incomingMeta: { date: number },
    existing: any,
    incoming: any,
  ) {
    return !deepEquals(existing, incoming);
  }
}
```