### PR TITLE
enhance: Endpoint.sideEffect can be

### DIFF
--- a/.changeset/new-readers-exercise.md
+++ b/.changeset/new-readers-exercise.md
@@ -1,0 +1,7 @@
+---
+"@data-client/endpoint": minor
+"@data-client/graphql": minor
+"@data-client/rest": minor
+---
+
+Endpoint.sideEffect can be `false`

--- a/packages/endpoint/src-4.2-types/endpointTypes.d.ts
+++ b/packages/endpoint/src-4.2-types/endpointTypes.d.ts
@@ -10,7 +10,7 @@ import type {
 export interface EndpointOptions<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = undefined,
-  M extends true | undefined = undefined,
+  M extends boolean | undefined = undefined,
 > extends EndpointExtraOptions<F> {
   key?: (...args: Parameters<F>) => string;
   sideEffect?: M;
@@ -20,7 +20,7 @@ export interface EndpointOptions<
 export interface EndpointExtendOptions<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointOptions<F, S, M> {
   fetch?: FetchFunction;
 }
@@ -32,7 +32,7 @@ export type ExtendedEndpoint<
   E extends EndpointInstance<
     FetchFunction,
     Schema | undefined,
-    true | undefined
+    boolean | undefined
   >,
   F extends FetchFunction,
 > = EndpointInstance<
@@ -49,13 +49,13 @@ export type ExtendedEndpoint<
 export interface EndpointInstance<
   F extends (...args: any) => Promise<any> = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointInstanceInterface<F, S, M> {
   extend<
     E extends EndpointInstance<
       (...args: any) => Promise<any>,
       Schema | undefined,
-      true | undefined
+      boolean | undefined
     >,
     O extends EndpointExtendOptions<F> &
       Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> &
@@ -72,7 +72,7 @@ export interface EndpointInstance<
 export interface EndpointInstanceInterface<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointInterface<F, S, M> {
   constructor: EndpointConstructor;
   /**
@@ -132,7 +132,7 @@ export interface EndpointConstructor {
       body?: any,
     ) => Promise<any>,
     S extends Schema | undefined = undefined,
-    M extends true | undefined = undefined,
+    M extends boolean | undefined = false,
     E extends Record<string, any> = {},
   >(
     fetchFunction: F,
@@ -148,7 +148,7 @@ export interface ExtendableEndpointConstructor {
       body?: any,
     ) => Promise<any>,
     S extends Schema | undefined = undefined,
-    M extends true | undefined = undefined,
+    M extends boolean | undefined = false,
     E extends Record<string, any> = {},
   >(
     RestFetch: F,

--- a/packages/endpoint/src-legacy-types/endpointTypes.d.ts
+++ b/packages/endpoint/src-legacy-types/endpointTypes.d.ts
@@ -7,7 +7,7 @@ import type { EndpointExtraOptions, FetchFunction } from './types.js';
 export interface EndpointOptions<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = undefined,
-  M extends true | undefined = undefined,
+  M extends boolean | undefined = false,
 > extends EndpointExtraOptions<F> {
   key?: (...args: Parameters<F>) => string;
   sideEffect?: M;
@@ -17,7 +17,7 @@ export interface EndpointOptions<
 export interface EndpointExtendOptions<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointOptions<F, S, M> {
   fetch?: FetchFunction;
 }
@@ -29,7 +29,7 @@ export type ExtendedEndpoint<
   E extends EndpointInstance<
     FetchFunction,
     Schema | undefined,
-    true | undefined
+    boolean | undefined
   >,
   F extends FetchFunction,
 > = EndpointInstance<
@@ -46,13 +46,13 @@ export type ExtendedEndpoint<
 export interface EndpointInstance<
   F extends (...args: any) => Promise<any> = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointInstanceInterface<F, S, M> {
   extend<
     E extends EndpointInstance<
       (...args: any) => Promise<any>,
       Schema | undefined,
-      true | undefined
+      boolean | undefined
     >,
     O extends EndpointExtendOptions<F> &
       Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> &
@@ -69,7 +69,7 @@ export interface EndpointInstance<
 export interface EndpointInstanceInterface<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointInterface<F, S, M> {
   constructor: EndpointConstructor;
   /**
@@ -125,7 +125,7 @@ export interface EndpointConstructor {
       body?: any,
     ) => Promise<any>,
     S extends Schema | undefined = undefined,
-    M extends true | undefined = undefined,
+    M extends boolean | undefined = false,
     E extends Record<string, any> = {},
   >(
     fetchFunction: F,
@@ -141,7 +141,7 @@ export interface ExtendableEndpointConstructor {
       body?: any,
     ) => Promise<any>,
     S extends Schema | undefined = undefined,
-    M extends true | undefined = undefined,
+    M extends boolean | undefined = false,
     E extends Record<string, any> = {},
   >(
     RestFetch: F,

--- a/packages/endpoint/src/__tests__/endpoint.ts
+++ b/packages/endpoint/src/__tests__/endpoint.ts
@@ -240,20 +240,20 @@ describe.each([true, false])(`Endpoint (CSP %s)`, mockCSP => {
     const BaseFetch = new Endpoint(fetchUsers);
     // @ts-expect-error
     const aa: true = BaseFetch.sideEffect;
-    const bb: undefined = BaseFetch.sideEffect;
+    const bb: false = BaseFetch.sideEffect;
     const UserDetail = new Endpoint(fetchUsers).extend({
       sideEffect: true,
       key: ({ id }: { id: string }) => `fetch my user ${id}`,
     });
     // @ts-expect-error
-    const a: undefined = UserDetail.sideEffect;
+    const a: false = UserDetail.sideEffect;
     const b: true = UserDetail.sideEffect;
 
     // ts-expect-error
     //const c: undefined = UserDetail.extend({ dataExpiryLength: 5 }).sideEffect;
     //const d: true = UserDetail.extend({ dataExpiryLength: 5 }).sideEffect;
 
-    function t(a: EndpointInterface<typeof fetchUsers, any, undefined>) {}
+    function t(a: EndpointInterface<typeof fetchUsers, any, false>) {}
     // @ts-expect-error
     t(UserDetail);
     t(BaseFetch);
@@ -457,7 +457,7 @@ describe.each([true, false])(`Endpoint (CSP %s)`, mockCSP => {
           name: 'UserDetai',
         },
       );
-      const a: undefined = UserDetail.sideEffect;
+      const a: false = UserDetail.sideEffect;
       // @ts-expect-error
       const b: true = UserDetail.sideEffect;
       UserDetail.schema;
@@ -533,7 +533,7 @@ describe.each([true, false])(`Endpoint (CSP %s)`, mockCSP => {
         },
       );
       const sch: (typeof User)[] = UserDetail.schema;
-      const s: undefined = UserDetail.sideEffect;
+      const s: false = UserDetail.sideEffect;
       UserDetail.random;
       // @ts-expect-error
       UserDetail.nonexistant;
@@ -593,7 +593,7 @@ describe.each([true, false])(`Endpoint (CSP %s)`, mockCSP => {
     /*class ResourceEndpoint<
       F extends (params?: any, body?: any) => Promise<any>,
       S extends Schema | undefined = undefined,
-      M extends true | undefined = undefined
+      M extends boolean | undefined = undefined
     > extends Endpoint<F, S, M> {
       constructor(
         fetchFunction: F,
@@ -647,7 +647,7 @@ describe.each([true, false])(`Endpoint (CSP %s)`, mockCSP => {
           body?: any,
         ) => Promise<any>,
         S extends Schema | undefined = undefined,
-        M extends true | undefined = undefined
+        M extends boolean | undefined = undefined
       > extends Endpoint<F, S, M> {
         token = 'password';
         authdFetch(info: RequestInfo, init?: RequestInit) {

--- a/packages/endpoint/src/endpointTypes.ts
+++ b/packages/endpoint/src/endpointTypes.ts
@@ -9,7 +9,7 @@ import type {
 export interface EndpointOptions<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = undefined,
-  M extends true | undefined = undefined,
+  M extends boolean | undefined = false,
 > extends EndpointExtraOptions<F> {
   key?: (...args: Parameters<F>) => string;
   sideEffect?: M;
@@ -20,7 +20,7 @@ export interface EndpointOptions<
 export interface EndpointExtendOptions<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointOptions<F, S, M> {
   fetch?: FetchFunction;
 }
@@ -37,7 +37,7 @@ export type ExtendedEndpoint<
   E extends EndpointInstance<
     FetchFunction,
     Schema | undefined,
-    true | undefined
+    boolean | undefined
   >,
   F extends FetchFunction,
 > = EndpointInstance<
@@ -55,13 +55,13 @@ export type ExtendedEndpoint<
 export interface EndpointInstance<
   F extends (...args: any) => Promise<any> = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointInstanceInterface<F, S, M> {
   extend<
     E extends EndpointInstance<
       (...args: any) => Promise<any>,
       Schema | undefined,
-      true | undefined
+      boolean | undefined
     >,
     O extends EndpointExtendOptions<F> &
       Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> &
@@ -79,7 +79,7 @@ export interface EndpointInstance<
 export interface EndpointInstanceInterface<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointInterface<F, S, M> {
   constructor: EndpointConstructor;
 
@@ -153,7 +153,7 @@ export interface EndpointConstructor {
       body?: any,
     ) => Promise<any>,
     S extends Schema | undefined = undefined,
-    M extends true | undefined = undefined,
+    M extends boolean | undefined = false,
     E extends Record<string, any> = {},
   >(
     fetchFunction: F,
@@ -170,7 +170,7 @@ export interface ExtendableEndpointConstructor {
       body?: any,
     ) => Promise<any>,
     S extends Schema | undefined = undefined,
-    M extends true | undefined = undefined,
+    M extends boolean | undefined = false,
     E extends Record<string, any> = {},
   >(
     RestFetch: F,

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -129,7 +129,7 @@ export interface GetIndex {
 export interface EndpointInterface<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointExtraOptions<F> {
   (...args: Parameters<F>): ReturnType<F>;
   key(...args: Parameters<F>): string;

--- a/packages/graphql/src/GQLEndpoint.ts
+++ b/packages/graphql/src/GQLEndpoint.ts
@@ -6,7 +6,7 @@ import GQLNetworkError from './GQLNetworkError.js';
 export interface GQLOptions<
   Variables,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends EndpointOptions<(v: Variables) => Promise<any>, S, M> {
   getHeaders?(headers: HeadersInit): HeadersInit;
   getRequestInit?(variables: any): RequestInit;
@@ -17,7 +17,7 @@ export interface GQLOptions<
 export default class GQLEndpoint<
   Variables,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
 > extends Endpoint<
   (v: Variables) => Promise<S extends undefined ? any : Denormalize<S>>,
   S,

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -20,11 +20,7 @@ import useController from '../hooks/useController.js';
  */
 export default function useCache<
   E extends Pick<
-    EndpointInterface<
-      FetchFunction,
-      Schema | undefined,
-      undefined | false | true
-    >,
+    EndpointInterface<FetchFunction, Schema | undefined, undefined | boolean>,
     'key' | 'schema' | 'invalidIfStale'
   >,
   Args extends readonly [...Parameters<E['key']>] | readonly [null],

--- a/packages/rest/src/RestEndpointTypes.ts
+++ b/packages/rest/src/RestEndpointTypes.ts
@@ -18,7 +18,7 @@ import { EndpointUpdateFunction } from './RestEndpointTypeHelp.js';
 export interface RestInstanceBase<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = any,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
   O extends {
     path: string;
     body?: any;
@@ -113,7 +113,7 @@ export interface RestInstanceBase<
 export interface RestInstance<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = any,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
   O extends {
     path: string;
     body?: any;
@@ -350,7 +350,7 @@ export interface RestGenerics extends PartialRestGenerics {
 }
 
 export type PaginationEndpoint<
-  E extends FetchFunction & RestGenerics & { sideEffect?: true | undefined },
+  E extends FetchFunction & RestGenerics & { sideEffect?: boolean | undefined },
   A extends any[],
 > = RestInstanceBase<
   ParamFetchNoBody<A[0], ResolveType<E>>,
@@ -361,7 +361,7 @@ export type PaginationEndpoint<
   }
 >;
 export type PaginationFieldEndpoint<
-  E extends FetchFunction & RestGenerics & { sideEffect?: true | undefined },
+  E extends FetchFunction & RestGenerics & { sideEffect?: boolean | undefined },
   C extends string,
 > = RestInstanceBase<
   ParamFetchNoBody<
@@ -417,7 +417,7 @@ export interface RestEndpointOptions<
   fetchResponse?(input: RequestInfo, init: RequestInit): Promise<any>;
   parseResponse?(response: Response): Promise<any>;
 
-  sideEffect?: true | undefined;
+  sideEffect?: boolean | undefined;
   name?: string;
   signal?: AbortSignal;
   fetch?: F;
@@ -491,7 +491,7 @@ export type RestType<
   UrlParams = any,
   Body = any,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
   R = any,
   O extends {
     path: string;
@@ -509,7 +509,7 @@ export type RestType<
 export type RestTypeWithBody<
   UrlParams = any,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
   Body = any,
   R = any /*Denormalize<S>*/,
   O extends {
@@ -522,7 +522,7 @@ export type RestTypeWithBody<
 export type RestTypeNoBody<
   UrlParams = any,
   S extends Schema | undefined = Schema | undefined,
-  M extends true | undefined = true | undefined,
+  M extends boolean | undefined = boolean | undefined,
   R = any /*Denormalize<S>*/,
   O extends {
     path: string;

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -177,7 +177,7 @@ interface GetIndex {
     };
 }
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): ReturnType<F>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -190,29 +190,29 @@ interface MutateEndpoint<F extends FetchFunction = FetchFunction, S extends Sche
 /** For retrieval requests */
 type ReadEndpoint<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined> = EndpointInterface<F, S, undefined>;
 
-interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends true | undefined = undefined> extends EndpointExtraOptions<F> {
+interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends boolean | undefined = false> extends EndpointExtraOptions<F> {
     key?: (...args: Parameters<F>) => string;
     sideEffect?: M;
     schema?: S;
     [k: string]: any;
 }
-interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointOptions<F, S, M> {
+interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointOptions<F, S, M> {
     fetch?: FetchFunction;
 }
 type KeyofEndpointInstance = keyof EndpointInstance<FetchFunction>;
-type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, true | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
+type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, boolean | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInstanceInterface<F, S, M> {
-    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, true | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
+interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInstanceInterface<F, S, M> {
+    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, boolean | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
 }
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInterface<F, S, M> {
+interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInterface<F, S, M> {
     constructor: EndpointConstructor;
     /**
      * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
@@ -247,11 +247,11 @@ interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S e
     testKey(key: string): boolean;
 }
 interface EndpointConstructor {
-    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
+    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
     readonly prototype: Function;
 }
 interface ExtendableEndpointConstructor {
-    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
+    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
     readonly prototype: Function;
 }
 type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [any, ...infer RestRem] ? Orig extends [any, ...infer RestOrig] ? RemoveArray<RestOrig, RestRem> : never : Orig;

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -177,7 +177,7 @@ interface GetIndex {
     };
 }
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): ReturnType<F>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -190,29 +190,29 @@ interface MutateEndpoint<F extends FetchFunction = FetchFunction, S extends Sche
 /** For retrieval requests */
 type ReadEndpoint<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined> = EndpointInterface<F, S, undefined>;
 
-interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends true | undefined = undefined> extends EndpointExtraOptions<F> {
+interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends boolean | undefined = false> extends EndpointExtraOptions<F> {
     key?: (...args: Parameters<F>) => string;
     sideEffect?: M;
     schema?: S;
     [k: string]: any;
 }
-interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointOptions<F, S, M> {
+interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointOptions<F, S, M> {
     fetch?: FetchFunction;
 }
 type KeyofEndpointInstance = keyof EndpointInstance<FetchFunction>;
-type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, true | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
+type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, boolean | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInstanceInterface<F, S, M> {
-    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, true | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
+interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInstanceInterface<F, S, M> {
+    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, boolean | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
 }
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInterface<F, S, M> {
+interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInterface<F, S, M> {
     constructor: EndpointConstructor;
     /**
      * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
@@ -247,11 +247,11 @@ interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S e
     testKey(key: string): boolean;
 }
 interface EndpointConstructor {
-    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
+    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
     readonly prototype: Function;
 }
 interface ExtendableEndpointConstructor {
-    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
+    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
     readonly prototype: Function;
 }
 type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [any, ...infer RestRem] ? Orig extends [any, ...infer RestOrig] ? RemoveArray<RestOrig, RestRem> : never : Orig;
@@ -1037,13 +1037,13 @@ declare class GQLEntity extends Entity {
     pk(): string;
 }
 
-interface GQLOptions<Variables, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointOptions<(v: Variables) => Promise<any>, S, M> {
+interface GQLOptions<Variables, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointOptions<(v: Variables) => Promise<any>, S, M> {
     getHeaders?(headers: HeadersInit): HeadersInit;
     getRequestInit?(variables: any): RequestInit;
     fetchResponse?(input: RequestInfo, init: RequestInit): Promise<any>;
     process?(value: any, variables: any): any;
 }
-declare class GQLEndpoint<Variables, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends Endpoint<(v: Variables) => Promise<S extends undefined ? any : Denormalize<S>>, S, M> {
+declare class GQLEndpoint<Variables, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends Endpoint<(v: Variables) => Promise<S extends undefined ? any : Denormalize<S>>, S, M> {
     readonly url: string;
     signal?: AbortSignal;
     constructor(url: string, options?: GQLOptions<Variables, S, M>);

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -111,7 +111,7 @@ declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema |
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | false | true>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
 
 /**
  * Query the store.

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -179,7 +179,7 @@ interface GetIndex {
     };
 }
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): ReturnType<F>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -188,29 +188,29 @@ interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends S
 /** For retrieval requests */
 type ReadEndpoint<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined> = EndpointInterface<F, S, undefined>;
 
-interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends true | undefined = undefined> extends EndpointExtraOptions<F> {
+interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends boolean | undefined = false> extends EndpointExtraOptions<F> {
     key?: (...args: Parameters<F>) => string;
     sideEffect?: M;
     schema?: S;
     [k: string]: any;
 }
-interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointOptions<F, S, M> {
+interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointOptions<F, S, M> {
     fetch?: FetchFunction;
 }
 type KeyofEndpointInstance = keyof EndpointInstance<FetchFunction>;
-type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, true | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
+type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, boolean | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInstanceInterface<F, S, M> {
-    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, true | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
+interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInstanceInterface<F, S, M> {
+    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, boolean | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
 }
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInterface<F, S, M> {
+interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInterface<F, S, M> {
     constructor: EndpointConstructor;
     /**
      * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
@@ -245,11 +245,11 @@ interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S e
     testKey(key: string): boolean;
 }
 interface EndpointConstructor {
-    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
+    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
     readonly prototype: Function;
 }
 interface ExtendableEndpointConstructor {
-    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
+    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
     readonly prototype: Function;
 }
 type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [any, ...infer RestRem] ? Orig extends [any, ...infer RestOrig] ? RemoveArray<RestOrig, RestRem> : never : Orig;
@@ -1083,7 +1083,7 @@ type ResultEntry<E extends FetchFunction & {
     schema: any;
 }> = E['schema'] extends undefined | null ? ResolveType<E> : Normalize<E['schema']>;
 
-interface RestInstanceBase<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends true | undefined = true | undefined, O extends {
+interface RestInstanceBase<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends boolean | undefined = boolean | undefined, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1150,7 +1150,7 @@ interface RestInstanceBase<F extends FetchFunction = FetchFunction, S extends Sc
      */
     extend<E extends RestInstanceBase, ExtendOptions extends PartialRestGenerics | {}>(this: E, options: Readonly<RestEndpointExtendOptions<ExtendOptions, E, F> & ExtendOptions>): RestExtendedEndpoint<ExtendOptions, E>;
 }
-interface RestInstance<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends true | undefined = true | undefined, O extends {
+interface RestInstance<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends boolean | undefined = boolean | undefined, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1255,12 +1255,12 @@ interface RestGenerics extends PartialRestGenerics {
     readonly path: string;
 }
 type PaginationEndpoint<E extends FetchFunction & RestGenerics & {
-    sideEffect?: true | undefined;
+    sideEffect?: boolean | undefined;
 }, A extends any[]> = RestInstanceBase<ParamFetchNoBody<A[0], ResolveType<E>>, E['schema'], E['sideEffect'], Pick<E, 'path' | 'searchParams' | 'body'> & {
     searchParams: Omit<A[0], keyof PathArgs<E['path']>>;
 }>;
 type PaginationFieldEndpoint<E extends FetchFunction & RestGenerics & {
-    sideEffect?: true | undefined;
+    sideEffect?: boolean | undefined;
 }, C extends string> = RestInstanceBase<ParamFetchNoBody<{
     [K in C]: string | number | boolean;
 } & E['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, ResolveType<E>>, E['schema'], E['sideEffect'], Pick<E, 'path' | 'searchParams' | 'body'> & {
@@ -1290,7 +1290,7 @@ interface RestEndpointOptions<F extends FetchFunction = FetchFunction, S extends
     getRequestInit?(body: any): Promise<RequestInit> | RequestInit;
     fetchResponse?(input: RequestInfo, init: RequestInit): Promise<any>;
     parseResponse?(response: Response): Promise<any>;
-    sideEffect?: true | undefined;
+    sideEffect?: boolean | undefined;
     name?: string;
     signal?: AbortSignal;
     fetch?: F;
@@ -1313,7 +1313,7 @@ interface RestEndpointConstructor {
 }
 type MethodToSide<M> = M extends string ? M extends 'GET' ? undefined : true : undefined;
 /** RestEndpoint types simplified */
-type RestType<UrlParams = any, Body = any, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined, R = any, O extends {
+type RestType<UrlParams = any, Body = any, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined, R = any, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1322,7 +1322,7 @@ type RestType<UrlParams = any, Body = any, S extends Schema | undefined = Schema
     path: string;
     paginationField: string;
 }> = IfTypeScriptLooseNull<RestInstance<RestFetch<UrlParams, Body, R>, S, M, O>, Body extends {} ? RestTypeWithBody<UrlParams, S, M, Body, R, O> : RestTypeNoBody<UrlParams, S, M, R, O>>;
-type RestTypeWithBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined, Body = any, R = any, O extends {
+type RestTypeWithBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined, Body = any, R = any, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1330,7 +1330,7 @@ type RestTypeWithBody<UrlParams = any, S extends Schema | undefined = Schema | u
     path: string;
     body: any;
 }> = RestInstance<ParamFetchWithBody<UrlParams, Body, R>, S, M, O>;
-type RestTypeNoBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined, R = any, O extends {
+type RestTypeNoBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined, R = any, O extends {
     path: string;
     body?: undefined;
     searchParams?: any;

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -183,7 +183,7 @@ interface GetIndex {
     };
 }
 /** Defines a networking endpoint */
-interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointExtraOptions<F> {
+interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointExtraOptions<F> {
     (...args: Parameters<F>): ReturnType<F>;
     key(...args: Parameters<F>): string;
     readonly sideEffect?: M;
@@ -192,29 +192,29 @@ interface EndpointInterface<F extends FetchFunction = FetchFunction, S extends S
 /** For retrieval requests */
 type ReadEndpoint<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined> = EndpointInterface<F, S, undefined>;
 
-interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends true | undefined = undefined> extends EndpointExtraOptions<F> {
+interface EndpointOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = undefined, M extends boolean | undefined = false> extends EndpointExtraOptions<F> {
     key?: (...args: Parameters<F>) => string;
     sideEffect?: M;
     schema?: S;
     [k: string]: any;
 }
-interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointOptions<F, S, M> {
+interface EndpointExtendOptions<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointOptions<F, S, M> {
     fetch?: FetchFunction;
 }
 type KeyofEndpointInstance = keyof EndpointInstance<FetchFunction>;
-type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, true | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
+type ExtendedEndpoint<O extends EndpointExtendOptions<F>, E extends EndpointInstance<FetchFunction, Schema | undefined, boolean | undefined>, F extends FetchFunction> = EndpointInstance<'fetch' extends keyof O ? Exclude<O['fetch'], undefined> : E['fetch'], 'schema' extends keyof O ? O['schema'] : E['schema'], 'sideEffect' extends keyof O ? O['sideEffect'] : E['sideEffect']> & Omit<O, KeyofEndpointInstance> & Omit<E, KeyofEndpointInstance>;
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInstanceInterface<F, S, M> {
-    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, true | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
+interface EndpointInstance<F extends (...args: any) => Promise<any> = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInstanceInterface<F, S, M> {
+    extend<E extends EndpointInstance<(...args: any) => Promise<any>, Schema | undefined, boolean | undefined>, O extends EndpointExtendOptions<F> & Partial<Omit<E, keyof EndpointInstance<FetchFunction>>> & Record<string, unknown>>(this: E, options: Readonly<O>): ExtendedEndpoint<typeof options, E, F>;
 }
 /**
  * Defines an async data source.
  * @see https://dataclient.io/docs/api/Endpoint
  */
-interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined> extends EndpointInterface<F, S, M> {
+interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointInterface<F, S, M> {
     constructor: EndpointConstructor;
     /**
      * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
@@ -249,11 +249,11 @@ interface EndpointInstanceInterface<F extends FetchFunction = FetchFunction, S e
     testKey(key: string): boolean;
 }
 interface EndpointConstructor {
-    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
+    new <F extends (this: EndpointInstance<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(fetchFunction: F, options?: EndpointOptions<F, S, M> & E): EndpointInstance<F, S, M> & E;
     readonly prototype: Function;
 }
 interface ExtendableEndpointConstructor {
-    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends true | undefined = undefined, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
+    new <F extends (this: EndpointInstanceInterface<FetchFunction> & E, params?: any, body?: any) => Promise<any>, S extends Schema | undefined = undefined, M extends boolean | undefined = false, E extends Record<string, any> = {}>(RestFetch: F, options?: Readonly<EndpointOptions<F, S, M>> & E): EndpointInstanceInterface<F, S, M> & E;
     readonly prototype: Function;
 }
 type RemoveArray<Orig extends any[], Rem extends any[]> = Rem extends [any, ...infer RestRem] ? Orig extends [any, ...infer RestOrig] ? RemoveArray<RestOrig, RestRem> : never : Orig;
@@ -1087,7 +1087,7 @@ type ResultEntry<E extends FetchFunction & {
     schema: any;
 }> = E['schema'] extends undefined | null ? ResolveType<E> : Normalize<E['schema']>;
 
-interface RestInstanceBase<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends true | undefined = true | undefined, O extends {
+interface RestInstanceBase<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends boolean | undefined = boolean | undefined, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1154,7 +1154,7 @@ interface RestInstanceBase<F extends FetchFunction = FetchFunction, S extends Sc
      */
     extend<E extends RestInstanceBase, ExtendOptions extends PartialRestGenerics | {}>(this: E, options: Readonly<RestEndpointExtendOptions<ExtendOptions, E, F> & ExtendOptions>): RestExtendedEndpoint<ExtendOptions, E>;
 }
-interface RestInstance<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends true | undefined = true | undefined, O extends {
+interface RestInstance<F extends FetchFunction = FetchFunction, S extends Schema | undefined = any, M extends boolean | undefined = boolean | undefined, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1259,12 +1259,12 @@ interface RestGenerics extends PartialRestGenerics {
     readonly path: string;
 }
 type PaginationEndpoint<E extends FetchFunction & RestGenerics & {
-    sideEffect?: true | undefined;
+    sideEffect?: boolean | undefined;
 }, A extends any[]> = RestInstanceBase<ParamFetchNoBody<A[0], ResolveType<E>>, E['schema'], E['sideEffect'], Pick<E, 'path' | 'searchParams' | 'body'> & {
     searchParams: Omit<A[0], keyof PathArgs<E['path']>>;
 }>;
 type PaginationFieldEndpoint<E extends FetchFunction & RestGenerics & {
-    sideEffect?: true | undefined;
+    sideEffect?: boolean | undefined;
 }, C extends string> = RestInstanceBase<ParamFetchNoBody<{
     [K in C]: string | number | boolean;
 } & E['searchParams'] & PathArgs<Exclude<E['path'], undefined>>, ResolveType<E>>, E['schema'], E['sideEffect'], Pick<E, 'path' | 'searchParams' | 'body'> & {
@@ -1294,7 +1294,7 @@ interface RestEndpointOptions<F extends FetchFunction = FetchFunction, S extends
     getRequestInit?(body: any): Promise<RequestInit> | RequestInit;
     fetchResponse?(input: RequestInfo, init: RequestInit): Promise<any>;
     parseResponse?(response: Response): Promise<any>;
-    sideEffect?: true | undefined;
+    sideEffect?: boolean | undefined;
     name?: string;
     signal?: AbortSignal;
     fetch?: F;
@@ -1317,7 +1317,7 @@ interface RestEndpointConstructor {
 }
 type MethodToSide<M> = M extends string ? M extends 'GET' ? undefined : true : undefined;
 /** RestEndpoint types simplified */
-type RestType<UrlParams = any, Body = any, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined, R = any, O extends {
+type RestType<UrlParams = any, Body = any, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined, R = any, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1326,7 +1326,7 @@ type RestType<UrlParams = any, Body = any, S extends Schema | undefined = Schema
     path: string;
     paginationField: string;
 }> = IfTypeScriptLooseNull<RestInstance<RestFetch<UrlParams, Body, R>, S, M, O>, Body extends {} ? RestTypeWithBody<UrlParams, S, M, Body, R, O> : RestTypeNoBody<UrlParams, S, M, R, O>>;
-type RestTypeWithBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined, Body = any, R = any, O extends {
+type RestTypeWithBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined, Body = any, R = any, O extends {
     path: string;
     body?: any;
     searchParams?: any;
@@ -1334,7 +1334,7 @@ type RestTypeWithBody<UrlParams = any, S extends Schema | undefined = Schema | u
     path: string;
     body: any;
 }> = RestInstance<ParamFetchWithBody<UrlParams, Body, R>, S, M, O>;
-type RestTypeNoBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends true | undefined = true | undefined, R = any, O extends {
+type RestTypeNoBody<UrlParams = any, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined, R = any, O extends {
     path: string;
     body?: undefined;
     searchParams?: any;
@@ -1695,7 +1695,7 @@ declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Sche
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false | true>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>, Args extends readonly [...Parameters<E['key']>] | readonly [null]>(endpoint: E, ...args: Args): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
 
 /**
  * Query the store.


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
More intuitive; supports sideEffect overrides when using `loosenulltypes`

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Support was already added to consumers (@data-client/react), so these will be supported by existing versions (0.11)