### PR TITLE
enhance: Warn for capitalization mistakes when calling createResource()

### DIFF
--- a/.changeset/fluffy-beans-act.md
+++ b/.changeset/fluffy-beans-act.md
@@ -1,0 +1,19 @@
+---
+"@data-client/rest": patch
+---
+
+Warn for capitalization mistakes when calling createResource()
+
+`Endpoint` and `Collection` are both capitalized because they
+are classes. However, this may not be intuitive since other arguments are lower-first. Let's add a console.warn() to help
+guide, since this may be intentional?
+
+```ts
+export const UserResource = createResource({
+  urlPrefix: CONFIG.API_ROOT,
+  path: '/users/:id',
+  schema: User,
+  // this should be 'Endpoint:'
+  endpoint: AuthedEndpoint,
+});
+```

--- a/examples/coin-app/src/pages/AssetDetail/LineChart.tsx
+++ b/examples/coin-app/src/pages/AssetDetail/LineChart.tsx
@@ -6,7 +6,7 @@ import { formatPrice } from '../../components/formatPrice';
 const TICK_LENGTH = 5;
 const AXIS_HEIGHT = 20;
 
-function LineChart({ data, width, height }: Props) {
+function LineChart({ data, width = 500, height = 400 }: Props) {
   const graphDetails = {
     xScale: scaleTime().range([0, width]),
     yScale: scaleLinear().range([height - AXIS_HEIGHT, 0]),
@@ -89,15 +89,10 @@ function LineChart({ data, width, height }: Props) {
   );
 }
 
-LineChart.defaultProps = {
-  width: 500,
-  height: 400,
-};
-
 interface Props {
   data: { timestamp: number; price_open: number }[];
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
 }
 
 const formatter = new Intl.DateTimeFormat('en-US', {

--- a/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
+++ b/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
@@ -5,3 +5,27 @@ exports[`createResource() UserResource.delete should work with  1`] = `"not foun
 exports[`createResource() UserResource.delete should work with {"id": 5} 1`] = `"not found"`;
 
 exports[`createResource() should not allow paths without at least one argument 1`] = `"Resource path requires at least one :parameter"`;
+
+exports[`createResource() warnings should warn when mis-capitalizing options 1`] = `
+[
+  [
+    "You passed 'endpoint' option; did you mean to use Endpoint?
+https://dataclient.io/rest/api/createResource#endpoint
+This parameter must be capitalized.
+
+This warning will not show in production.",
+  ],
+]
+`;
+
+exports[`createResource() warnings should warn when mis-capitalizing options 2`] = `
+[
+  [
+    "You passed 'collection' option; did you mean to use Collection?
+https://dataclient.io/rest/api/createResource#collection
+This parameter must be capitalized.
+
+This warning will not show in production.",
+  ],
+]
+`;

--- a/packages/rest/src/createResource.ts
+++ b/packages/rest/src/createResource.ts
@@ -30,6 +30,46 @@ export default function createResource<O extends ResourceGenerics>({
   paginationField,
   ...extraOptions
 }: Readonly<O> & ResourceOptions): Resource<O> {
+  if (process.env.NODE_ENV !== 'production') {
+    // if they lowercase and it looks like they meant to use upper-case version
+    if (
+      'endpoint' in extraOptions &&
+      Endpoint === RestEndpoint &&
+      typeof extraOptions['endpoint'] === 'function' &&
+      extraOptions['endpoint'] &&
+      Object.prototype.isPrototypeOf.call(
+        RestEndpoint.prototype,
+        (extraOptions['endpoint'] as any).prototype,
+      )
+    ) {
+      console.warn(
+        `You passed 'endpoint' option; did you mean to use Endpoint?
+https://dataclient.io/rest/api/createResource#endpoint
+This parameter must be capitalized.
+
+This warning will not show in production.`,
+      );
+    }
+    // if they lowercase and it looks like they meant to use upper-case version
+    if (
+      'collection' in extraOptions &&
+      Collection === BaseCollection &&
+      typeof extraOptions['collection'] === 'function' &&
+      extraOptions['collection'] &&
+      Object.prototype.isPrototypeOf.call(
+        BaseCollection.prototype,
+        (extraOptions['collection'] as any).prototype,
+      )
+    ) {
+      console.warn(
+        `You passed 'collection' option; did you mean to use Collection?
+https://dataclient.io/rest/api/createResource#collection
+This parameter must be capitalized.
+
+This warning will not show in production.`,
+      );
+    }
+  }
   const shortenedPath = shortenPath(path);
   const getName = (name: string) => `${(schema as any)?.name}.${name}`;
   // this accounts for derivative endpoints


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Report of bug on discord server. Code was the following, which had `endpoint` parameters uncapitalized.

```ts
export const UserResource = createResource({
  urlPrefix: CONFIG.API_ROOT,
  path: '/users/:id',
  schema: User,
  endpoint: AuthedEndpoint,
});
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add warning

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Should we just take lower cased versions as well? Do people actually need the lower cased for their class?