### PR TITLE
docs: Add DiffEditor

### DIFF
--- a/website/blog/2024-04-08-v0.11-queries-querable-usequery.md
+++ b/website/blog/2024-04-08-v0.11-queries-querable-usequery.md
@@ -60,10 +60,12 @@ for most operations and [Queries](/rest/api/Query) being 16x faster.
 
 - useCache() accepts Endpoints with sideEffects (like [Resource.update](/rest/api/createResource#update))
 - Allow Entity.pk() to return numbers.
+- 2-16x [performance improvements](/blog/2024/04/08/v0.11-queries-querable-usequery#performance)
 
 <!--truncate-->
 
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
+import DiffEditor from '@site/src/components/DiffEditor';
 
 ### Querable
 
@@ -124,10 +126,43 @@ const getBob = new schema.Query(
 We can now [access the store](/docs/api/Controller#get) with just a Queryable Schema - we no longer need an entire Endpoint.
 [#2921](https://github.com/reactive/data-client/pull/2921)
 
-```tsx title="Before"
+<DiffEditor>
+
+```ts title="Before"
+getOptimisticResponse(snapshot, { id }) {
+  // highlight-next-line
+  const { data: post } = snapshot.getResponse(Base.get, { id });
+  if (!post) throw snapshot.abort;
+  return {
+    id,
+    votes: post.votes + 1,
+  };
+}
+```
+
+```ts title="After"
+getOptimisticResponse(snapshot, { id }) {
+  // highlight-next-line
+  const post = snapshot.get(Post, { id });
+  if (!post) throw snapshot.abort;
+  return {
+    id,
+    votes: post.votes + 1,
+  };
+}
+```
+</DiffEditor>
+
+Since we no longer need to access other [Resource members](/rest/api/createResource#members) to get `Post`, we
+can use the much simpler [Resource.extend()](/rest/api/createResource#extend-new) overload.
+
+<DiffEditor>
+
+```ts title="Before"
 export const PostResource = createResource({
   path: '/posts/:id',
   schema: Post,
+// highlight-next-line
 }).extend(Base => ({
   vote: new RestEndpoint({
     path: '/posts/:id/vote',
@@ -135,29 +170,28 @@ export const PostResource = createResource({
     body: undefined,
     schema: Post,
     getOptimisticResponse(snapshot, { id }) {
-      // highlight-next-line
-      const { data } = snapshot.getResponse(Base.get, { id });
-      if (!data) throw new AbortOptimistic();
+      const { data: post } = snapshot.getResponse(Base.get, { id });
+      if (!post) throw snapshot.abort;
       return {
         id,
-        votes: data.votes + 1,
+        votes: post.votes + 1,
       };
     },
   }),
 }));
 ```
 
-```tsx title="After"
+```ts title="After"
 export const PostResource = createResource({
   path: '/posts/:id',
   schema: Post,
+// highlight-next-line
 }).extend('vote', {
   path: '/posts/:id/vote',
   method: 'POST',
   body: undefined,
   schema: Post,
   getOptimisticResponse(snapshot, { id }) {
-    // highlight-next-line
     const post = snapshot.get(Post, { id });
     if (!post) throw snapshot.abort;
     return {
@@ -167,6 +201,8 @@ export const PostResource = createResource({
   },
 });
 ```
+
+</DiffEditor>
 
 ### useQuery
 
@@ -241,6 +277,7 @@ xychart-beta
   const lastCreated = useCache(MyResource.getList.push);
   ```
 - Allow pk to return numbers [#2961](https://github.com/reactive/data-client/pull/2961)
+  <DiffEditor>
   ```ts title="Before"
   class MyEntity extends Entity {
     id = 0;
@@ -259,6 +296,7 @@ xychart-beta
     }
   }
   ```
+  </DiffEditor>
 - Typing
   - Improve .extend() typing when using [loose null checks](https://www.typescriptlang.org/tsconfig#strictNullChecks) and no body parameter [#2962](https://github.com/reactive/data-client/pull/2962)
     ```ts
@@ -288,21 +326,26 @@ This upgrade requires updating all package versions simultaneously.
 
 Just use Entities directly in [useQuery](/docs/api/useQuery)
 
-```jsx title="Before"
+<DiffEditor>
+
+```tsx title="Before"
 const UserIndex = new Index(User);
 
 const bob = useCache(UserIndex, { username: 'bob' });
 ```
 
-```jsx title="After"
+```tsx title="After"
 const bob = useQuery(User, { username: 'bob' });
 ```
+</DiffEditor>
 
 ### new Query -> new schema.Query {#query-migration}
 
 [Query](/rest/api/Query) is now a schema; used with [useQuery](/docs/api/useQuery)
 
-```jsx title="Before"
+<DiffEditor>
+
+```tsx title="Before"
 // highlight-next-line
 const getUserCount = new Query(
   new schema.All(User),
@@ -317,7 +360,7 @@ const userCount = useCache(getUserCount);
 const adminCount = useCache(getUserCount, { isAdmin: true });
 ```
 
-```jsx title="After"
+```tsx title="After"
 // highlight-next-line
 const getUserCount = new schema.Query(
   new schema.All(User),
@@ -331,10 +374,13 @@ const getUserCount = new schema.Query(
 const userCount = useQuery(getUserCount);
 const adminCount = useQuery(getUserCount, { isAdmin: true });
 ```
+</DiffEditor>
 
 ### new AbortOptimistic() -> snapshot.abort {#snap.abort}
 
 [snapshot.abort](https://dataclient.io/docs/api/Snapshot#abort) removes the need to import AbortOptimistic [#2957](https://github.com/reactive/data-client/pull/2957)
+
+<DiffEditor>
 
 ```ts title="Before"
 getOptimisticResponse(snapshot, { id }) {
@@ -359,10 +405,13 @@ getOptimisticResponse(snapshot, { id }) {
   };
 }
 ```
+</DiffEditor>
 
 ### Entity.useIncoming → Entity.shouldUpdate {#shouldupdate}
 
 Make [Entity.shouldUpdate](/rest/api/Entity#shouldupdate) name consistent with [Entity.shouldReorder](/rest/api/Entity#shouldreorder) [#2972](https://github.com/reactive/data-client/pull/2972)
+
+<DiffEditor>
 
 ```ts title="Before"
 class MyEntity extends Entity {
@@ -391,6 +440,7 @@ class MyEntity extends Entity {
   }
 }
 ```
+</DiffEditor>
 
 ### useDLE() reactive native focus handling
 
@@ -408,6 +458,8 @@ This could result in more fetches than occured previously.
 
 Most people have not overridden the `infer()` method. In this case you need to rename to `queryKey()`,
 as well as update the parameter list.
+
+<DiffEditor>
 
 ```ts title="Before"
 class MyEntity extends Entity {
@@ -442,6 +494,7 @@ class MyEntity extends Entity {
   }
 }
 ```
+</DiffEditor>
 
 ##### getEntity(key, pk?)
 
@@ -472,6 +525,8 @@ return getIndex(schema.key, indexName, value)[value];
 
 Subtle change into what will be in the store. This will likely only matter when using [@data-client/normalizr](https://www.npmjs.com/package/@data-client/normalizr)
 directly.
+
+<DiffEditor>
 
 ```json title="Before"
 {
@@ -510,11 +565,14 @@ directly.
   }
 }
 ```
+</DiffEditor>
 
 #### state.results -> state.endpoints [#2971](https://github.com/reactive/data-client/pull/2971)
 
 This will only likely matter when consuming [@data-client/core](https://www.npmjs.com/package/@data-client/core) directly as internal state is structure
 is opaque to [@data-client/react](https://www.npmjs.com/package/@data-client/react).
+
+<DiffEditor>
 
 ```json "Before"
 {
@@ -551,6 +609,7 @@ is opaque to [@data-client/react](https://www.npmjs.com/package/@data-client/rea
   }
 }
 ```
+</DiffEditor>
 
 #### inferResults() -> memo.buildQueryKey() [#2977](https://github.com/reactive/data-client/pull/2977), [#2978](https://github.com/reactive/data-client/pull/2978)
 
@@ -559,6 +618,8 @@ These methods are exported in [@data-client/core](https://www.npmjs.com/package/
 #### denormalizeCached() -> memo.denormalize() [#2978](https://github.com/reactive/data-client/pull/2978)
 
 Exported in [@data-client/normalizr](https://www.npmjs.com/package/@data-client/normalizr)
+
+<DiffEditor>
 
 ```ts title="Before"
 const endpointCache = new WeakEntityMap();
@@ -575,14 +636,22 @@ denormalizeCached(
 
 ```ts title="After"
 const memo = new MemoCached();
-memo.denormalize(input, schema, state.entities, args);
+memo.denormalize(
+  input,
+  schema,
+  state.entities,
+  args,
+);
 ```
+</DiffEditor>
 
 #### WeakEntityMap -> WeakDependencyMap [#2978](https://github.com/reactive/data-client/pull/2978)
 
 Exported in [@data-client/normalizr](https://www.npmjs.com/package/@data-client/normalizr)
 
 We generalize this data type so it can be used with other dependencies.
+
+<DiffEditor>
 
 ```ts title="Before"
 new WeakEntityMap();
@@ -591,6 +660,7 @@ new WeakEntityMap();
 ```ts title="After"
 new WeakDependencyMap<EntityPath>();
 ```
+</DiffEditor>
 
 ### Upgrade support
 

--- a/website/src/components/DiffEditor.tsx
+++ b/website/src/components/DiffEditor.tsx
@@ -1,0 +1,24 @@
+import CodeBlock from '@theme/CodeBlock';
+
+import DiffEditorChooser from './DiffEditorChooser';
+import Grid from './Grid';
+import { useCode } from './Playground/useCode';
+
+export default function DiffEditor({ children, row }) {
+  const { handleCodeChange, codes, codeTabs } = useCode(children, 'Before');
+
+  const fallback = (
+    <Grid wrap>
+      <CodeBlock language={codeTabs[0].language} title="Before">
+        {codes[0]}
+      </CodeBlock>
+      <CodeBlock language={codeTabs[1].language} title="After">
+        {codes[1]}
+      </CodeBlock>
+    </Grid>
+  );
+
+  return (
+    <DiffEditorChooser codes={codes} codeTabs={codeTabs} fallback={fallback} />
+  );
+}

--- a/website/src/components/DiffEditorChooser.tsx
+++ b/website/src/components/DiffEditorChooser.tsx
@@ -1,0 +1,6 @@
+import DiffEditorMonaco, { type DiffMonacoProps } from './DiffEditorMonaco';
+import usingMonaco from './Playground/usingMonaco';
+
+const DiffEditorChooser =
+  usingMonaco ? DiffEditorMonaco : ({ fallback }: DiffMonacoProps) => fallback;
+export default DiffEditorChooser;

--- a/website/src/components/DiffEditorMonaco.tsx
+++ b/website/src/components/DiffEditorMonaco.tsx
@@ -1,0 +1,83 @@
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { DiffEditor as BaseDiffEditor } from '@monaco-editor/react';
+import clsx from 'clsx';
+import { useMemo } from 'react';
+
+import { extensionToMonacoLanguage } from './Playground/extensionToMonacoLanguage';
+import MonacoPreloads from './Playground/MonacoPreloads';
+import { options } from './Playground/PlaygroundMonacoEditor';
+import styles from './Playground/styles.module.css';
+import useAutoHeight from './Playground/useAutoHeight';
+
+export default function DiffEditor({
+  codes,
+  codeTabs,
+  fallback,
+}: DiffMonacoProps) {
+  const { height, handleMount } = useAutoHeight({
+    lineHeight: options.lineHeight,
+  });
+
+  const [original, modified] = useMemo(
+    () => [
+      codes[0].replaceAll(/^\s*\/\/ highlight-(next-line|start|end)\n/gm, ''),
+      codes[1].replaceAll(/^\s*\/\/ highlight-(next-line|start|end)\n/gm, ''),
+    ],
+    [codes],
+  );
+
+  return (
+    <>
+      <BrowserOnly fallback={fallback}>
+        {() => (
+          <div
+            className={clsx(
+              styles.playgroundContainer,
+              styles.standaloneEditor,
+            )}
+          >
+            <div className={styles.playgroundTextEdit}>
+              <div className={clsx(styles.playgroundEditor)}>
+                <BaseDiffEditor
+                  language={extensionToMonacoLanguage(codeTabs[0].language)}
+                  original={original}
+                  modified={modified}
+                  options={DIFF_OPTIONS}
+                  onMount={handleMount}
+                  height={height}
+                  theme="prism"
+                  loading={fallback}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </BrowserOnly>
+      <MonacoPreloads />
+    </>
+  );
+}
+
+export type DiffMonacoProps = {
+  fallback: JSX.Element;
+  codes: string[];
+  codeTabs: {
+    [k: string]: any;
+    code: string;
+    path?: string | undefined;
+    title?: string | undefined;
+    collapsed: boolean;
+  }[];
+};
+
+const DIFF_OPTIONS = {
+  ...options,
+  renderSideBySide: true,
+  renderOverviewRuler: false,
+  renderGutterMenu: false,
+  renderMarginRevertIcon: false,
+  renderIndicators: false,
+  useInlineViewWhenSpaceIsLimited: false,
+  enableSplitViewResizing: false,
+  readOnly: true,
+};

--- a/website/src/components/Grid.module.css
+++ b/website/src/components/Grid.module.css
@@ -5,6 +5,11 @@
   column-gap: 15px;
 }
 
+.grid.wrap :global(.prism-code) {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 @media only screen and (max-width: 768px) {
   .grid {
     grid-template-columns: minmax(min-content, 1fr);

--- a/website/src/components/Grid.tsx
+++ b/website/src/components/Grid.tsx
@@ -1,8 +1,10 @@
+import clsx from 'clsx';
+
 import styles from './Grid.module.css';
 
-export default function Grid({ children, cols }) {
+export default function Grid({ children, cols = 2, wrap = false }) {
   return (
-    <div className={styles.grid}>
+    <div className={clsx(styles.grid, { [styles.wrap]: wrap })}>
       {typeof children === 'string' ?
         children
       : Array.isArray(children) ?

--- a/website/src/components/Playground/PlaygroundTextEdit.tsx
+++ b/website/src/components/Playground/PlaygroundTextEdit.tsx
@@ -65,49 +65,57 @@ export function PlaygroundTextEdit({
           isPlayground={isPlayground}
         />
       : null}
-      {codeTabs.map(({ title, path, code, collapsed, col, ...rest }, i) => (
-        <React.Fragment key={i}>
-          {(!row || col) && title ?
-            <CodeTabHeader
-              onClick={() => handleTabToggle(i)}
-              closed={closedList[i]}
-              title={title}
-              collapsible={codeTabs.length > 1 || fixtures?.length}
-              lastChild={i === codeTabs.length - 1 && large}
-            />
-          : null}
-          <div
-            key={i}
-            className={clsx(styles.playgroundEditor, {
-              [styles.hidden]: closedList[i],
-            })}
-          >
-            <BrowserOnly
-              fallback={
-                <LiveEditor key={i} language="tsx" code={codes[i]} disabled />
-              }
+      {codeTabs.map(
+        ({ title, path, code, collapsed, col, language, ...rest }, i) => (
+          <React.Fragment key={i}>
+            {(!row || col) && title ?
+              <CodeTabHeader
+                onClick={() => handleTabToggle(i)}
+                closed={closedList[i]}
+                title={title}
+                collapsible={codeTabs.length > 1 || fixtures?.length}
+                lastChild={i === codeTabs.length - 1 && large}
+              />
+            : null}
+            <div
+              key={i}
+              className={clsx(styles.playgroundEditor, {
+                [styles.hidden]: closedList[i],
+              })}
             >
-              {() => (
-                /*closedList[i] ? null : */ <PlaygroundEditor
-                  key={i}
-                  tabIndex={i}
-                  onFocus={
-                    row && !col && codeTabs.length > 1 ?
-                      handleTabSwitch
-                    : handleTabOpen
-                  }
-                  onChange={handleCodeChange[i]}
-                  code={codes[i]}
-                  path={'/' + id + '/' + (path || title || 'default.tsx')}
-                  isFocused={!closedList[i]}
-                  {...rest}
-                  large={large}
-                />
-              )}
-            </BrowserOnly>
-          </div>
-        </React.Fragment>
-      ))}
+              <BrowserOnly
+                fallback={
+                  <LiveEditor
+                    key={i}
+                    language={language}
+                    code={codes[i]}
+                    disabled
+                  />
+                }
+              >
+                {() => (
+                  /*closedList[i] ? null : */ <PlaygroundEditor
+                    key={i}
+                    tabIndex={i}
+                    onFocus={
+                      row && !col && codeTabs.length > 1 ?
+                        handleTabSwitch
+                      : handleTabOpen
+                    }
+                    onChange={handleCodeChange[i]}
+                    code={codes[i]}
+                    path={'/' + id + '/' + path}
+                    isFocused={!closedList[i]}
+                    language={language}
+                    {...rest}
+                    large={large}
+                  />
+                )}
+              </BrowserOnly>
+            </div>
+          </React.Fragment>
+        ),
+      )}
     </div>
   );
 }
@@ -216,11 +224,18 @@ function HeaderWithTabControls({ children }) {
 }
 
 function EditorHeader({
-  title,
+  title = (
+    <Translate
+      id="theme.Playground.liveEditor"
+      description="The live editor label of the live codeblocks"
+    >
+      Editor
+    </Translate>
+  ),
   fixtures = [],
 }: {
-  title: string;
-  fixtures: (Fixture | Interceptor)[];
+  title?: React.ReactNode;
+  fixtures?: (Fixture | Interceptor)[];
 }) {
   const { values } = useContext(CodeTabContext);
   const hasTabs = values.length > 0;
@@ -239,14 +254,3 @@ function EditorHeader({
     </>
   );
 }
-EditorHeader.defaultProps = {
-  title: (
-    <Translate
-      id="theme.Playground.liveEditor"
-      description="The live editor label of the live codeblocks"
-    >
-      Editor
-    </Translate>
-  ),
-  fixtures: [],
-};

--- a/website/src/components/Playground/extensionToMonacoLanguage.tsx
+++ b/website/src/components/Playground/extensionToMonacoLanguage.tsx
@@ -1,0 +1,4 @@
+export function extensionToMonacoLanguage(ext: string) {
+  if (ext === 'tsx' || ext === 'ts') return 'typescript';
+  return ext;
+}

--- a/website/src/components/Playground/monaco-init.ts
+++ b/website/src/components/Playground/monaco-init.ts
@@ -56,7 +56,7 @@ if (
         skipLibCheck: true,
         noImplicitAny: false,
       });
-      // TODO: load theme from docusaurus config
+      // TODO: load theme from docusaurus config so we eliminate DRY violation
       // see https://microsoft.github.io/monaco-editor/playground.html for full options
       monaco.editor.defineTheme('prism', {
         base: 'vs-dark',
@@ -130,6 +130,14 @@ if (
             endLineNumber: position.lineNumber,
             endColumn: position.column,
           });
+          // Get the current word
+          const word = model.getWordUntilPosition(position);
+          const range = {
+            startLineNumber: position.lineNumber,
+            endLineNumber: position.lineNumber,
+            startColumn: word.startColumn,
+            endColumn: word.endColumn,
+          };
           // Match things like `from "` and `require("`
           if (
             /(([\s|\n]+from\s+)|(\brequire\b\s*\())["|'][^'^"]*$/.test(
@@ -158,6 +166,7 @@ if (
                     // Don't keep extension for JS files
                     insertText: file.replace(/\.tsx?$/, ''),
                     kind: monaco.languages.CompletionItemKind.Module,
+                    range,
                   };
                 });
               if (!completions.length) return;
@@ -190,6 +199,7 @@ if (
                   //detail: suggestionDependencies[name],
                   kind: monaco.languages.CompletionItemKind.Module,
                   insertText: name,
+                  range,
                 })),
               };
             }

--- a/website/src/components/Playground/useAutoHeight.tsx
+++ b/website/src/components/Playground/useAutoHeight.tsx
@@ -1,0 +1,94 @@
+import { type MonacoDiffEditor } from '@monaco-editor/react';
+import type * as Monaco from 'monaco-editor';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export default function useAutoHeight({
+  isFocused = false,
+  lineHeight,
+  containerGutter = 10,
+}) {
+  const updateHeightRef = useRef<() => void>();
+  useEffect(() => {
+    if (isFocused && updateHeightRef.current) {
+      setTimeout(updateHeightRef.current, 5);
+    }
+  }, [isFocused]);
+
+  const [height, setHeight] = useState<string | number>('1000');
+  const handleMount = useCallback(
+    (
+      editor: Monaco.editor.ICodeEditor | MonacoDiffEditor,
+      monaco: typeof Monaco,
+    ) => {
+      // autoheight
+      const LINE_HEIGHT = lineHeight;
+      const CONTAINER_GUTTER = containerGutter;
+
+      const el = editor.getContainerDomNode();
+      const codeContainer = el.getElementsByClassName('view-lines')[0];
+
+      let prevLineCount = 0;
+
+      const model = editor.getModel();
+      let lineCount = 10;
+      if (model) {
+        // before rendering we have no view information, so we initialize based on unwrapped lines
+        lineCount = getLineCount(model);
+      }
+
+      const contentHeight = lineCount * LINE_HEIGHT + CONTAINER_GUTTER;
+      el.style.height = contentHeight + 'px';
+      setHeight(contentHeight);
+
+      editor.layout();
+
+      updateHeightRef.current = () => {
+        const viewlinecount =
+          editor._modelData?.viewModel?.getLineCount?.() ??
+          codeContainer.childElementCount;
+        const model = editor.getModel();
+        const modellinecount =
+          model ? getLineCount(model) : codeContainer.childElementCount;
+        const lineCount =
+          viewlinecount < modellinecount * 3 ? viewlinecount : modellinecount;
+        const height = lineCount * LINE_HEIGHT + CONTAINER_GUTTER; // fold
+        prevLineCount = codeContainer.childElementCount;
+
+        el.style.height = height + 'px';
+        setHeight(height);
+
+        editor.layout();
+      };
+      if ('onDidChangeModelDecorations' in editor) {
+        editor.onDidChangeModelDecorations(() => {
+          // wait until dom rendered
+          setTimeout(updateHeightRef.current, 0);
+        });
+      } else {
+        editor.getOriginalEditor().onDidChangeModelDecorations(() => {
+          // wait until dom rendered
+          setTimeout(updateHeightRef.current, 0);
+        });
+        editor.getModifiedEditor().onDidChangeModelDecorations(() => {
+          // wait until dom rendered
+          setTimeout(updateHeightRef.current, 0);
+        });
+      }
+      return () => editor?.dispose();
+    },
+    [],
+  );
+  return { height, handleMount };
+}
+
+function getLineCount(
+  model: Monaco.editor.ITextModel | Monaco.editor.IDiffEditorModel,
+) {
+  if ('original' in model) {
+    return Math.max(
+      model.original.getLineCount(),
+      model.modified.getLineCount(),
+    );
+  }
+  return model.getLineCount();
+}

--- a/website/src/components/Playground/useCode.tsx
+++ b/website/src/components/Playground/useCode.tsx
@@ -10,7 +10,7 @@ export function useCode(children, defaultTab) {
     [k: string]: any;
   }[] = useMemo(() => {
     if (typeof children === 'string')
-      return [{ code: children.replace(/\n$/, ''), collapsed: false }];
+      return [{ code: getCode(children), collapsed: false }];
     return (Array.isArray(children) ? children : [children])
       .filter(child => child.props.children)
       .map(child =>
@@ -25,15 +25,22 @@ export function useCode(children, defaultTab) {
             title !== defaultTab
           : parseCodeBlockCollapsed(metastring) ?? false;
         const col = parseCodeBlockCol(metastring) ?? false;
-        const path = parseCodeBlockPath(metastring);
         const highlights = /\{([\d\-,.]+)\}/.exec(metastring)?.[1];
+        const language = /language-(\w+)/.exec(rest.className)?.[1] ?? 'tsx';
+        const extension = langToExtension(language);
+        const fileBase = title || 'default';
+        const path =
+          parseCodeBlockPath(metastring) || fileBase.includes('.') ?
+            fileBase
+          : `${fileBase}.${extension}`;
         return {
-          code: children.replace(/\n$/, ''),
+          code: getCode(children),
           title,
           collapsed,
           col,
           path,
           highlights,
+          language,
           ...rest,
         };
       });
@@ -82,4 +89,13 @@ export function parseCodeBlockCol(metastring?: string): boolean {
 }
 export function parseCodeBlockPath(metastring?: string): string {
   return metastring?.match(codeBlockPathRegex)?.groups!.title ?? '';
+}
+
+export function langToExtension(lang: string) {
+  if (lang === 'typescript') return 'ts';
+  return lang;
+}
+
+function getCode(code: string) {
+  return code.replace(/\n$/, '');
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Easier to understand changes

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
![image](https://github.com/reactive/data-client/assets/866147/c5c8db14-cf5f-47f6-a89f-e8afab308bec)

Monaco has built in editor, so configure in similar way. Diffs should have 'before' and 'after'. Highlights will be removed.

```mdx
 <DiffEditor>

  ``ts title="Before"
  class MyEntity extends Entity {
    id = 0;
    pk() {
      // highlight-next-line
      return `${this.id}`;
    }
  }
  ``

  ``ts title="After"
  class MyEntity extends Entity {
    id = 0;
    pk() {
      // highlight-next-line
      return this.id;
    }
  }
  ``

  </DiffEditor>
```


