### PR TITLE
internal(fix): Fix flaky tests by testing old ts versions with older @types/react

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,9 @@ jobs:
             if [ "<< parameters.typescript-version >>" != "latest" ]; then
             yarn add --dev typescript@<< parameters.typescript-version >>
             fi
+            if [ "<< parameters.typescript-version >>" == "~4.0" ]; then
+            yarn add --dev @types/react@18.2.0
+            fi
       - run:
           name: typecheck
           command: |


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
ts 4.0 tests flake every 1 in 10. https://app.circleci.com/pipelines/github/reactive/data-client/13890/workflows/b1197b76-94cd-430d-acad-b9507c50b9a3/jobs/119748

<details collapsed>
<summary><b>Flake error</b></summary>

```bash
node_modules/@types/react/ts5.0/index.d.ts:3287:50 - error TS1110: Type expected.

3287     type OptionalPrefixToken<T extends string> = `${T} ` | "";
                                                      ~~~

node_modules/@types/react/ts5.0/index.d.ts:3288:51 - error TS1110: Type expected.

3288     type OptionalPostfixToken<T extends string> = ` ${T}` | "";
                                                       ~~~~

node_modules/@types/react/ts5.0/index.d.ts:3289:48 - error TS1110: Type expected.

3289     type AutoFillField = AutoFillNormalField | `${OptionalPrefixToken<AutoFillContactKind>}${AutoFillContactField}`;
                                                    ~~~

node_modules/@types/react/ts5.0/index.d.ts:3289:91 - error TS1005: '(' expected.

3289     type AutoFillField = AutoFillNormalField | `${OptionalPrefixToken<AutoFillContactKind>}${AutoFillContactField}`;
                                                                                               ~

node_modules/@types/react/ts5.0/index.d.ts:3290:28 - error TS1110: Type expected.

3290     type AutoFillSection = `section-${string}`;
                                ~~~~~~~~~~~

node_modules/@types/react/ts5.0/index.d.ts:3293:11 - error TS1110: Type expected.

3293         | `${OptionalPrefixToken<AutoFillSection>}${OptionalPrefixToken<
               ~~~

node_modules/@types/react/ts5.0/index.d.ts:3293:50 - error TS1005: '(' expected.

3293         | `${OptionalPrefixToken<AutoFillSection>}${OptionalPrefixToken<
                                                      ~

node_modules/@types/react/ts5.0/index.d.ts:3295:10 - error TS1005: '(' expected.

3295         >}${AutoFillField}${OptionalPostfixToken<AutoFillCredentialField>}`;
              ~

node_modules/@types/react/ts5.0/index.d.ts:3295:74 - error TS1005: '(' expected.

3295         >}${AutoFillField}${OptionalPostfixToken<AutoFillCredentialField>}`;
                                                                              ~

```

</details>

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This is occurring in the @types/react library so we fix it to an old version we knew wasn't flaking.