### PR TITLE
enhance: Improve argmatch typing

### DIFF
--- a/.changeset/famous-moose-hammer.md
+++ b/.changeset/famous-moose-hammer.md
@@ -1,0 +1,6 @@
+---
+"@data-client/react": patch
+"@data-client/core": patch
+---
+
+Improve [controller](https://dataclient.io/docs/api/Controller) type matching for its methods

--- a/.changeset/healthy-suns-love.md
+++ b/.changeset/healthy-suns-love.md
@@ -1,0 +1,5 @@
+---
+"@data-client/react": patch
+---
+
+Improve [useFetch()](https://dataclient.io/docs/api/useFetch) argtype matching similar to [useSuspense()](https://dataclient.io/docs/api/useSuspense)

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -56,8 +56,8 @@ export type SetAction<E extends EndpointAndUpdate<E> = EndpointDefault> =
   | SetActionError<E>;
 
 /* FETCH */
-export interface FetchMeta {
-  args: readonly any[];
+export interface FetchMeta<A extends readonly any[] = readonly any[]> {
+  args: A;
   key: string;
   throttle: boolean;
   resolve: (value?: any | PromiseLike<any>) => void;
@@ -71,7 +71,7 @@ export interface FetchMeta {
 export interface FetchAction<E extends EndpointAndUpdate<E> = EndpointDefault> {
   type: typeof FETCH_TYPE;
   endpoint: E;
-  meta: FetchMeta;
+  meta: FetchMeta<Parameters<E>>;
   payload: () => ReturnType<E>;
 }
 

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -71,7 +71,7 @@ export interface FetchMeta<A extends readonly any[] = readonly any[]> {
 export interface FetchAction<E extends EndpointAndUpdate<E> = EndpointDefault> {
   type: typeof FETCH_TYPE;
   endpoint: E;
-  meta: FetchMeta<Parameters<E>>;
+  meta: FetchMeta<readonly [...Parameters<E>]>;
   payload: () => ReturnType<E>;
 }
 

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -107,7 +107,7 @@ export default class Controller<
     E extends EndpointInterface & { update?: EndpointUpdateFunction<E> },
   >(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E>>]
+    ...args: readonly [...Parameters<E>]
   ): E['schema'] extends undefined | null ? ReturnType<E>
   : Promise<Denormalize<E['schema']>> => {
     const action = createFetch(endpoint, {
@@ -131,7 +131,7 @@ export default class Controller<
     E extends EndpointInterface & { update?: EndpointUpdateFunction<E> },
   >(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E>>]
+    ...args: readonly [...Parameters<E>]
   ): E['schema'] extends undefined | null ? ReturnType<E> | ResolveType<E>
   : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']> => {
     const { data, expiresAt, expiryStatus } = this.getResponse(
@@ -150,7 +150,7 @@ export default class Controller<
    */
   invalidate = <E extends EndpointInterface>(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+    ...args: readonly [...Parameters<E>] | readonly [null]
   ): Promise<void> =>
     args[0] !== null ?
       this.dispatch(
@@ -192,7 +192,7 @@ export default class Controller<
     },
   >(
     endpoint: E,
-    ...rest: readonly [...NI<Parameters<E>>, any]
+    ...rest: readonly [...Parameters<E>, any]
   ): Promise<void> => {
     const response: ResolveType<E> = rest[rest.length - 1];
     const action = createSet(endpoint, {
@@ -212,7 +212,7 @@ export default class Controller<
     },
   >(
     endpoint: E,
-    ...rest: readonly [...NI<Parameters<E>>, Error]
+    ...rest: readonly [...Parameters<E>, Error]
   ): Promise<void> => {
     const response: Error = rest[rest.length - 1];
     const action = createSet(endpoint, {
@@ -235,13 +235,13 @@ export default class Controller<
     endpoint: E,
     meta:
       | {
-          args: readonly [...NI<Parameters<E>>];
+          args: readonly [...Parameters<E>];
           response: Error;
           fetchedAt: number;
           error: true;
         }
       | {
-          args: readonly [...NI<Parameters<E>>];
+          args: readonly [...Parameters<E>];
           response: any;
           fetchedAt: number;
           error?: false | undefined;
@@ -586,7 +586,7 @@ class Snapshot<T = unknown> implements SnapshotInterface {
 
   getResponse<E extends EndpointInterface>(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E>>]
+    ...args: readonly [...Parameters<E>]
   ): {
     data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
@@ -597,7 +597,7 @@ class Snapshot<T = unknown> implements SnapshotInterface {
     E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
   >(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
+    ...args: readonly [...Parameters<E['key']>] | readonly [null]
   ): {
     data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
@@ -608,7 +608,7 @@ class Snapshot<T = unknown> implements SnapshotInterface {
     E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
   >(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
+    ...args: readonly [...Parameters<E['key']>] | readonly [null]
   ): {
     data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
@@ -620,17 +620,17 @@ class Snapshot<T = unknown> implements SnapshotInterface {
   /** @see https://dataclient.io/docs/api/Snapshot#getError */
   getError<E extends EndpointInterface>(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+    ...args: readonly [...Parameters<E>] | readonly [null]
   ): ErrorTypes | undefined;
 
   getError<E extends Pick<EndpointInterface, 'key'>>(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
+    ...args: readonly [...Parameters<E['key']>] | readonly [null]
   ): ErrorTypes | undefined;
 
   getError<E extends Pick<EndpointInterface, 'key'>>(
     endpoint: E,
-    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
+    ...args: readonly [...Parameters<E['key']>] | readonly [null]
   ): ErrorTypes | undefined {
     return this.controller.getError(endpoint, ...args, this.state);
   }

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -107,7 +107,7 @@ export default class Controller<
     E extends EndpointInterface & { update?: EndpointUpdateFunction<E> },
   >(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>>]
+    ...args: readonly [...NI<Parameters<E>>]
   ): E['schema'] extends undefined | null ? ReturnType<E>
   : Promise<Denormalize<E['schema']>> => {
     const action = createFetch(endpoint, {
@@ -131,7 +131,7 @@ export default class Controller<
     E extends EndpointInterface & { update?: EndpointUpdateFunction<E> },
   >(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>>]
+    ...args: readonly [...NI<Parameters<E>>]
   ): E['schema'] extends undefined | null ? ReturnType<E> | ResolveType<E>
   : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']> => {
     const { data, expiresAt, expiryStatus } = this.getResponse(
@@ -150,12 +150,12 @@ export default class Controller<
    */
   invalidate = <E extends EndpointInterface>(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+    ...args: readonly [...NI<Parameters<E>>] | readonly [null]
   ): Promise<void> =>
     args[0] !== null ?
       this.dispatch(
         createInvalidate(endpoint, {
-          args: args as readonly [...Parameters<E>],
+          args: args as Parameters<E>,
         }),
       )
     : Promise.resolve();
@@ -192,7 +192,7 @@ export default class Controller<
     },
   >(
     endpoint: E,
-    ...rest: readonly [...Parameters<NI<E>>, any]
+    ...rest: readonly [...NI<Parameters<E>>, any]
   ): Promise<void> => {
     const response: ResolveType<E> = rest[rest.length - 1];
     const action = createSet(endpoint, {
@@ -212,7 +212,7 @@ export default class Controller<
     },
   >(
     endpoint: E,
-    ...rest: readonly [...Parameters<NI<E>>, Error]
+    ...rest: readonly [...NI<Parameters<E>>, Error]
   ): Promise<void> => {
     const response: Error = rest[rest.length - 1];
     const action = createSet(endpoint, {
@@ -235,13 +235,13 @@ export default class Controller<
     endpoint: E,
     meta:
       | {
-          args: readonly [...Parameters<NI<E>>];
+          args: readonly [...NI<Parameters<E>>];
           response: Error;
           fetchedAt: number;
           error: true;
         }
       | {
-          args: readonly [...Parameters<NI<E>>];
+          args: readonly [...NI<Parameters<E>>];
           response: any;
           fetchedAt: number;
           error?: false | undefined;
@@ -579,14 +579,14 @@ class Snapshot<T = unknown> implements SnapshotInterface {
     endpoint: E,
     ...args: readonly [null]
   ): {
-    data: DenormalizeNullable<NI<E>['schema']>;
+    data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
     expiresAt: number;
   };
 
   getResponse<E extends EndpointInterface>(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>>]
+    ...args: readonly [...NI<Parameters<E>>]
   ): {
     data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
@@ -597,7 +597,7 @@ class Snapshot<T = unknown> implements SnapshotInterface {
     E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
   >(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
+    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
   ): {
     data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
@@ -608,7 +608,7 @@ class Snapshot<T = unknown> implements SnapshotInterface {
     E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
   >(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
+    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
   ): {
     data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
@@ -620,17 +620,17 @@ class Snapshot<T = unknown> implements SnapshotInterface {
   /** @see https://dataclient.io/docs/api/Snapshot#getError */
   getError<E extends EndpointInterface>(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+    ...args: readonly [...NI<Parameters<E>>] | readonly [null]
   ): ErrorTypes | undefined;
 
   getError<E extends Pick<EndpointInterface, 'key'>>(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
+    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
   ): ErrorTypes | undefined;
 
   getError<E extends Pick<EndpointInterface, 'key'>>(
     endpoint: E,
-    ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
+    ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
   ): ErrorTypes | undefined {
     return this.controller.getError(endpoint, ...args, this.state);
   }

--- a/packages/core/src/controller/createFetch.ts
+++ b/packages/core/src/controller/createFetch.ts
@@ -1,4 +1,4 @@
-import type { EndpointInterface } from '@data-client/normalizr';
+import type { EndpointInterface, NI } from '@data-client/normalizr';
 
 import { EndpointUpdateFunction } from './types.js';
 import { FETCH_TYPE } from '../actionTypes.js';
@@ -19,7 +19,7 @@ export default function createFetch<
   const promise = new Promise<any>((a, b) => {
     [resolve, reject] = [a, b];
   });
-  const meta: FetchMeta = {
+  const meta: FetchMeta<any> = {
     args,
     key,
     throttle: !endpoint.sideEffect,

--- a/packages/core/src/controller/createFetch.ts
+++ b/packages/core/src/controller/createFetch.ts
@@ -19,7 +19,7 @@ export default function createFetch<
   const promise = new Promise<any>((a, b) => {
     [resolve, reject] = [a, b];
   });
-  const meta: FetchMeta<any> = {
+  const meta: FetchMeta<typeof args> = {
     args,
     key,
     throttle: !endpoint.sideEffect,

--- a/packages/core/src/manager/NetworkManager.ts
+++ b/packages/core/src/manager/NetworkManager.ts
@@ -71,7 +71,7 @@ export default class NetworkManager implements Manager {
                   if (error) {
                     this.handleSet(
                       createSet(action.endpoint, {
-                        args: action.meta.args as any,
+                        args: action.meta.args,
                         response: error,
                         fetchedAt: action.meta.fetchedAt,
                         error: true,
@@ -192,7 +192,7 @@ export default class NetworkManager implements Manager {
           // don't update state with promises started before last clear
           if (createdAt >= lastReset) {
             this.controller.resolve(action.endpoint, {
-              args: action.meta.args as any,
+              args: action.meta.args,
               response: data,
               fetchedAt: createdAt,
             });
@@ -204,7 +204,7 @@ export default class NetworkManager implements Manager {
           // don't update state with promises started before last clear
           if (createdAt >= lastReset) {
             this.controller.resolve(action.endpoint, {
-              args: action.meta.args as any,
+              args: action.meta.args,
               response: error,
               fetchedAt: createdAt,
               error: true,

--- a/packages/core/src/manager/__tests__/networkManager.ts
+++ b/packages/core/src/manager/__tests__/networkManager.ts
@@ -54,6 +54,7 @@ describe('NetworkManager', () => {
       (v: { id: number }) => Promise.resolve({ id: 5, title: 'hi' }),
       {
         schema: Article,
+        name: 'detailEndpoint',
       },
     );
     const fetchResolveAction = createFetch(detailEndpoint, {

--- a/packages/core/src/manager/__tests__/pollingSubscription.ts
+++ b/packages/core/src/manager/__tests__/pollingSubscription.ts
@@ -288,7 +288,9 @@ describe('PollingSubscription', () => {
       afterEach(() => {
         warnSpy.mockRestore();
       });
-      beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
+      beforeEach(() =>
+        (warnSpy = jest.spyOn(console, 'warn')).mockImplementation(() => {}),
+      );
 
       it('should stop all timers', () => {
         dispatch.mockClear();

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -54,7 +54,9 @@ describe(`${schema.Collection.name} normalization`, () => {
   afterEach(() => {
     warnSpy.mockRestore();
   });
-  beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
+  beforeEach(() =>
+    (warnSpy = jest.spyOn(console, 'warn')).mockImplementation(() => {}),
+  );
 
   test('should throw a custom error if data loads with string unexpected value', () => {
     function normalizeBad() {

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -60,7 +60,9 @@ describe(`${Entity.name} normalization`, () => {
   afterEach(() => {
     warnSpy.mockRestore();
   });
-  beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
+  beforeEach(() =>
+    (warnSpy = jest.spyOn(console, 'warn')).mockImplementation(() => {}),
+  );
 
   test('normalizes an entity', () => {
     class MyEntity extends IDEntity {}

--- a/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
@@ -300,7 +300,9 @@ describe(`${schema.Entity.name} normalization`, () => {
   afterEach(() => {
     warnSpy.mockRestore();
   });
-  beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
+  beforeEach(() =>
+    (warnSpy = jest.spyOn(console, 'warn')).mockImplementation(() => {}),
+  );
 
   test('normalizes an entity', () => {
     class MyEntity extends schema.Entity(IDData) {}

--- a/packages/endpoint/src/schemas/__tests__/Union.test.js
+++ b/packages/endpoint/src/schemas/__tests__/Union.test.js
@@ -17,6 +17,13 @@ beforeAll(() => {
 afterAll(() => {
   dateSpy.mockRestore();
 });
+let warnSpy;
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+beforeEach(() =>
+  (warnSpy = jest.spyOn(console, 'warn')).mockImplementation(() => {}),
+);
 
 describe(`${schema.Union.name} normalization`, () => {
   test('throws if not given a schemaAttribute', () => {
@@ -60,6 +67,7 @@ describe(`${schema.Union.name} normalization`, () => {
       normalize({ id: '2', groupname: 'People' }, union),
     ).toMatchSnapshot();
     expect(normalize({ id: '3', notdefined: 'yep' }, union)).toMatchSnapshot();
+    expect(warnSpy.mock.calls).toMatchSnapshot();
   });
 });
 
@@ -335,6 +343,7 @@ describe.each([
         expect(
           denormalize(createInput({ id: '1' }), union, createInput(entities)),
         ).toMatchSnapshot();
+        expect(warnSpy.mock.calls).toMatchSnapshot();
       });
 
       test('returns the original value when string is given', () => {
@@ -351,6 +360,7 @@ describe.each([
         expect(
           denormalize('1', union, createInput(entities)),
         ).toMatchSnapshot();
+        expect(warnSpy.mock.calls).toMatchSnapshot();
       });
 
       test('returns the original value when null is given', () => {

--- a/packages/endpoint/src/schemas/__tests__/Values.test.js
+++ b/packages/endpoint/src/schemas/__tests__/Values.test.js
@@ -27,6 +27,14 @@ class Dog extends IDEntity {
 }
 
 describe(`${schema.Values.name} normalization`, () => {
+  let warnSpy;
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+  beforeEach(() =>
+    (warnSpy = jest.spyOn(console, 'warn')).mockImplementation(() => {}),
+  );
+
   test('normalizes without schemaAttribute', () => {
     class MyEntity extends IDEntity {
       name = '';
@@ -89,6 +97,7 @@ describe(`${schema.Values.name} normalization`, () => {
         valuesSchema,
       ),
     ).toMatchSnapshot();
+    expect(warnSpy.mock.calls).toMatchSnapshot();
   });
 
   test('filters out null and undefined values', () => {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -66,6 +66,20 @@ exports[`UnionSchema normalization normalizes an array of multiple entities usin
 }
 `;
 
+exports[`UnionSchema normalization normalizes an array of multiple entities using a function to infer the schemaAttribute 4`] = `
+[
+  [
+    "Schema attribute null is not expected.
+Expected one of: "users", "groups"
+
+Value: {
+  "id": "3",
+  "notdefined": "yep"
+}",
+  ],
+]
+`;
+
 exports[`UnionSchema normalization normalizes an object using string schemaAttribute 1`] = `
 {
   "entities": {
@@ -529,7 +543,27 @@ exports[`input (direct) UnionSchema denormalization (current) returns the origin
 }
 `;
 
+exports[`input (direct) UnionSchema denormalization (current) returns the original value when no schema is given 2`] = `
+[
+  [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: {
+  "id": "1"
+}.",
+  ],
+]
+`;
+
 exports[`input (direct) UnionSchema denormalization (current) returns the original value when string is given 1`] = `"1"`;
+
+exports[`input (direct) UnionSchema denormalization (current) returns the original value when string is given 2`] = `
+[
+  [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: "1".",
+  ],
+]
+`;
 
 exports[`input (immutable) UnionSchema denormalization (current) denormalizes an array of multiple entities using a function to infer the schemaAttribute 1`] = `
 User {
@@ -569,4 +603,24 @@ Immutable.Map {
 }
 `;
 
+exports[`input (immutable) UnionSchema denormalization (current) returns the original value when no schema is given 2`] = `
+[
+  [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: {
+  "id": "1"
+}.",
+  ],
+]
+`;
+
 exports[`input (immutable) UnionSchema denormalization (current) returns the original value when string is given 1`] = `"1"`;
+
+exports[`input (immutable) UnionSchema denormalization (current) returns the original value when string is given 2`] = `
+[
+  [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: "1".",
+  ],
+]
+`;

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -50,6 +50,20 @@ exports[`ValuesSchema normalization can use a function to determine the schema w
 }
 `;
 
+exports[`ValuesSchema normalization can use a function to determine the schema when normalizing 2`] = `
+[
+  [
+    "Schema attribute "lizards" is not expected.
+Expected one of: "dogs", "cats"
+
+Value: {
+  "id": "2",
+  "type": "lizard"
+}",
+  ],
+]
+`;
+
 exports[`ValuesSchema normalization filters out null and undefined values 1`] = `
 {
   "entities": {

--- a/packages/react/src/__tests__/endpoint-types.web.tsx
+++ b/packages/react/src/__tests__/endpoint-types.web.tsx
@@ -135,14 +135,26 @@ describe('endpoint types', () => {
     });
 
     it('types should strictly enforce with body that are any', async () => {
-      const { result } = renderDataClient(() => {
+      const { result, controller } = renderDataClient(() => {
         return useController().fetch;
       });
+      () => TypedArticleResource.anybody({ id: payload.id }, { title: 'hi' });
+      () =>
+        controller.fetch(
+          TypedArticleResource.anybody,
+          { id: payload.id },
+          {
+            title: 'hi',
+          },
+        );
+
       () =>
         result.current(
           TypedArticleResource.anybody,
           { id: payload.id },
-          { title: 'hi' },
+          {
+            title: 'hi',
+          },
         );
       // @ts-expect-error
       () => result.current(TypedArticleResource.anybody(), { id: payload.id });

--- a/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
@@ -595,8 +595,7 @@ describe.each([
       const params = { id: payload.id };
       const { result, controller } = renderDataClient(
         () => {
-          const article = useCache(OptimisticArticleResource.get, params);
-          return article;
+          return useCache(OptimisticArticleResource.get, params);
         },
         {
           initialFixtures: [
@@ -638,7 +637,9 @@ describe.each([
           content: 'firstoptimistic',
         }),
       );
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
 
       // second optimistic
       act(() => {
@@ -665,7 +666,9 @@ describe.each([
           content: 'firstoptimistic',
         }),
       );
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
 
       // third optimistic
       act(() => {

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -26,7 +26,7 @@ export default function useCache<
   >,
 >(
   endpoint: E,
-  ...args: NI<readonly [...Parameters<E['key']>] | readonly [null]>
+  ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
 ): E['schema'] extends undefined | null ?
   E extends (...args: any) => any ?
     ResolveType<E> | undefined
@@ -41,12 +41,7 @@ export default function useCache<
 
   // Compute denormalized value
   const { data, expiryStatus, expiresAt } = useMemo(() => {
-    // @ts-ignore
-    return controller.getResponse(endpoint, ...args, state) as {
-      data: DenormalizeNullable<E['schema']>;
-      expiryStatus: ExpiryStatus;
-      expiresAt: number;
-    };
+    return controller.getResponse(endpoint, ...args, state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     cacheResults,
@@ -76,7 +71,6 @@ export default function useCache<
     // if useSuspense() would suspend, don't include entities from cache
     if (wouldSuspend) {
       if (!endpoint.schema) return undefined;
-      // @ts-ignore
       return controller.getResponse(endpoint, ...args, {
         ...state,
         entities: {},

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -26,7 +26,7 @@ export default function useCache<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
 ): E['schema'] extends undefined | null ?
   E extends (...args: any) => any ?
     ResolveType<E> | undefined

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -26,7 +26,7 @@ export default function useCache<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
+  ...args: readonly [...Parameters<E['key']>] | readonly [null]
 ): E['schema'] extends undefined | null ?
   E extends (...args: any) => any ?
     ResolveType<E> | undefined

--- a/packages/react/src/hooks/useDLE.native.ts
+++ b/packages/react/src/hooks/useDLE.native.ts
@@ -47,7 +47,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>]
+  ...args: readonly [...NI<Parameters<E>>]
 ): E['schema'] extends undefined | null ? AsyncReturn<E>
 : SchemaReturn<E['schema']>;
 
@@ -59,7 +59,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): {
   data: E['schema'] extends undefined | null ? undefined
   : DenormalizeNullable<E['schema']>;

--- a/packages/react/src/hooks/useDLE.native.ts
+++ b/packages/react/src/hooks/useDLE.native.ts
@@ -47,7 +47,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>]
+  ...args: readonly [...Parameters<E>]
 ): E['schema'] extends undefined | null ? AsyncReturn<E>
 : SchemaReturn<E['schema']>;
 
@@ -59,7 +59,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): {
   data: E['schema'] extends undefined | null ? undefined
   : DenormalizeNullable<E['schema']>;

--- a/packages/react/src/hooks/useDLE.ts
+++ b/packages/react/src/hooks/useDLE.ts
@@ -45,7 +45,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>]
+  ...args: readonly [...NI<Parameters<E>>]
 ): E['schema'] extends undefined | null ? AsyncReturn<E>
 : SchemaReturn<E['schema']>;
 
@@ -57,7 +57,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): {
   data: E['schema'] extends undefined | null ? undefined
   : DenormalizeNullable<E['schema']>;

--- a/packages/react/src/hooks/useDLE.ts
+++ b/packages/react/src/hooks/useDLE.ts
@@ -81,12 +81,7 @@ export default function useDLE<
   // Compute denormalized value
   // eslint-disable-next-line prefer-const
   let { data, expiryStatus, expiresAt } = useMemo(() => {
-    // @ts-ignore
-    return controller.getResponse(endpoint, ...args, state) as {
-      data: DenormalizeNullable<E['schema']> | undefined;
-      expiryStatus: ExpiryStatus;
-      expiresAt: number;
-    };
+    return controller.getResponse(endpoint, ...args, state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     cacheResults,
@@ -97,7 +92,6 @@ export default function useDLE<
     key,
   ]);
 
-  // @ts-ignore
   const error = controller.getError(endpoint, ...args, state);
 
   // If we are hard invalid we must fetch regardless of triggering or staleness
@@ -119,7 +113,6 @@ export default function useDLE<
     // if useSuspense() would suspend, don't include entities from cache
     if (loading) {
       if (!endpoint.schema) return undefined;
-      // @ts-ignore
       return controller.getResponse(endpoint, ...args, {
         ...state,
         entities: {},
@@ -134,5 +127,5 @@ export default function useDLE<
     data,
     loading,
     error,
-  } as any;
+  };
 }

--- a/packages/react/src/hooks/useDLE.ts
+++ b/packages/react/src/hooks/useDLE.ts
@@ -45,7 +45,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>]
+  ...args: readonly [...Parameters<E>]
 ): E['schema'] extends undefined | null ? AsyncReturn<E>
 : SchemaReturn<E['schema']>;
 
@@ -57,7 +57,7 @@ export default function useDLE<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): {
   data: E['schema'] extends undefined | null ? undefined
   : DenormalizeNullable<E['schema']>;

--- a/packages/react/src/hooks/useError.ts
+++ b/packages/react/src/hooks/useError.ts
@@ -13,7 +13,7 @@ export type ErrorTypes = NetworkError | UnknownError;
  */
 export default function useError<E extends Pick<EndpointInterface, 'key'>>(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
+  ...args: readonly [...Parameters<E['key']>] | readonly [null]
 ): ErrorTypes | undefined {
   const state = useCacheState();
 

--- a/packages/react/src/hooks/useError.ts
+++ b/packages/react/src/hooks/useError.ts
@@ -13,7 +13,7 @@ export type ErrorTypes = NetworkError | UnknownError;
  */
 export default function useError<E extends Pick<EndpointInterface, 'key'>>(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E['key']>>] | readonly [null]
 ): ErrorTypes | undefined {
   const state = useCacheState();
 

--- a/packages/react/src/hooks/useError.ts
+++ b/packages/react/src/hooks/useError.ts
@@ -13,11 +13,11 @@ export type ErrorTypes = NetworkError | UnknownError;
  */
 export default function useError<E extends Pick<EndpointInterface, 'key'>>(
   endpoint: E,
-  ...args: NI<readonly [...Parameters<E['key']>] | readonly [null]>
+  ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]
 ): ErrorTypes | undefined {
   const state = useCacheState();
 
   const controller = useController();
 
-  return controller.getError(endpoint, ...args, state) as any;
+  return controller.getError(endpoint, ...args, state);
 }

--- a/packages/react/src/hooks/useFetch.native.ts
+++ b/packages/react/src/hooks/useFetch.native.ts
@@ -25,7 +25,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>]
+  ...args: readonly [...NI<Parameters<E>>]
 ): E['schema'] extends undefined | null ? ReturnType<E>
 : Promise<Denormalize<E['schema']>>;
 
@@ -37,7 +37,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): E['schema'] extends undefined | null ? ReturnType<E> | undefined
 : Promise<DenormalizeNullable<E['schema']>>;
 
@@ -49,7 +49,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): Promise<any> | undefined {
   const state = useCacheState();
   const controller = useController();

--- a/packages/react/src/hooks/useFetch.native.ts
+++ b/packages/react/src/hooks/useFetch.native.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { ExpiryStatus } from '@data-client/core';
+import { DenormalizeNullable, ExpiryStatus, NI } from '@data-client/core';
 import {
   EndpointInterface,
   Denormalize,
@@ -23,8 +23,34 @@ export default function useFetch<
     Schema | undefined,
     undefined | false
   >,
-  Args extends readonly [...Parameters<E>] | readonly [null],
->(endpoint: E, ...args: Args) {
+>(
+  endpoint: E,
+  ...args: readonly [...Parameters<NI<E>>]
+): E['schema'] extends undefined | null ? ReturnType<E>
+: Promise<Denormalize<E['schema']>>;
+
+export default function useFetch<
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
+>(
+  endpoint: E,
+  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+): E['schema'] extends undefined | null ? ReturnType<E> | undefined
+: Promise<DenormalizeNullable<E['schema']>>;
+
+export default function useFetch<
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
+>(
+  endpoint: E,
+  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+): Promise<any> | undefined {
   const state = useCacheState();
   const controller = useController();
 
@@ -34,7 +60,6 @@ export default function useFetch<
 
   // Compute denormalized value
   const { expiryStatus, expiresAt } = useMemo(() => {
-    // @ts-ignore
     return controller.getResponse(endpoint, ...args, state) as {
       data: Denormalize<E['schema']>;
       expiryStatus: ExpiryStatus;
@@ -56,8 +81,8 @@ export default function useFetch<
   const maybePromise = useMemo(() => {
     // null params mean don't do anything
     if ((Date.now() <= expiresAt && !forceFetch) || !key) return;
-    // @ts-ignore
-    return controller.fetch(endpoint, ...args);
+    // if args is [null], we won't get to this line
+    return controller.fetch(endpoint, ...(args as [...Parameters<E>]));
     // we need to check against serialized params, since params can change frequently
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expiresAt, controller, key, forceFetch, state.lastReset]);

--- a/packages/react/src/hooks/useFetch.native.ts
+++ b/packages/react/src/hooks/useFetch.native.ts
@@ -25,7 +25,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>]
+  ...args: readonly [...Parameters<E>]
 ): E['schema'] extends undefined | null ? ReturnType<E>
 : Promise<Denormalize<E['schema']>>;
 
@@ -37,7 +37,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): E['schema'] extends undefined | null ? ReturnType<E> | undefined
 : Promise<DenormalizeNullable<E['schema']>>;
 
@@ -49,7 +49,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): Promise<any> | undefined {
   const state = useCacheState();
   const controller = useController();

--- a/packages/react/src/hooks/useFetch.ts
+++ b/packages/react/src/hooks/useFetch.ts
@@ -23,7 +23,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>]
+  ...args: readonly [...Parameters<E>]
 ): E['schema'] extends undefined | null ? ReturnType<E>
 : Promise<Denormalize<E['schema']>>;
 
@@ -35,7 +35,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): E['schema'] extends undefined | null ? ReturnType<E> | undefined
 : Promise<DenormalizeNullable<E['schema']>>;
 
@@ -47,7 +47,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): Promise<any> | undefined {
   const state = useCacheState();
   const controller = useController();

--- a/packages/react/src/hooks/useFetch.ts
+++ b/packages/react/src/hooks/useFetch.ts
@@ -23,7 +23,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>]
+  ...args: readonly [...NI<Parameters<E>>]
 ): E['schema'] extends undefined | null ? ReturnType<E>
 : Promise<Denormalize<E['schema']>>;
 
@@ -35,7 +35,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): E['schema'] extends undefined | null ? ReturnType<E> | undefined
 : Promise<DenormalizeNullable<E['schema']>>;
 
@@ -47,7 +47,7 @@ export default function useFetch<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): Promise<any> | undefined {
   const state = useCacheState();
   const controller = useController();

--- a/packages/react/src/hooks/useLive.ts
+++ b/packages/react/src/hooks/useLive.ts
@@ -28,7 +28,7 @@ export default function useLive<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>]
+  ...args: readonly [...Parameters<E>]
 ): E['schema'] extends undefined | null ? ResolveType<E>
 : Denormalize<E['schema']>;
 
@@ -40,7 +40,7 @@ export default function useLive<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): E['schema'] extends undefined | null ? ResolveType<E> | undefined
 : DenormalizeNullable<E['schema']>;
 

--- a/packages/react/src/hooks/useLive.ts
+++ b/packages/react/src/hooks/useLive.ts
@@ -28,7 +28,7 @@ export default function useLive<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>]
+  ...args: readonly [...NI<Parameters<E>>]
 ): E['schema'] extends undefined | null ? ResolveType<E>
 : Denormalize<E['schema']>;
 
@@ -40,7 +40,7 @@ export default function useLive<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): E['schema'] extends undefined | null ? ResolveType<E> | undefined
 : DenormalizeNullable<E['schema']>;
 

--- a/packages/react/src/hooks/useSubscription.native.tsx
+++ b/packages/react/src/hooks/useSubscription.native.tsx
@@ -18,7 +18,7 @@ export default function useSubscription<
     Schema | undefined,
     undefined | false
   >,
->(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]) {
+>(endpoint: E, ...args: readonly [...NI<Parameters<E>>] | readonly [null]) {
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';

--- a/packages/react/src/hooks/useSubscription.native.tsx
+++ b/packages/react/src/hooks/useSubscription.native.tsx
@@ -1,4 +1,9 @@
-import { EndpointInterface, Schema, FetchFunction } from '@data-client/core';
+import {
+  EndpointInterface,
+  Schema,
+  FetchFunction,
+  NI,
+} from '@data-client/core';
 
 import useController from './useController.js';
 import useFocusEffect from './useFocusEffect.native.js';
@@ -13,8 +18,7 @@ export default function useSubscription<
     Schema | undefined,
     undefined | false
   >,
-  Args extends readonly [...Parameters<E>] | readonly [null],
->(endpoint: E, ...args: Args) {
+>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]) {
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';

--- a/packages/react/src/hooks/useSubscription.native.tsx
+++ b/packages/react/src/hooks/useSubscription.native.tsx
@@ -18,7 +18,7 @@ export default function useSubscription<
     Schema | undefined,
     undefined | false
   >,
->(endpoint: E, ...args: readonly [...NI<Parameters<E>>] | readonly [null]) {
+>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) {
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';

--- a/packages/react/src/hooks/useSubscription.tsx
+++ b/packages/react/src/hooks/useSubscription.tsx
@@ -18,7 +18,7 @@ export default function useSubscription<
     Schema | undefined,
     undefined | false
   >,
->(endpoint: E, ...args: NI<readonly [...Parameters<E>] | readonly [null]>) {
+>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]) {
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';

--- a/packages/react/src/hooks/useSubscription.tsx
+++ b/packages/react/src/hooks/useSubscription.tsx
@@ -18,7 +18,7 @@ export default function useSubscription<
     Schema | undefined,
     undefined | false
   >,
->(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]) {
+>(endpoint: E, ...args: readonly [...NI<Parameters<E>>] | readonly [null]) {
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';

--- a/packages/react/src/hooks/useSubscription.tsx
+++ b/packages/react/src/hooks/useSubscription.tsx
@@ -18,7 +18,7 @@ export default function useSubscription<
     Schema | undefined,
     undefined | false
   >,
->(endpoint: E, ...args: readonly [...NI<Parameters<E>>] | readonly [null]) {
+>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) {
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';

--- a/packages/react/src/hooks/useSuspense.native.ts
+++ b/packages/react/src/hooks/useSuspense.native.ts
@@ -5,11 +5,13 @@ import type {
   Denormalize,
   Schema,
   FetchFunction,
+  DenormalizeNullable,
+  ResolveType,
+  NI,
 } from '@data-client/core';
 import { useMemo } from 'react';
 import { InteractionManager } from 'react-native';
 
-import { SuspenseReturn } from './types.js';
 import useCacheState from './useCacheState.js';
 import useController from './useController.js';
 import useFocusEffect from './useFocusEffect.native.js';
@@ -29,8 +31,31 @@ export default function useSuspense<
     Schema | undefined,
     undefined | false
   >,
-  Args extends readonly [...Parameters<E>] | readonly [null],
->(endpoint: E, ...args: Args): SuspenseReturn<E, Args> {
+>(
+  endpoint: E,
+  ...args: readonly [...Parameters<NI<E>>]
+): E['schema'] extends undefined | null ? ResolveType<E>
+: Denormalize<E['schema']>;
+
+export default function useSuspense<
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
+>(
+  endpoint: E,
+  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+): E['schema'] extends undefined | null ? ResolveType<E> | undefined
+: DenormalizeNullable<E['schema']>;
+
+export default function useSuspense<
+  E extends EndpointInterface<
+    FetchFunction,
+    Schema | undefined,
+    undefined | false
+  >,
+>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): any {
   const state = useCacheState();
   const controller = useController();
 
@@ -40,12 +65,7 @@ export default function useSuspense<
 
   // Compute denormalized value
   const { data, expiryStatus, expiresAt } = useMemo(() => {
-    // @ts-ignore
-    return controller.getResponse(endpoint, ...args, state) as {
-      data: Denormalize<E['schema']>;
-      expiryStatus: ExpiryStatus;
-      expiresAt: number;
-    };
+    return controller.getResponse(endpoint, ...args, state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     cacheResults,
@@ -56,7 +76,6 @@ export default function useSuspense<
     key,
   ]);
 
-  // @ts-ignore
   const error = controller.getError(endpoint, ...args, state);
 
   // If we are hard invalid we must fetch regardless of triggering or staleness
@@ -66,9 +85,12 @@ export default function useSuspense<
     // null params mean don't do anything
     if ((Date.now() <= expiresAt && !forceFetch) || !key) return;
 
-    return controller
-      .fetch(endpoint, ...(args as readonly [...Parameters<E>]))
-      .catch(() => {});
+    return (
+      controller
+        // if args is [null], we won't get to this line
+        .fetch(endpoint, ...(args as [...Parameters<E>]))
+        .catch(() => {})
+    );
     // we need to check against serialized params, since params can change frequently
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expiresAt, controller, key, forceFetch, state.lastReset]);
@@ -91,5 +113,5 @@ export default function useSuspense<
     return () => task.cancel();
   }, []);
 
-  return data as any;
+  return data;
 }

--- a/packages/react/src/hooks/useSuspense.native.ts
+++ b/packages/react/src/hooks/useSuspense.native.ts
@@ -33,7 +33,7 @@ export default function useSuspense<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>]
+  ...args: readonly [...Parameters<E>]
 ): E['schema'] extends undefined | null ? ResolveType<E>
 : Denormalize<E['schema']>;
 
@@ -45,7 +45,7 @@ export default function useSuspense<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): E['schema'] extends undefined | null ? ResolveType<E> | undefined
 : DenormalizeNullable<E['schema']>;
 

--- a/packages/react/src/hooks/useSuspense.native.ts
+++ b/packages/react/src/hooks/useSuspense.native.ts
@@ -33,7 +33,7 @@ export default function useSuspense<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>]
+  ...args: readonly [...NI<Parameters<E>>]
 ): E['schema'] extends undefined | null ? ResolveType<E>
 : Denormalize<E['schema']>;
 
@@ -45,7 +45,7 @@ export default function useSuspense<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...NI<Parameters<E>>] | readonly [null]
 ): E['schema'] extends undefined | null ? ResolveType<E> | undefined
 : DenormalizeNullable<E['schema']>;
 

--- a/packages/react/src/hooks/useSuspense.ts
+++ b/packages/react/src/hooks/useSuspense.ts
@@ -31,7 +31,7 @@ export default function useSuspense<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>]
+  ...args: readonly [...NI<Parameters<E>>]
 ): E['schema'] extends undefined | null ? ResolveType<E>
 : Denormalize<E['schema']>;
 

--- a/packages/react/src/hooks/useSuspense.ts
+++ b/packages/react/src/hooks/useSuspense.ts
@@ -31,7 +31,7 @@ export default function useSuspense<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...NI<Parameters<E>>]
+  ...args: readonly [...Parameters<E>]
 ): E['schema'] extends undefined | null ? ResolveType<E>
 : Denormalize<E['schema']>;
 
@@ -43,7 +43,7 @@ export default function useSuspense<
   >,
 >(
   endpoint: E,
-  ...args: readonly [...Parameters<NI<E>>] | readonly [null]
+  ...args: readonly [...Parameters<E>] | readonly [null]
 ): E['schema'] extends undefined | null ? ResolveType<E> | undefined
 : DenormalizeNullable<E['schema']>;
 

--- a/packages/react/src/hooks/useSuspense.ts
+++ b/packages/react/src/hooks/useSuspense.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import {
-  ExpiryStatus,
+import { ExpiryStatus } from '@data-client/core';
+import type {
   EndpointInterface,
   Denormalize,
   Schema,
@@ -12,7 +12,7 @@ import {
 import { useMemo } from 'react';
 
 import useCacheState from './useCacheState.js';
-import useController from '../hooks/useController.js';
+import useController from './useController.js';
 
 /**
  * Ensure an endpoint is available.
@@ -63,12 +63,7 @@ export default function useSuspense<
 
   // Compute denormalized value
   const { data, expiryStatus, expiresAt } = useMemo(() => {
-    // @ts-ignore
-    return controller.getResponse(endpoint, ...args, state) as {
-      data: Denormalize<E['schema']>;
-      expiryStatus: ExpiryStatus;
-      expiresAt: number;
-    };
+    return controller.getResponse(endpoint, ...args, state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     cacheResults,
@@ -79,7 +74,6 @@ export default function useSuspense<
     key,
   ]);
 
-  // @ts-ignore
   const error = controller.getError(endpoint, ...args, state);
 
   // If we are hard invalid we must fetch regardless of triggering or staleness
@@ -89,9 +83,12 @@ export default function useSuspense<
     // null params mean don't do anything
     if ((Date.now() <= expiresAt && !forceFetch) || !key) return;
 
-    return controller
-      .fetch(endpoint, ...(args as readonly [...Parameters<E>]))
-      .catch(() => {});
+    return (
+      controller
+        // if args is [null], we won't get to this line
+        .fetch(endpoint, ...(args as [...Parameters<E>]))
+        .catch(() => {})
+    );
     // we need to check against serialized params, since params can change frequently
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expiresAt, controller, key, forceFetch, state.lastReset]);
@@ -103,5 +100,5 @@ export default function useSuspense<
 
   if (error) throw error;
 
-  return data as any;
+  return data;
 }

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -459,19 +459,19 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
      */
     fetch: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<E>) => E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
+    }>(endpoint: E, ...args_0: Parameters<NoInfer<E>>) => E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
     /**
      * Fetches only if endpoint is considered 'stale'; otherwise returns undefined
      * @see https://dataclient.io/docs/api/Controller#fetchIfStale
      */
     fetchIfStale: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<E>) => E['schema'] extends undefined | null ? ReturnType<E> | ResolveType<E> : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']>;
+    }>(endpoint: E, ...args_0: Parameters<NoInfer<E>>) => E['schema'] extends undefined | null ? ReturnType<E> | ResolveType<E> : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']>;
     /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://dataclient.io/docs/api/Controller#invalidate
      */
-    invalidate: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) => Promise<void>;
+    invalidate: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]) => Promise<void>;
     /**
      * Forces refetching and suspense on useSuspense on all matching endpoint result keys.
      * @see https://dataclient.io/docs/api/Controller#invalidateAll
@@ -499,14 +499,14 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
      */
     setResponse: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...rest: readonly [...Parameters<E>, any]) => Promise<void>;
+    }>(endpoint: E, ...rest: readonly [...Parameters<NI<E>>, any]) => Promise<void>;
     /**
      * Stores the result of Endpoint and args as the error provided.
      * @see https://dataclient.io/docs/api/Controller#setError
      */
     setError: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...rest: readonly [...Parameters<E>, Error]) => Promise<void>;
+    }>(endpoint: E, ...rest: readonly [...Parameters<NI<E>>, Error]) => Promise<void>;
     /**
      * Resolves an inflight fetch. `fetchedAt` should `fetch`'s `createdAt`
      * @see https://dataclient.io/docs/api/Controller#resolve
@@ -514,12 +514,12 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
     resolve: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
     }>(endpoint: E, meta: {
-        args: readonly [...Parameters<E>];
+        args: readonly [...Parameters<NI<E>>];
         response: Error;
         fetchedAt: number;
         error: true;
     } | {
-        args: readonly [...Parameters<E>];
+        args: readonly [...Parameters<NI<E>>];
         response: any;
         fetchedAt: number;
         error?: false | undefined;
@@ -544,17 +544,13 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
      * Gets the error, if any, for a given endpoint. Returns undefined for no errors.
      * @see https://dataclient.io/docs/api/Controller#getError
      */
-    getError: <E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined>, "key">, Args extends readonly [null] | readonly [...Parameters<E["key"]>]>(endpoint: E, ...rest: [...Args, State<unknown>]) => ErrorTypes | undefined;
+    getError<E extends EndpointInterface>(endpoint: E, ...rest: readonly [null, State<unknown>] | readonly [...Parameters<E>, State<unknown>]): ErrorTypes | undefined;
+    getError<E extends Pick<EndpointInterface, 'key'>>(endpoint: E, ...rest: readonly [null, State<unknown>] | readonly [...Parameters<E['key']>, State<unknown>]): ErrorTypes | undefined;
     /**
      * Gets the (globally referentially stable) response for a given endpoint/args pair from state given.
      * @see https://dataclient.io/docs/api/Controller#getResponse
      */
-    getResponse<E extends EndpointInterface>(endpoint: E, ...rest: readonly [null, State<unknown>]): {
-        data: DenormalizeNullable<E['schema']>;
-        expiryStatus: ExpiryStatus;
-        expiresAt: number;
-    };
-    getResponse<E extends EndpointInterface>(endpoint: E, ...rest: readonly [...Parameters<E>, State<unknown>]): {
+    getResponse<E extends EndpointInterface>(endpoint: E, ...rest: readonly [null, State<unknown>] | readonly [...Parameters<E>, State<unknown>]): {
         data: DenormalizeNullable<E['schema']>;
         expiryStatus: ExpiryStatus;
         expiresAt: number;

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -305,8 +305,8 @@ interface SetActionError<E extends EndpointAndUpdate<E> = EndpointDefault> {
     error: true;
 }
 type SetAction<E extends EndpointAndUpdate<E> = EndpointDefault> = SetActionSuccess<E> | SetActionError<E>;
-interface FetchMeta {
-    args: readonly any[];
+interface FetchMeta<A extends readonly any[] = readonly any[]> {
+    args: A;
     key: string;
     throttle: boolean;
     resolve: (value?: any | PromiseLike<any>) => void;
@@ -318,7 +318,7 @@ interface FetchMeta {
 interface FetchAction<E extends EndpointAndUpdate<E> = EndpointDefault> {
     type: typeof FETCH_TYPE;
     endpoint: E;
-    meta: FetchMeta;
+    meta: FetchMeta<readonly [...Parameters<E>]>;
     payload: () => ReturnType<E>;
 }
 interface OptimisticAction<E extends EndpointAndUpdate<E> = EndpointDefault> {
@@ -459,19 +459,19 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
      */
     fetch: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<NoInfer<E>>) => E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
+    }>(endpoint: E, ...args_0: Parameters<E>) => E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
     /**
      * Fetches only if endpoint is considered 'stale'; otherwise returns undefined
      * @see https://dataclient.io/docs/api/Controller#fetchIfStale
      */
     fetchIfStale: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...args_0: Parameters<NoInfer<E>>) => E['schema'] extends undefined | null ? ReturnType<E> | ResolveType<E> : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']>;
+    }>(endpoint: E, ...args_0: Parameters<E>) => E['schema'] extends undefined | null ? ReturnType<E> | ResolveType<E> : Promise<Denormalize<E['schema']>> | Denormalize<E['schema']>;
     /**
      * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
      * @see https://dataclient.io/docs/api/Controller#invalidate
      */
-    invalidate: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]) => Promise<void>;
+    invalidate: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]) => Promise<void>;
     /**
      * Forces refetching and suspense on useSuspense on all matching endpoint result keys.
      * @see https://dataclient.io/docs/api/Controller#invalidateAll
@@ -499,14 +499,14 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
      */
     setResponse: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...rest: readonly [...Parameters<NI<E>>, any]) => Promise<void>;
+    }>(endpoint: E, ...rest: readonly [...Parameters<E>, any]) => Promise<void>;
     /**
      * Stores the result of Endpoint and args as the error provided.
      * @see https://dataclient.io/docs/api/Controller#setError
      */
     setError: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
-    }>(endpoint: E, ...rest: readonly [...Parameters<NI<E>>, Error]) => Promise<void>;
+    }>(endpoint: E, ...rest: readonly [...Parameters<E>, Error]) => Promise<void>;
     /**
      * Resolves an inflight fetch. `fetchedAt` should `fetch`'s `createdAt`
      * @see https://dataclient.io/docs/api/Controller#resolve
@@ -514,12 +514,12 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
     resolve: <E extends EndpointInterface<FetchFunction, Schema | undefined, boolean | undefined> & {
         update?: EndpointUpdateFunction<E> | undefined;
     }>(endpoint: E, meta: {
-        args: readonly [...Parameters<NI<E>>];
+        args: readonly [...Parameters<E>];
         response: Error;
         fetchedAt: number;
         error: true;
     } | {
-        args: readonly [...Parameters<NI<E>>];
+        args: readonly [...Parameters<E>];
         response: any;
         fetchedAt: number;
         error?: false | undefined;

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -1,5 +1,5 @@
 import * as _data_client_core from '@data-client/core';
-import { Manager, State, Controller, EndpointInterface, FetchFunction, Schema, NI, ResolveType, Denormalize, DenormalizeNullable, Queryable, SchemaArgs, NetworkError, UnknownError, ErrorTypes as ErrorTypes$1, ActionTypes, __INTERNAL__, createReducer, applyManager } from '@data-client/core';
+import { Manager, State, Controller, EndpointInterface, FetchFunction, Schema, ResolveType, Denormalize, DenormalizeNullable, Queryable, NI, SchemaArgs, NetworkError, UnknownError, ErrorTypes as ErrorTypes$1, ActionTypes, __INTERNAL__, createReducer, applyManager } from '@data-client/core';
 export { AbstractInstanceType, ActionTypes, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, ResetAction, ResolveType, Schema, SetAction, SetTypes, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@data-client/core';
 import * as react_jsx_runtime from 'react/jsx-runtime';
 import React$1, { Context } from 'react';
@@ -103,8 +103,8 @@ interface Props {
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>]): E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>;
-declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType<E> | undefined : DenormalizeNullable<E['schema']>;
+declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>;
+declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType<E> | undefined : DenormalizeNullable<E['schema']>;
 
 /**
  * Access a response if it is available.
@@ -112,7 +112,7 @@ declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema |
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: readonly [...Parameters<E['key']>] | readonly [null]): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
 
 /**
  * Query the store.
@@ -127,20 +127,20 @@ type ErrorTypes = NetworkError | UnknownError;
  * Get any errors for a given request
  * @see https://dataclient.io/docs/api/useError
  */
-declare function useError<E extends Pick<EndpointInterface, 'key'>>(endpoint: E, ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]): ErrorTypes | undefined;
+declare function useError<E extends Pick<EndpointInterface, 'key'>>(endpoint: E, ...args: readonly [...Parameters<E['key']>] | readonly [null]): ErrorTypes | undefined;
 
 /**
  * Request a resource if it is not in cache.
  * @see https://dataclient.io/docs/api/useFetch
  */
-declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>]): E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
-declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]): E['schema'] extends undefined | null ? ReturnType<E> | undefined : Promise<DenormalizeNullable<E['schema']>>;
+declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
+declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ReturnType<E> | undefined : Promise<DenormalizeNullable<E['schema']>>;
 
 /**
  * Keeps a resource fresh by subscribing to updates.
  * @see https://dataclient.io/docs/api/useSubscription
  */
-declare function useSubscription<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]): void;
+declare function useSubscription<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): void;
 
 type SchemaReturn<S extends Schema | undefined> = {
     data: Denormalize<S>;
@@ -172,8 +172,8 @@ type AsyncReturn<E> = {
  * Use async date with { data, loading, error } (DLE)
  * @see https://dataclient.io/docs/api/useDLE
  */
-declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>]): E['schema'] extends undefined | null ? AsyncReturn<E> : SchemaReturn<E['schema']>;
-declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]): {
+declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? AsyncReturn<E> : SchemaReturn<E['schema']>;
+declare function useDLE<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): {
     data: E['schema'] extends undefined | null ? undefined : DenormalizeNullable<E['schema']>;
     loading: false;
     error: undefined;
@@ -193,8 +193,8 @@ declare function useController(): Controller;
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>]): E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>;
-declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType<E> | undefined : DenormalizeNullable<E['schema']>;
+declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType<E> : Denormalize<E['schema']>;
+declare function useLive<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType<E> | undefined : DenormalizeNullable<E['schema']>;
 
 declare const StateContext: Context<State<unknown>>;
 declare const ControllerContext: Context<Controller<_data_client_core.DataClientDispatch>>;

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -112,7 +112,7 @@ declare function useSuspense<E extends EndpointInterface<FetchFunction, Schema |
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: NI<readonly [...Parameters<E['key']>] | readonly [null]>): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface<FetchFunction, Schema | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType<E> | undefined : any : DenormalizeNullable<E['schema']>;
 
 /**
  * Query the store.
@@ -127,19 +127,20 @@ type ErrorTypes = NetworkError | UnknownError;
  * Get any errors for a given request
  * @see https://dataclient.io/docs/api/useError
  */
-declare function useError<E extends Pick<EndpointInterface, 'key'>>(endpoint: E, ...args: NI<readonly [...Parameters<E['key']>] | readonly [null]>): ErrorTypes | undefined;
+declare function useError<E extends Pick<EndpointInterface, 'key'>>(endpoint: E, ...args: readonly [...Parameters<NI<E>['key']>] | readonly [null]): ErrorTypes | undefined;
 
 /**
  * Request a resource if it is not in cache.
  * @see https://dataclient.io/docs/api/useFetch
  */
-declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: NI<readonly [...Parameters<E>] | readonly [null]>): (E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize<E["schema"]>>) | undefined;
+declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>]): E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize<E['schema']>>;
+declare function useFetch<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]): E['schema'] extends undefined | null ? ReturnType<E> | undefined : Promise<DenormalizeNullable<E['schema']>>;
 
 /**
  * Keeps a resource fresh by subscribing to updates.
  * @see https://dataclient.io/docs/api/useSubscription
  */
-declare function useSubscription<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: NI<readonly [...Parameters<E>] | readonly [null]>): void;
+declare function useSubscription<E extends EndpointInterface<FetchFunction, Schema | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI<E>>] | readonly [null]): void;
 
 type SchemaReturn<S extends Schema | undefined> = {
     data: Denormalize<S>;

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -1,5 +1,5 @@
 import { PathFunction } from 'path-to-regexp';
-import { Manager, State, Controller, EndpointInterface as EndpointInterface$1, FetchFunction as FetchFunction$1, Schema as Schema$1, NI as NI$1, ResolveType as ResolveType$1, Denormalize as Denormalize$1, DenormalizeNullable as DenormalizeNullable$1, Queryable as Queryable$1, SchemaArgs as SchemaArgs$1, NetworkError as NetworkError$2, UnknownError as UnknownError$1, ErrorTypes as ErrorTypes$2 } from '@data-client/core';
+import { Manager, State, Controller, EndpointInterface as EndpointInterface$1, FetchFunction as FetchFunction$1, Schema as Schema$1, ResolveType as ResolveType$1, Denormalize as Denormalize$1, DenormalizeNullable as DenormalizeNullable$1, Queryable as Queryable$1, NI as NI$1, SchemaArgs as SchemaArgs$1, NetworkError as NetworkError$2, UnknownError as UnknownError$1, ErrorTypes as ErrorTypes$2 } from '@data-client/core';
 export { Manager } from '@data-client/core';
 import React from 'react';
 import * as react_jsx_runtime from 'react/jsx-runtime';
@@ -1693,8 +1693,8 @@ interface Props {
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
-declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
+declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
+declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
 
 /**
  * Access a response if it is available.
@@ -1702,7 +1702,7 @@ declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Sche
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>['key']>] | readonly [null]): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: readonly [...Parameters<E['key']>] | readonly [null]): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
 
 /**
  * Query the store.
@@ -1717,20 +1717,20 @@ type ErrorTypes = NetworkError$2 | UnknownError$1;
  * Get any errors for a given request
  * @see https://dataclient.io/docs/api/useError
  */
-declare function useError<E extends Pick<EndpointInterface$1, 'key'>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>['key']>] | readonly [null]): ErrorTypes | undefined;
+declare function useError<E extends Pick<EndpointInterface$1, 'key'>>(endpoint: E, ...args: readonly [...Parameters<E['key']>] | readonly [null]): ErrorTypes | undefined;
 
 /**
  * Request a resource if it is not in cache.
  * @see https://dataclient.io/docs/api/useFetch
  */
-declare function useFetch<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>]): E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize$1<E['schema']>>;
-declare function useFetch<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>] | readonly [null]): E['schema'] extends undefined | null ? ReturnType<E> | undefined : Promise<DenormalizeNullable$1<E['schema']>>;
+declare function useFetch<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize$1<E['schema']>>;
+declare function useFetch<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ReturnType<E> | undefined : Promise<DenormalizeNullable$1<E['schema']>>;
 
 /**
  * Keeps a resource fresh by subscribing to updates.
  * @see https://dataclient.io/docs/api/useSubscription
  */
-declare function useSubscription<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>] | readonly [null]): void;
+declare function useSubscription<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): void;
 
 type SchemaReturn<S extends Schema$1 | undefined> = {
     data: Denormalize$1<S>;
@@ -1762,8 +1762,8 @@ type AsyncReturn<E> = {
  * Use async date with { data, loading, error } (DLE)
  * @see https://dataclient.io/docs/api/useDLE
  */
-declare function useDLE<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>]): E['schema'] extends undefined | null ? AsyncReturn<E> : SchemaReturn<E['schema']>;
-declare function useDLE<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>] | readonly [null]): {
+declare function useDLE<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? AsyncReturn<E> : SchemaReturn<E['schema']>;
+declare function useDLE<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): {
     data: E['schema'] extends undefined | null ? undefined : DenormalizeNullable$1<E['schema']>;
     loading: false;
     error: undefined;
@@ -1783,7 +1783,7 @@ declare function useController(): Controller;
  * @throws {Promise} If data is not yet available.
  * @throws {NetworkError} If fetch fails.
  */
-declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
-declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
+declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
+declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
 
 export { AbstractInstanceType, AddEndpoint, Array$1 as Array, _default as AsyncBoundary, CacheProvider, Collection, CustomResource, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes$1 as ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, createResource, getUrlBase, getUrlTokens, hookifyResource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -1702,7 +1702,7 @@ declare function useSuspense<E extends EndpointInterface$1<FetchFunction$1, Sche
  * `useCache` guarantees referential equality globally.
  * @see https://dataclient.io/docs/api/useCache
  */
-declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: NI$1<readonly [...Parameters<E['key']>] | readonly [null]>): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
+declare function useCache<E extends Pick<EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | boolean>, 'key' | 'schema' | 'invalidIfStale'>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>['key']>] | readonly [null]): E['schema'] extends undefined | null ? E extends (...args: any) => any ? ResolveType$1<E> | undefined : any : DenormalizeNullable$1<E['schema']>;
 
 /**
  * Query the store.
@@ -1717,19 +1717,20 @@ type ErrorTypes = NetworkError$2 | UnknownError$1;
  * Get any errors for a given request
  * @see https://dataclient.io/docs/api/useError
  */
-declare function useError<E extends Pick<EndpointInterface$1, 'key'>>(endpoint: E, ...args: NI$1<readonly [...Parameters<E['key']>] | readonly [null]>): ErrorTypes | undefined;
+declare function useError<E extends Pick<EndpointInterface$1, 'key'>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>['key']>] | readonly [null]): ErrorTypes | undefined;
 
 /**
  * Request a resource if it is not in cache.
  * @see https://dataclient.io/docs/api/useFetch
  */
-declare function useFetch<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: NI$1<readonly [...Parameters<E>] | readonly [null]>): (E["schema"] extends null | undefined ? ReturnType<E> : Promise<Denormalize$1<E["schema"]>>) | undefined;
+declare function useFetch<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>]): E['schema'] extends undefined | null ? ReturnType<E> : Promise<Denormalize$1<E['schema']>>;
+declare function useFetch<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>] | readonly [null]): E['schema'] extends undefined | null ? ReturnType<E> | undefined : Promise<DenormalizeNullable$1<E['schema']>>;
 
 /**
  * Keeps a resource fresh by subscribing to updates.
  * @see https://dataclient.io/docs/api/useSubscription
  */
-declare function useSubscription<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: NI$1<readonly [...Parameters<E>] | readonly [null]>): void;
+declare function useSubscription<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<NI$1<E>>] | readonly [null]): void;
 
 type SchemaReturn<S extends Schema$1 | undefined> = {
     data: Denormalize$1<S>;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Types that match more situations better; working better in generics situation so type casting is not necessary.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- ctrl.getError() uses overloading
- Removed use of NoInfer as it seems not necessary when using Parameters (not sure tho)
- Update .native versions to have same type updates from main file.
- useFetch() uses similar overloading pattern to useSuspense