### PR TITLE
enhance: Allow sideEffect overrides when using .extend()

### DIFF
--- a/.changeset/quick-spiders-wave.md
+++ b/.changeset/quick-spiders-wave.md
@@ -1,0 +1,5 @@
+---
+"@data-client/rest": patch
+---
+
+Allow sideEffect overrides when using .extend()

--- a/packages/normalizr/README.md
+++ b/packages/normalizr/README.md
@@ -217,13 +217,18 @@ const memo = new MemoCache();
 const { data, paths } = memo.denormalize(input, schema, state.entities, args);
 
 const data = memo.query(key, schema, args, state.entities, state.indexes);
-const queryKey = memo.buildQueryKey(
-  key,
-  schema,
-  args,
-  state.entities,
-  state.indexes,
-);
+
+function query(key, schema, args, state) {
+  const queryKey = memo.buildQueryKey(
+    key,
+    schema,
+    args,
+    state.entities,
+    state.indexes,
+  );
+  const { data } = this.denormalize(queryKey, schema, state.entities, args);
+  return typeof data === 'symbol' ? undefined : (data as any);
+}
 ```
 
 `memo.denormalize()` is just like denormalize() above but includes `paths` as part of the return value. `paths`

--- a/packages/rest/src/RestEndpointTypes.ts
+++ b/packages/rest/src/RestEndpointTypes.ts
@@ -221,7 +221,9 @@ type OptionsToRestEndpoint<
         'method' extends keyof O ? O['method'] : E['method']
       >,
       'schema' extends keyof O ? O['schema'] : E['schema'],
-      'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
+      'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true>
+      : 'method' extends keyof O ? MethodToSide<O['method']>
+      : E['sideEffect'],
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>,
       {
         path: Exclude<O['path'], undefined>;
@@ -246,7 +248,9 @@ type OptionsToRestEndpoint<
         'method' extends keyof O ? O['method'] : E['method']
       >,
       'schema' extends keyof O ? O['schema'] : E['schema'],
-      'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
+      'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true>
+      : 'method' extends keyof O ? MethodToSide<O['method']>
+      : E['sideEffect'],
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>,
       {
         path: E['path'];
@@ -269,7 +273,9 @@ type OptionsToRestEndpoint<
         'method' extends keyof O ? O['method'] : E['method']
       >,
       'schema' extends keyof O ? O['schema'] : E['schema'],
-      'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
+      'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true>
+      : 'method' extends keyof O ? MethodToSide<O['method']>
+      : E['sideEffect'],
       O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>,
       {
         path: E['path'];
@@ -284,7 +290,9 @@ type OptionsToRestEndpoint<
   : RestInstance<
       F,
       'schema' extends keyof O ? O['schema'] : E['schema'],
-      'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'],
+      'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true>
+      : 'method' extends keyof O ? MethodToSide<O['method']>
+      : E['sideEffect'],
       {
         path: 'path' extends keyof O ? Exclude<O['path'], undefined>
         : E['path'];

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -234,7 +234,7 @@ describe('RestEndpoint', () => {
     () => epbody({ title: 'hi' }, { title: 'hi' });
   });
 
-  /* TODO: it('should allow sideEffect overrides', () => {
+  it('should allow sideEffect overrides', () => {
     const weirdGetUser = new RestEndpoint({
       path: 'http\\://test.com/user/:id',
       name: 'getter',
@@ -244,9 +244,10 @@ describe('RestEndpoint', () => {
     });
 
     expect(weirdGetUser.sideEffect).toBe(undefined);
-    //s @ts-expect-error
-    //const y: true = weirdGetUser.sideEffect;
-  });*/
+    const a: undefined = weirdGetUser.sideEffect;
+    // @ts-expect-error
+    const y: true = weirdGetUser.sideEffect;
+  });
 
   it('should handle simple urls', () => {
     expect(getUser.url({ id: '5' })).toBe('http://test.com/user/5');

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Entity, schema } from '@data-client/endpoint';
-import { useSuspense } from '@data-client/react';
+import { useController, useLive, useSuspense } from '@data-client/react';
 import { User } from '__tests__/new';
 
 import createResource from '../createResource';
@@ -426,6 +426,62 @@ it('should precisely type function arguments', () => {
     () => noSearch({ userId: 'hi' });
     // @ts-expect-error
     () => noSearch(5);
+  };
+});
+
+it('should allow sideEffect overrides', () => {
+  const getEth = new RestEndpoint({
+    urlPrefix: 'https://rpc.ankr.com',
+    path: '/eth',
+    method: 'POST',
+    body: {} as { jsonrpc: string; id: number; method: string; params: any[] },
+    pollFrequency: 30 * 1000,
+    sideEffect: undefined,
+  });
+  () => {
+    const ctrl = useController();
+    ctrl.fetch(getEth, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    useSuspense(getEth, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    // @ts-expect-error
+    ctrl.fetch(getEth, {
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    // @ts-expect-error
+    useSuspense(getEth, {
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    // @ts-expect-error
+    useSuspense(getEth, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 6,
+      params: ['latest', true],
+    });
+    useSuspense(
+      getEth,
+      // @ts-expect-error
+      {},
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_getBlockByNumber',
+        params: ['latest', true],
+      },
+    );
   };
 });
 

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -438,6 +438,16 @@ it('should allow sideEffect overrides', () => {
     pollFrequency: 30 * 1000,
     sideEffect: undefined,
   });
+  const getEthExtend = new RestEndpoint({
+    urlPrefix: 'https://rpc.ankr.com',
+    path: '/eth',
+    method: 'POST',
+    body: {} as { jsonrpc: string; id: number; method: string; params: any[] },
+    pollFrequency: 30 * 1000,
+  }).extend({ sideEffect: undefined });
+
+  const a: undefined = getEth.sideEffect;
+  const b: undefined = getEthExtend.sideEffect;
   () => {
     const ctrl = useController();
     ctrl.fetch(getEth, {
@@ -473,6 +483,51 @@ it('should allow sideEffect overrides', () => {
     });
     useSuspense(
       getEth,
+      // @ts-expect-error
+      {},
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_getBlockByNumber',
+        params: ['latest', true],
+      },
+    );
+  };
+  () => {
+    const ctrl = useController();
+    ctrl.fetch(getEthExtend, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    useSuspense(getEthExtend, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    // @ts-expect-error
+    ctrl.fetch(getEthExtend, {
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    // @ts-expect-error
+    useSuspense(getEthExtend, {
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['latest', true],
+    });
+    // @ts-expect-error
+    useSuspense(getEthExtend, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 6,
+      params: ['latest', true],
+    });
+    useSuspense(
+      getEthExtend,
       // @ts-expect-error
       {},
       {

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -1199,25 +1199,25 @@ type RestEndpointExtendOptions<O extends PartialRestGenerics, E extends {
 type OptionsToRestEndpoint<O extends PartialRestGenerics, E extends RestInstanceBase & {
     body?: any;
     paginationField?: string;
-}, F extends FetchFunction> = 'path' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>> : PathArgs<Exclude<O['path'], undefined>>, OptionsToBodyArgument<'body' extends keyof O ? O : E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
+}, F extends FetchFunction> = 'path' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>> : PathArgs<Exclude<O['path'], undefined>>, OptionsToBodyArgument<'body' extends keyof O ? O : E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
     path: Exclude<O['path'], undefined>;
     body: 'body' extends keyof O ? O['body'] : E['body'];
     searchParams: 'searchParams' extends keyof O ? O['searchParams'] : E['searchParams'];
     method: 'method' extends keyof O ? O['method'] : E['method'];
     paginationField: 'paginationField' extends keyof O ? O['paginationField'] : E['paginationField'];
-}> : 'body' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>> : PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<O, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
+}> : 'body' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>> : PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<O, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
     path: E['path'];
     body: O['body'];
     searchParams: 'searchParams' extends keyof O ? O['searchParams'] : E['searchParams'];
     method: 'method' extends keyof O ? O['method'] : E['method'];
     paginationField: 'paginationField' extends keyof O ? O['paginationField'] : Extract<E['paginationField'], string>;
-}> : 'searchParams' extends keyof O ? RestType<O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
+}> : 'searchParams' extends keyof O ? RestType<O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
     path: E['path'];
     body: E['body'];
     searchParams: O['searchParams'];
     method: 'method' extends keyof O ? O['method'] : E['method'];
     paginationField: 'paginationField' extends keyof O ? O['paginationField'] : Extract<E['paginationField'], string>;
-}> : RestInstance<F, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], {
+}> : RestInstance<F, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], {
     path: 'path' extends keyof O ? Exclude<O['path'], undefined> : E['path'];
     body: 'body' extends keyof O ? O['body'] : E['body'];
     searchParams: 'searchParams' extends keyof O ? O['searchParams'] : E['searchParams'];

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -1203,25 +1203,25 @@ type RestEndpointExtendOptions<O extends PartialRestGenerics, E extends {
 type OptionsToRestEndpoint<O extends PartialRestGenerics, E extends RestInstanceBase & {
     body?: any;
     paginationField?: string;
-}, F extends FetchFunction> = 'path' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>> : PathArgs<Exclude<O['path'], undefined>>, OptionsToBodyArgument<'body' extends keyof O ? O : E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
+}, F extends FetchFunction> = 'path' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<O['path'], undefined>> : PathArgs<Exclude<O['path'], undefined>>, OptionsToBodyArgument<'body' extends keyof O ? O : E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
     path: Exclude<O['path'], undefined>;
     body: 'body' extends keyof O ? O['body'] : E['body'];
     searchParams: 'searchParams' extends keyof O ? O['searchParams'] : E['searchParams'];
     method: 'method' extends keyof O ? O['method'] : E['method'];
     paginationField: 'paginationField' extends keyof O ? O['paginationField'] : E['paginationField'];
-}> : 'body' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>> : PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<O, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
+}> : 'body' extends keyof O ? RestType<'searchParams' extends keyof O ? O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>> : PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<O, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
     path: E['path'];
     body: O['body'];
     searchParams: 'searchParams' extends keyof O ? O['searchParams'] : E['searchParams'];
     method: 'method' extends keyof O ? O['method'] : E['method'];
     paginationField: 'paginationField' extends keyof O ? O['paginationField'] : Extract<E['paginationField'], string>;
-}> : 'searchParams' extends keyof O ? RestType<O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
+}> : 'searchParams' extends keyof O ? RestType<O['searchParams'] extends undefined ? PathArgs<Exclude<O['path'], undefined>> : O['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, OptionsToBodyArgument<E, 'method' extends keyof O ? O['method'] : E['method']>, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], O['process'] extends {} ? ReturnType<O['process']> : ResolveType<F>, {
     path: E['path'];
     body: E['body'];
     searchParams: O['searchParams'];
     method: 'method' extends keyof O ? O['method'] : E['method'];
     paginationField: 'paginationField' extends keyof O ? O['paginationField'] : Extract<E['paginationField'], string>;
-}> : RestInstance<F, 'schema' extends keyof O ? O['schema'] : E['schema'], 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], {
+}> : RestInstance<F, 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? Extract<O['sideEffect'], undefined | true> : 'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect'], {
     path: 'path' extends keyof O ? Exclude<O['path'], undefined> : E['path'];
     body: 'body' extends keyof O ? O['body'] : E['body'];
     searchParams: 'searchParams' extends keyof O ? O['searchParams'] : E['searchParams'];


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Some weird APIs aren't REST, but they still mostly use HTTP protocols, so allow explicit set of sideEffect


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We already do this correctly in constructor of RestEndpoint. Update type code in extend to reflect same logic in constructor. Add tests.

