### PR TITLE
feat: Add @data-client/react/nextjs entrypoint

### DIFF
--- a/.changeset/brave-bottles-talk.md
+++ b/.changeset/brave-bottles-talk.md
@@ -1,0 +1,21 @@
+---
+'@data-client/react': patch
+---
+
+Add /nextjs entrypoint - eliminating the need for @data-client/ssr package
+
+```tsx
+import { DataProvider } from '@data-client/react/nextjs';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <DataProvider>
+          {children}
+        </DataProvider>
+      </body>
+    </html>
+  );
+}
+```

--- a/docs/core/guides/ssr.md
+++ b/docs/core/guides/ssr.md
@@ -28,7 +28,7 @@ performance improvements, as well as dynamic and nested routing.
 Place [DataProvider](https://dataclient.io/docs/api/DataProvider) in your [root layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required)
 
 ```tsx title="app/layout.tsx"
-import { DataProvider } from '@data-client/ssr/nextjs';
+import { DataProvider } from '@data-client/react/nextjs';
 import { AsyncBoundary } from '@data-client/react';
 
 export default function RootLayout({ children }) {

--- a/docs/core/shared/_installation.mdx
+++ b/docs/core/shared/_installation.mdx
@@ -67,15 +67,12 @@ Alternatively [integrate state with redux](../guides/redux.md)
 
 <TabItem value="nextjs">
 
-<PkgInstall pkgs="@data-client/ssr @data-client/redux redux" />
-
 <p style={{textAlign: 'center'}}>
 <Link className="button button--primary" to="../guides/ssr#nextjs">Full NextJS Guide</Link>
 </p>
 
 ```tsx title="app/layout.tsx"
-import { DataProvider } from '@data-client/ssr/nextjs';
-import { AsyncBoundary } from '@data-client/react';
+import { DataProvider } from '@data-client/react/nextjs';
 
 export default function RootLayout({ children }) {
   return (

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -3,3 +3,4 @@
 /legacy
 /index.d.ts
 /next.d.ts
+/nextjs.d.ts

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,6 +64,9 @@
       "next": [
         "lib/next/index.d.ts"
       ],
+      "nextjs": [
+        "lib/server/nextjs/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
@@ -91,6 +94,10 @@
       "types": "./lib/next/index.d.ts",
       "require": "./dist/next.js",
       "default": "./lib/next/index.js"
+    },
+    "./nextjs": {
+      "types": "./lib/server/nextjs/index.d.ts",
+      "default": "./lib/server/nextjs/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -57,6 +57,11 @@ if (process.env.BROWSERSLIST_ENV !== 'node12') {
   });
   configs.push(typeConfig);
   configs.push(typeConfigNext);
+  configs.push({
+    ...typeConfig,
+    input: './lib/server/nextjs/index.d.ts',
+    output: [{ file: 'nextjs.d.ts', format: 'es' }],
+  });
 } else {
   // node-friendly commonjs build
   [

--- a/packages/react/src/server/ServerData.tsx
+++ b/packages/react/src/server/ServerData.tsx
@@ -1,0 +1,31 @@
+import type { State } from '@data-client/core';
+
+export const ServerData = ({
+  data,
+  nonce,
+  id = 'data-client-data',
+}: {
+  data: State<unknown>;
+  id?: string;
+  nonce?: string | undefined;
+}) => {
+  try {
+    const encoded = JSON.stringify(data);
+    return (
+      <script
+        id={id}
+        type="application/json"
+        dangerouslySetInnerHTML={{
+          __html: encoded,
+        }}
+        nonce={nonce}
+      />
+    );
+  } catch (e) {
+    console.error(`Error serializing json for ${id}`);
+    console.error(e);
+    return null;
+  }
+};
+
+export default ServerData;

--- a/packages/react/src/server/getInitialData.ts
+++ b/packages/react/src/server/getInitialData.ts
@@ -1,0 +1,52 @@
+import { initialState } from '@data-client/core';
+
+export const awaitInitialData = (id = 'data-client-data'): Promise<any> => {
+  return new Promise<any>((resolve, reject) => {
+    let el: HTMLScriptElement | null;
+    if ((el = document.getElementById(id) as any)) {
+      resolve(getDataFromEl(el, id));
+      return;
+    }
+    document.addEventListener('DOMContentLoaded', () => {
+      el = document.getElementById(id) as any;
+      if (el) resolve(getDataFromEl(el, id));
+      else
+        reject(new Error('failed to find DOM with reactive data client state'));
+    });
+  });
+};
+
+export const getInitialData = (id = 'data-client-data') => {
+  const el: HTMLScriptElement | null = document.getElementById(id) as any;
+  if (!el) return initialState;
+  return getDataFromEl(el, id);
+};
+
+function getDataFromEl(el: HTMLScriptElement, key: string) {
+  if (el.text === undefined) {
+    console.error(
+      `#${key} is completely empty. This could be due to CSP issues.`,
+    );
+  }
+  if (getInitialData.name !== 'getInitialData') {
+    (document as any).FUNC_MANGLE = function () {
+      console.error(
+        'Data Client Error: https://dataclient.io/errors/osid',
+        this,
+      );
+      delete (document as any).FUNC_MANGLE;
+    };
+  }
+  if (Test.name !== 'Test') {
+    (document as any).CLS_MANGLE = function () {
+      console.error(
+        'Data Client Error: https://dataclient.io/errors/dklj',
+        this,
+      );
+      delete (document as any).CLS_MANGLE;
+    };
+  }
+  return el?.text ? JSON.parse(el?.text) : undefined;
+}
+
+class Test {}

--- a/packages/react/src/server/nextjs/DataProvider/DataProvider.tsx
+++ b/packages/react/src/server/nextjs/DataProvider/DataProvider.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useMemo, type ComponentProps } from 'react';
+
+import createPersistedStore from './createPersistedStore.js';
+import ServerDataComponent from './ServerDataComponent.js';
+import type CacheProvider from '../../../components/CacheProvider.js';
+
+export default function DataProvider({
+  children,
+  ...props
+}: ProviderProps): React.ReactElement {
+  const [ServerCacheProvider, initPromise] = useMemo(createPersistedStore, []);
+
+  return (
+    <>
+      <ServerDataComponent initPromise={initPromise} />
+      <ServerCacheProvider {...props} initPromise={initPromise}>
+        {children}
+      </ServerCacheProvider>
+    </>
+  );
+}
+
+type ProviderProps = Omit<
+  Partial<ComponentProps<typeof CacheProvider>>,
+  'initialState'
+> & {
+  children: React.ReactNode;
+};

--- a/packages/react/src/server/nextjs/DataProvider/ServerDataComponent.tsx
+++ b/packages/react/src/server/nextjs/DataProvider/ServerDataComponent.tsx
@@ -1,0 +1,17 @@
+import { use } from 'react';
+
+import ServerData from '../../ServerData.js';
+
+const id = 'data-client-data';
+
+const ServerDataComponent = ({
+  nonce,
+  initPromise,
+}: {
+  nonce?: string | undefined;
+  initPromise: Promise<any>;
+}) => {
+  const data = use(initPromise);
+  return <ServerData data={data} id={id} nonce={nonce} />;
+};
+export default ServerDataComponent;

--- a/packages/react/src/server/nextjs/DataProvider/createPersistedStore.ts
+++ b/packages/react/src/server/nextjs/DataProvider/createPersistedStore.ts
@@ -1,0 +1,8 @@
+import createPersistedStoreClient from './createPersistedStoreClient.js';
+import createPersistedStoreServer from './createPersistedStoreServer.js';
+
+const createPersistedStore =
+  typeof window === 'undefined' ?
+    createPersistedStoreServer
+  : createPersistedStoreClient;
+export default createPersistedStore;

--- a/packages/react/src/server/nextjs/DataProvider/createPersistedStoreClient.tsx
+++ b/packages/react/src/server/nextjs/DataProvider/createPersistedStoreClient.tsx
@@ -1,0 +1,32 @@
+/// <reference types="react/canary" />
+import { type State } from '@data-client/core';
+import { ComponentProps, use } from 'react';
+
+import CacheProvider from '../../../components/CacheProvider.js';
+import { awaitInitialData } from '../../getInitialData.js';
+
+export default function createPersistedStore() {
+  const initPromise = awaitInitialData();
+
+  const StoreCacheProvider = ({
+    children,
+    initPromise,
+    ...props
+  }: ProviderProps) => {
+    const initialState = use(initPromise);
+    return (
+      <CacheProvider {...props} initialState={initialState}>
+        {children}
+      </CacheProvider>
+    );
+  };
+  return [StoreCacheProvider, initPromise] as const;
+}
+
+type ProviderProps = Omit<
+  Partial<ComponentProps<typeof CacheProvider>>,
+  'initialState'
+> & {
+  children: React.ReactNode;
+  initPromise: Promise<State<any>>;
+};

--- a/packages/react/src/server/nextjs/DataProvider/createPersistedStoreServer.tsx
+++ b/packages/react/src/server/nextjs/DataProvider/createPersistedStoreServer.tsx
@@ -1,0 +1,85 @@
+import {
+  Controller,
+  Manager,
+  NetworkManager,
+  State,
+  createReducer,
+  initialState,
+  applyManager,
+} from '@data-client/core';
+import type { ComponentProps } from 'react';
+
+import type CacheProvider from '../../../components/CacheProvider.js';
+import {
+  ExternalCacheProvider,
+  PromiseifyMiddleware,
+} from '../../redux/index.js';
+import { createStore, applyMiddleware } from '../../redux/redux.js';
+
+export default function createPersistedStore(managers?: Manager[]) {
+  const controller = new Controller();
+  managers = managers ?? [new NetworkManager()];
+  const nm: NetworkManager = managers.find(
+    m => m instanceof NetworkManager,
+  ) as any;
+  if (nm === undefined)
+    throw new Error('managers must include a NetworkManager');
+  const reducer = createReducer(controller);
+  const enhancer = applyMiddleware(
+    // redux 5's types are wrong and do not allow any return typing from next, which is incorrect.
+    // `next: (action: unknown) => unknown`: allows any action, but disallows all return types.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ...applyManager(managers, controller),
+    PromiseifyMiddleware,
+  );
+  const store = createStore(reducer, initialState as any, enhancer);
+  managers.forEach(manager => manager.init?.(store.getState()));
+
+  const selector = (state: any) => state;
+
+  const getState = () => selector(store.getState());
+
+  const initPromise: Promise<State<any>> = (async () => {
+    let firstRender = true;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const inFlightFetches = nm.allSettled();
+      if (inFlightFetches) {
+        firstRender = false;
+        await inFlightFetches;
+        continue;
+      }
+      if (firstRender) {
+        firstRender = false;
+        // TODO: instead of waiting 10ms - see if we can wait until next part of react is streamed and race with nm getting new fetches
+        await new Promise(resolve => setTimeout(resolve, 10));
+        continue;
+      }
+      break;
+    }
+    return getState();
+  })();
+
+  const StoreCacheProvider = ({ children }: ProviderProps) => {
+    return (
+      <ExternalCacheProvider
+        store={store}
+        selector={selector}
+        controller={controller}
+      >
+        {children}
+      </ExternalCacheProvider>
+    );
+  };
+
+  return [StoreCacheProvider, initPromise] as const;
+}
+
+type ProviderProps = Omit<
+  Partial<ComponentProps<typeof CacheProvider>>,
+  'initialState'
+> & {
+  children: React.ReactNode;
+  initPromise: Promise<State<any>>;
+};

--- a/packages/react/src/server/nextjs/index.ts
+++ b/packages/react/src/server/nextjs/index.ts
@@ -1,0 +1,1 @@
+export { default as DataProvider } from './DataProvider/DataProvider.js';

--- a/packages/react/src/server/redux/ExternalCacheProvider.tsx
+++ b/packages/react/src/server/redux/ExternalCacheProvider.tsx
@@ -1,0 +1,86 @@
+import {
+  State,
+  ActionTypes,
+  Controller,
+  createReducer,
+} from '@data-client/core';
+import React, {
+  useEffect,
+  useState,
+  useMemo,
+  useRef,
+  useCallback,
+} from 'react';
+
+import {
+  ControllerContext,
+  StoreContext,
+  BackupLoading,
+  UniversalSuspense,
+  usePromisifiedDispatch,
+} from '../../index.js';
+
+interface Store<S> {
+  subscribe(listener: () => void): () => void;
+  dispatch: React.Dispatch<ActionTypes>;
+  getState(): S;
+}
+interface Props<S> {
+  children: React.ReactNode;
+  store: Store<S>;
+  selector: (state: S) => State<unknown>;
+  controller: Controller;
+}
+
+/**
+ * Like CacheProvider, but for an external store
+ * @see https://dataclient.io/docs/api/ExternalCacheProvider
+ */
+export default function ExternalCacheProvider<S>({
+  children,
+  store,
+  selector,
+  controller,
+}: Props<S>) {
+  const masterReducer = useMemo(() => createReducer(controller), [controller]);
+  const selectState = useCallback(() => {
+    const state = selector(store.getState());
+    return state.optimistic.reduce(masterReducer, state);
+  }, [masterReducer, selector, store]);
+
+  const [state, setState] = useState(selectState);
+
+  const isMounted = useRef(true);
+  useEffect(() => {
+    isMounted.current = true;
+    () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = store.subscribe(() => {
+      if (isMounted.current) setState(selectState());
+    });
+    return unsubscribe;
+  }, [selectState, store]);
+
+  const dispatch = usePromisifiedDispatch(store.dispatch, state);
+
+  const adaptedStore = useMemo(() => {
+    return { ...store, getState: () => selector(store.getState()) };
+  }, [selector, store]);
+
+  return (
+    <StoreContext.Provider value={adaptedStore}>
+      <ControllerContext.Provider value={controller}>
+        <UniversalSuspense fallback={<BackupLoading />}>
+          {children}
+        </UniversalSuspense>
+        {process.env.NODE_ENV !== 'production' ?
+          <UniversalSuspense fallback={null} />
+        : undefined}
+      </ControllerContext.Provider>
+    </StoreContext.Provider>
+  );
+}

--- a/packages/react/src/server/redux/PromiseifyMiddleware.ts
+++ b/packages/react/src/server/redux/PromiseifyMiddleware.ts
@@ -1,0 +1,11 @@
+import type { Dispatch } from '@data-client/core';
+import React from 'react';
+
+const PromiseifyMiddleware =
+  <R extends React.Reducer<any, any>>(_: unknown) =>
+  (next: Dispatch<R>) =>
+  (action: React.ReducerAction<R>): Promise<void> => {
+    next(action);
+    return Promise.resolve();
+  };
+export default PromiseifyMiddleware;

--- a/packages/react/src/server/redux/index.ts
+++ b/packages/react/src/server/redux/index.ts
@@ -1,0 +1,6 @@
+export { applyManager, initialState, createReducer } from '@data-client/core';
+// export { prepareStore } from './prepareStore.js';
+// export { default as CacheProvider } from './CacheProvider.js';
+export { default as ExternalCacheProvider } from './ExternalCacheProvider.js';
+export { default as mapMiddleware } from './mapMiddleware.js';
+export { default as PromiseifyMiddleware } from './PromiseifyMiddleware.js';

--- a/packages/react/src/server/redux/mapMiddleware.ts
+++ b/packages/react/src/server/redux/mapMiddleware.ts
@@ -1,0 +1,16 @@
+import type { State } from '@data-client/core';
+
+import type { MiddlewareAPI, Middleware } from './redux.js';
+
+const mapMiddleware =
+  <M extends Middleware[]>(selector: (state: any) => State<unknown>) =>
+  (...middlewares: Middleware[]): M => {
+    return middlewares.map(
+      middleware =>
+        ({ getState, ...args }: MiddlewareAPI) => {
+          const wrapped = () => selector(getState());
+          return middleware({ getState: wrapped, ...args } as any);
+        },
+    ) as any;
+  };
+export default mapMiddleware;

--- a/packages/react/src/server/redux/redux.d.ts
+++ b/packages/react/src/server/redux/redux.d.ts
@@ -1,0 +1,717 @@
+/**
+ * An *action* is a plain object that represents an intention to change the
+ * state. Actions are the only way to get data into the store. Any data,
+ * whether from UI events, network callbacks, or other sources such as
+ * WebSockets needs to eventually be dispatched as actions.
+ *
+ * Actions must have a `type` field that indicates the type of action being
+ * performed. Types can be defined as constants and imported from another
+ * module. These must be strings, as strings are serializable.
+ *
+ * Other than `type`, the structure of an action object is really up to you.
+ * If you're interested, check out Flux Standard Action for recommendations on
+ * how actions should be constructed.
+ *
+ * @template T the type of the action's `type` tag.
+ */
+type Action<T extends string = string> = {
+  type: T;
+};
+/**
+ * An Action type which accepts any other properties.
+ * This is mainly for the use of the `Reducer` type.
+ * This is not part of `Action` itself to prevent types that extend `Action` from
+ * having an index signature.
+ */
+interface UnknownAction extends Action {
+  [extraProps: string]: unknown;
+}
+/**
+ * An Action type which accepts any other properties.
+ * This is mainly for the use of the `Reducer` type.
+ * This is not part of `Action` itself to prevent types that extend `Action` from
+ * having an index signature.
+ * @deprecated use Action or UnknownAction instead
+ */
+interface AnyAction extends Action {
+  [extraProps: string]: any;
+}
+/**
+ * An *action creator* is, quite simply, a function that creates an action. Do
+ * not confuse the two terms—again, an action is a payload of information, and
+ * an action creator is a factory that creates an action.
+ *
+ * Calling an action creator only produces an action, but does not dispatch
+ * it. You need to call the store's `dispatch` function to actually cause the
+ * mutation. Sometimes we say *bound action creators* to mean functions that
+ * call an action creator and immediately dispatch its result to a specific
+ * store instance.
+ *
+ * If an action creator needs to read the current state, perform an API call,
+ * or cause a side effect, like a routing transition, it should return an
+ * async action instead of an action.
+ *
+ * @template A Returned action type.
+ */
+interface ActionCreator<A, P extends any[] = any[]> {
+  (...args: P): A;
+}
+/**
+ * Object whose values are action creator functions.
+ */
+interface ActionCreatorsMapObject<A = any, P extends any[] = any[]> {
+  [key: string]: ActionCreator<A, P>;
+}
+
+/**
+ * A *reducer* is a function that accepts
+ * an accumulation and a value and returns a new accumulation. They are used
+ * to reduce a collection of values down to a single value
+ *
+ * Reducers are not unique to Redux—they are a fundamental concept in
+ * functional programming.  Even most non-functional languages, like
+ * JavaScript, have a built-in API for reducing. In JavaScript, it's
+ * `Array.prototype.reduce()`.
+ *
+ * In Redux, the accumulated value is the state object, and the values being
+ * accumulated are actions. Reducers calculate a new state given the previous
+ * state and an action. They must be *pure functions*—functions that return
+ * the exact same output for given inputs. They should also be free of
+ * side-effects. This is what enables exciting features like hot reloading and
+ * time travel.
+ *
+ * Reducers are the most important concept in Redux.
+ *
+ * *Do not put API calls into reducers.*
+ *
+ * @template S The type of state consumed and produced by this reducer.
+ * @template A The type of actions the reducer can potentially respond to.
+ * @template PreloadedState The type of state consumed by this reducer the first time it's called.
+ */
+type Reducer<S = any, A extends Action = UnknownAction, PreloadedState = S> = (
+  state: S | PreloadedState | undefined,
+  action: A,
+) => S;
+/**
+ * Object whose values correspond to different reducer functions.
+ *
+ * @template S The combined state of the reducers.
+ * @template A The type of actions the reducers can potentially respond to.
+ * @template PreloadedState The combined preloaded state of the reducers.
+ */
+type ReducersMapObject<
+  S = any,
+  A extends Action = UnknownAction,
+  PreloadedState = S,
+> =
+  keyof PreloadedState extends keyof S ?
+    {
+      [K in keyof S]: Reducer<
+        S[K],
+        A,
+        K extends keyof PreloadedState ? PreloadedState[K] : never
+      >;
+    }
+  : never;
+/**
+ * Infer a combined state shape from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+type StateFromReducersMapObject<M> =
+  M[keyof M] extends Reducer<any, any, any> | undefined ?
+    {
+      [P in keyof M]: M[P] extends Reducer<infer S, any, any> ? S : never;
+    }
+  : never;
+/**
+ * Infer reducer union type from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+type ReducerFromReducersMapObject<M> =
+  M[keyof M] extends Reducer<any, any, any> | undefined ? M[keyof M] : never;
+/**
+ * Infer action type from a reducer function.
+ *
+ * @template R Type of reducer.
+ */
+type ActionFromReducer<R> = R extends Reducer<any, infer A, any> ? A : never;
+/**
+ * Infer action union type from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+type ActionFromReducersMapObject<M> = ActionFromReducer<
+  ReducerFromReducersMapObject<M>
+>;
+/**
+ * Infer a combined preloaded state shape from a `ReducersMapObject`.
+ *
+ * @template M Object map of reducers as provided to `combineReducers(map: M)`.
+ */
+type PreloadedStateShapeFromReducersMapObject<M> =
+  M[keyof M] extends Reducer<any, any, any> | undefined ?
+    {
+      [P in keyof M]: M[P] extends (
+        (inputState: infer InputState, action: UnknownAction) => any
+      ) ?
+        InputState
+      : never;
+    }
+  : never;
+
+/**
+ * A *dispatching function* (or simply *dispatch function*) is a function that
+ * accepts an action or an async action; it then may or may not dispatch one
+ * or more actions to the store.
+ *
+ * We must distinguish between dispatching functions in general and the base
+ * `dispatch` function provided by the store instance without any middleware.
+ *
+ * The base dispatch function *always* synchronously sends an action to the
+ * store's reducer, along with the previous state returned by the store, to
+ * calculate a new state. It expects actions to be plain objects ready to be
+ * consumed by the reducer.
+ *
+ * Middleware wraps the base dispatch function. It allows the dispatch
+ * function to handle async actions in addition to actions. Middleware may
+ * transform, delay, ignore, or otherwise interpret actions or async actions
+ * before passing them to the next middleware.
+ *
+ * @template A The type of things (actions or otherwise) which may be
+ *   dispatched.
+ */
+interface Dispatch<A extends Action = UnknownAction> {
+  <T extends A>(action: T, ...extraArgs: any[]): T;
+}
+/**
+ * Function to remove listener added by `Store.subscribe()`.
+ */
+interface Unsubscribe {
+  (): void;
+}
+type ListenerCallback = () => void;
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+/**
+ * A minimal observable of state changes.
+ * For more information, see the observable proposal:
+ * https://github.com/tc39/proposal-observable
+ */
+type Observable<T> = {
+  /**
+   * The minimal observable subscription method.
+   * @param {Object} observer Any object that can be used as an observer.
+   * The observer object should have a `next` method.
+   * @returns {subscription} An object with an `unsubscribe` method that can
+   * be used to unsubscribe the observable from the store, and prevent further
+   * emission of values from the observable.
+   */
+  subscribe: (observer: Observer<T>) => {
+    unsubscribe: Unsubscribe;
+  };
+  [Symbol.observable](): Observable<T>;
+};
+/**
+ * An Observer is used to receive data from an Observable, and is supplied as
+ * an argument to subscribe.
+ */
+type Observer<T> = {
+  next?(value: T): void;
+};
+/**
+ * A store is an object that holds the application's state tree.
+ * There should only be a single store in a Redux app, as the composition
+ * happens on the reducer level.
+ *
+ * @template S The type of state held by this store.
+ * @template A the type of actions which may be dispatched by this store.
+ * @template StateExt any extension to state from store enhancers
+ */
+interface Store<S = any, A extends Action = UnknownAction, StateExt = unknown> {
+  /**
+   * Dispatches an action. It is the only way to trigger a state change.
+   *
+   * The `reducer` function, used to create the store, will be called with the
+   * current state tree and the given `action`. Its return value will be
+   * considered the **next** state of the tree, and the change listeners will
+   * be notified.
+   *
+   * The base implementation only supports plain object actions. If you want
+   * to dispatch a Promise, an Observable, a thunk, or something else, you
+   * need to wrap your store creating function into the corresponding
+   * middleware. For example, see the documentation for the `redux-thunk`
+   * package. Even the middleware will eventually dispatch plain object
+   * actions using this method.
+   *
+   * @param action A plain object representing “what changed”. It is a good
+   *   idea to keep actions serializable so you can record and replay user
+   *   sessions, or use the time travelling `redux-devtools`. An action must
+   *   have a `type` property which may not be `undefined`. It is a good idea
+   *   to use string constants for action types.
+   *
+   * @returns For convenience, the same action object you dispatched.
+   *
+   * Note that, if you use a custom middleware, it may wrap `dispatch()` to
+   * return something else (for example, a Promise you can await).
+   */
+  dispatch: Dispatch<A>;
+  /**
+   * Reads the state tree managed by the store.
+   *
+   * @returns The current state tree of your application.
+   */
+  getState(): S & StateExt;
+  /**
+   * Adds a change listener. It will be called any time an action is
+   * dispatched, and some part of the state tree may potentially have changed.
+   * You may then call `getState()` to read the current state tree inside the
+   * callback.
+   *
+   * You may call `dispatch()` from a change listener, with the following
+   * caveats:
+   *
+   * 1. The subscriptions are snapshotted just before every `dispatch()` call.
+   * If you subscribe or unsubscribe while the listeners are being invoked,
+   * this will not have any effect on the `dispatch()` that is currently in
+   * progress. However, the next `dispatch()` call, whether nested or not,
+   * will use a more recent snapshot of the subscription list.
+   *
+   * 2. The listener should not expect to see all states changes, as the state
+   * might have been updated multiple times during a nested `dispatch()` before
+   * the listener is called. It is, however, guaranteed that all subscribers
+   * registered before the `dispatch()` started will be called with the latest
+   * state by the time it exits.
+   *
+   * @param listener A callback to be invoked on every dispatch.
+   * @returns A function to remove this change listener.
+   */
+  subscribe(listener: ListenerCallback): Unsubscribe;
+  /**
+   * Replaces the reducer currently used by the store to calculate the state.
+   *
+   * You might need this if your app implements code splitting and you want to
+   * load some of the reducers dynamically. You might also need this if you
+   * implement a hot reloading mechanism for Redux.
+   *
+   * @param nextReducer The reducer for the store to use instead.
+   */
+  replaceReducer(nextReducer: Reducer<S, A>): void;
+  /**
+   * Interoperability point for observable/reactive libraries.
+   * @returns {observable} A minimal observable of state changes.
+   * For more information, see the observable proposal:
+   * https://github.com/tc39/proposal-observable
+   */
+  [Symbol.observable](): Observable<S & StateExt>;
+}
+type UnknownIfNonSpecific<T> = {} extends T ? unknown : T;
+/**
+ * A store creator is a function that creates a Redux store. Like with
+ * dispatching function, we must distinguish the base store creator,
+ * `createStore(reducer, preloadedState)` exported from the Redux package, from
+ * store creators that are returned from the store enhancers.
+ *
+ * @template S The type of state to be held by the store.
+ * @template A The type of actions which may be dispatched.
+ * @template PreloadedState The initial state that is passed into the reducer.
+ * @template Ext Store extension that is mixed in to the Store type.
+ * @template StateExt State extension that is mixed into the state type.
+ */
+interface StoreCreator {
+  <S, A extends Action, Ext extends {} = {}, StateExt extends {} = {}>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<Ext, StateExt>,
+  ): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext;
+  <
+    S,
+    A extends Action,
+    Ext extends {} = {},
+    StateExt extends {} = {},
+    PreloadedState = S,
+  >(
+    reducer: Reducer<S, A, PreloadedState>,
+    preloadedState?: PreloadedState | undefined,
+    enhancer?: StoreEnhancer<Ext>,
+  ): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext;
+}
+/**
+ * A store enhancer is a higher-order function that composes a store creator
+ * to return a new, enhanced store creator. This is similar to middleware in
+ * that it allows you to alter the store interface in a composable way.
+ *
+ * Store enhancers are much the same concept as higher-order components in
+ * React, which are also occasionally called “component enhancers”.
+ *
+ * Because a store is not an instance, but rather a plain-object collection of
+ * functions, copies can be easily created and modified without mutating the
+ * original store. There is an example in `compose` documentation
+ * demonstrating that.
+ *
+ * Most likely you'll never write a store enhancer, but you may use the one
+ * provided by the developer tools. It is what makes time travel possible
+ * without the app being aware it is happening. Amusingly, the Redux
+ * middleware implementation is itself a store enhancer.
+ *
+ * @template Ext Store extension that is mixed into the Store type.
+ * @template StateExt State extension that is mixed into the state type.
+ */
+type StoreEnhancer<Ext extends {} = {}, StateExt extends {} = {}> = <
+  NextExt extends {},
+  NextStateExt extends {},
+>(
+  next: StoreEnhancerStoreCreator<NextExt, NextStateExt>,
+) => StoreEnhancerStoreCreator<NextExt & Ext, NextStateExt & StateExt>;
+type StoreEnhancerStoreCreator<
+  Ext extends {} = {},
+  StateExt extends {} = {},
+> = <S, A extends Action, PreloadedState>(
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | undefined,
+) => Store<S, A, StateExt> & Ext;
+
+declare function createStore<
+  S,
+  A extends Action,
+  Ext extends {} = {},
+  StateExt extends {} = {},
+>(
+  reducer: Reducer<S, A>,
+  enhancer?: StoreEnhancer<Ext, StateExt>,
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext;
+declare function createStore<
+  S,
+  A extends Action,
+  Ext extends {} = {},
+  StateExt extends {} = {},
+  PreloadedState = S,
+>(
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | undefined,
+  enhancer?: StoreEnhancer<Ext, StateExt>,
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext;
+/**
+ * Creates a Redux store that holds the state tree.
+ *
+ * **We recommend using `configureStore` from the
+ * `@reduxjs/toolkit` package**, which replaces `createStore`:
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
+ *
+ * The only way to change the data in the store is to call `dispatch()` on it.
+ *
+ * There should only be a single store in your app. To specify how different
+ * parts of the state tree respond to actions, you may combine several reducers
+ * into a single reducer function by using `combineReducers`.
+ *
+ * @param {Function} reducer A function that returns the next state tree, given
+ * the current state tree and the action to handle.
+ *
+ * @param {any} [preloadedState] The initial state. You may optionally specify it
+ * to hydrate the state from the server in universal apps, or to restore a
+ * previously serialized user session.
+ * If you use `combineReducers` to produce the root reducer function, this must be
+ * an object with the same shape as `combineReducers` keys.
+ *
+ * @param {Function} [enhancer] The store enhancer. You may optionally specify it
+ * to enhance the store with third-party capabilities such as middleware,
+ * time travel, persistence, etc. The only store enhancer that ships with Redux
+ * is `applyMiddleware()`.
+ *
+ * @returns {Store} A Redux store that lets you read the state, dispatch actions
+ * and subscribe to changes.
+ */
+declare function legacy_createStore<
+  S,
+  A extends Action,
+  Ext extends {} = {},
+  StateExt extends {} = {},
+>(
+  reducer: Reducer<S, A>,
+  enhancer?: StoreEnhancer<Ext, StateExt>,
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext;
+/**
+ * Creates a Redux store that holds the state tree.
+ *
+ * **We recommend using `configureStore` from the
+ * `@reduxjs/toolkit` package**, which replaces `createStore`:
+ * **https://redux.js.org/introduction/why-rtk-is-redux-today**
+ *
+ * The only way to change the data in the store is to call `dispatch()` on it.
+ *
+ * There should only be a single store in your app. To specify how different
+ * parts of the state tree respond to actions, you may combine several reducers
+ * into a single reducer function by using `combineReducers`.
+ *
+ * @param {Function} reducer A function that returns the next state tree, given
+ * the current state tree and the action to handle.
+ *
+ * @param {any} [preloadedState] The initial state. You may optionally specify it
+ * to hydrate the state from the server in universal apps, or to restore a
+ * previously serialized user session.
+ * If you use `combineReducers` to produce the root reducer function, this must be
+ * an object with the same shape as `combineReducers` keys.
+ *
+ * @param {Function} [enhancer] The store enhancer. You may optionally specify it
+ * to enhance the store with third-party capabilities such as middleware,
+ * time travel, persistence, etc. The only store enhancer that ships with Redux
+ * is `applyMiddleware()`.
+ *
+ * @returns {Store} A Redux store that lets you read the state, dispatch actions
+ * and subscribe to changes.
+ */
+declare function legacy_createStore<
+  S,
+  A extends Action,
+  Ext extends {} = {},
+  StateExt extends {} = {},
+  PreloadedState = S,
+>(
+  reducer: Reducer<S, A, PreloadedState>,
+  preloadedState?: PreloadedState | undefined,
+  enhancer?: StoreEnhancer<Ext, StateExt>,
+): Store<S, A, UnknownIfNonSpecific<StateExt>> & Ext;
+
+/**
+ * Turns an object whose values are different reducer functions, into a single
+ * reducer function. It will call every child reducer, and gather their results
+ * into a single state object, whose keys correspond to the keys of the passed
+ * reducer functions.
+ *
+ * @template S Combined state object type.
+ *
+ * @param reducers An object whose values correspond to different reducer
+ *   functions that need to be combined into one. One handy way to obtain it
+ *   is to use `import * as reducers` syntax. The reducers may never
+ *   return undefined for any action. Instead, they should return their
+ *   initial state if the state passed to them was undefined, and the current
+ *   state for any unrecognized action.
+ *
+ * @returns A reducer function that invokes every reducer inside the passed
+ *   object, and builds a state object with the same shape.
+ */
+declare function combineReducers<M>(
+  reducers: M,
+): M[keyof M] extends Reducer<any, any, any> | undefined ?
+  Reducer<
+    StateFromReducersMapObject<M>,
+    ActionFromReducersMapObject<M>,
+    Partial<PreloadedStateShapeFromReducersMapObject<M>>
+  >
+: never;
+
+/**
+ * Turns an object whose values are action creators, into an object with the
+ * same keys, but with every function wrapped into a `dispatch` call so they
+ * may be invoked directly. This is just a convenience method, as you can call
+ * `store.dispatch(MyActionCreators.doSomething())` yourself just fine.
+ *
+ * For convenience, you can also pass an action creator as the first argument,
+ * and get a dispatch wrapped function in return.
+ *
+ * @param actionCreators An object whose values are action
+ * creator functions. One handy way to obtain it is to use `import * as`
+ * syntax. You may also pass a single function.
+ *
+ * @param dispatch The `dispatch` function available on your Redux
+ * store.
+ *
+ * @returns The object mimicking the original object, but with
+ * every action creator wrapped into the `dispatch` call. If you passed a
+ * function as `actionCreators`, the return value will also be a single
+ * function.
+ */
+declare function bindActionCreators<A, C extends ActionCreator<A>>(
+  actionCreator: C,
+  dispatch: Dispatch,
+): C;
+declare function bindActionCreators<
+  A extends ActionCreator<any>,
+  B extends ActionCreator<any>,
+>(actionCreator: A, dispatch: Dispatch): B;
+declare function bindActionCreators<A, M extends ActionCreatorsMapObject<A>>(
+  actionCreators: M,
+  dispatch: Dispatch,
+): M;
+declare function bindActionCreators<
+  M extends ActionCreatorsMapObject,
+  N extends ActionCreatorsMapObject,
+>(actionCreators: M, dispatch: Dispatch): N;
+
+interface MiddlewareAPI<D extends Dispatch = Dispatch, S = any> {
+  dispatch: D;
+  getState(): S;
+}
+/**
+ * A middleware is a higher-order function that composes a dispatch function
+ * to return a new dispatch function. It often turns async actions into
+ * actions.
+ *
+ * Middleware is composable using function composition. It is useful for
+ * logging actions, performing side effects like routing, or turning an
+ * asynchronous API call into a series of synchronous actions.
+ *
+ * @template DispatchExt Extra Dispatch signature added by this middleware.
+ * @template S The type of the state supported by this middleware.
+ * @template D The type of Dispatch of the store where this middleware is
+ *   installed.
+ */
+interface Middleware<
+  _DispatchExt = {}, // TODO: see if this can be used in type definition somehow (can't be removed, as is used to get final dispatch type)
+  S = any,
+  D extends Dispatch = Dispatch,
+> {
+  (
+    api: MiddlewareAPI<D, S>,
+  ): (next: (action: unknown) => unknown) => (action: unknown) => unknown;
+}
+
+/**
+ * Creates a store enhancer that applies middleware to the dispatch method
+ * of the Redux store. This is handy for a variety of tasks, such as expressing
+ * asynchronous actions in a concise manner, or logging every action payload.
+ *
+ * See `redux-thunk` package as an example of the Redux middleware.
+ *
+ * Because middleware is potentially asynchronous, this should be the first
+ * store enhancer in the composition chain.
+ *
+ * Note that each middleware will be given the `dispatch` and `getState` functions
+ * as named arguments.
+ *
+ * @param middlewares The middleware chain to be applied.
+ * @returns A store enhancer applying the middleware.
+ *
+ * @template Ext Dispatch signature added by a middleware.
+ * @template S The type of the state supported by a middleware.
+ */
+declare function applyMiddleware(): StoreEnhancer;
+declare function applyMiddleware<Ext1, S>(
+  middleware1: Middleware<Ext1, S, any>,
+): StoreEnhancer<{
+  dispatch: Ext1;
+}>;
+declare function applyMiddleware<Ext1, Ext2, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>,
+): StoreEnhancer<{
+  dispatch: Ext1 & Ext2;
+}>;
+declare function applyMiddleware<Ext1, Ext2, Ext3, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>,
+  middleware3: Middleware<Ext3, S, any>,
+): StoreEnhancer<{
+  dispatch: Ext1 & Ext2 & Ext3;
+}>;
+declare function applyMiddleware<Ext1, Ext2, Ext3, Ext4, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>,
+  middleware3: Middleware<Ext3, S, any>,
+  middleware4: Middleware<Ext4, S, any>,
+): StoreEnhancer<{
+  dispatch: Ext1 & Ext2 & Ext3 & Ext4;
+}>;
+declare function applyMiddleware<Ext1, Ext2, Ext3, Ext4, Ext5, S>(
+  middleware1: Middleware<Ext1, S, any>,
+  middleware2: Middleware<Ext2, S, any>,
+  middleware3: Middleware<Ext3, S, any>,
+  middleware4: Middleware<Ext4, S, any>,
+  middleware5: Middleware<Ext5, S, any>,
+): StoreEnhancer<{
+  dispatch: Ext1 & Ext2 & Ext3 & Ext4 & Ext5;
+}>;
+declare function applyMiddleware<Ext, S = any>(
+  ...middlewares: Middleware<any, S, any>[]
+): StoreEnhancer<{
+  dispatch: Ext;
+}>;
+
+type Func<T extends any[], R> = (...a: T) => R;
+/**
+ * Composes single-argument functions from right to left. The rightmost
+ * function can take multiple arguments as it provides the signature for the
+ * resulting composite function.
+ *
+ * @param funcs The functions to compose.
+ * @returns A function obtained by composing the argument functions from right
+ *   to left. For example, `compose(f, g, h)` is identical to doing
+ *   `(...args) => f(g(h(...args)))`.
+ */
+declare function compose(): <R>(a: R) => R;
+declare function compose<F extends (...args: any) => any>(f: F): F;
+declare function compose<A, T extends any[], R>(
+  f1: (a: A) => R,
+  f2: Func<T, A>,
+): Func<T, R>;
+declare function compose<A, B, T extends any[], R>(
+  f1: (b: B) => R,
+  f2: (a: A) => B,
+  f3: Func<T, A>,
+): Func<T, R>;
+declare function compose<A, B, C, T extends any[], R>(
+  f1: (c: C) => R,
+  f2: (b: B) => C,
+  f3: (a: A) => B,
+  f4: Func<T, A>,
+): Func<T, R>;
+declare function compose<R>(
+  f1: (a: any) => R,
+  ...funcs: ((...args: any) => any)[]
+): (...args: any[]) => R;
+declare function compose<R>(
+  ...funcs: ((...args: any) => any)[]
+): (...args: any[]) => R;
+
+declare function isAction(action: unknown): action is Action<string>;
+
+/**
+ * @param obj The object to inspect.
+ * @returns True if the argument appears to be a plain object.
+ */
+declare function isPlainObject(obj: any): obj is object;
+
+/**
+ * These are private action types reserved by Redux.
+ * For any unknown actions, you must return the current state.
+ * If the current state is undefined, you must return the initial state.
+ * Do not reference these action types directly in your code.
+ */
+declare const ActionTypes: {
+  INIT: string;
+  REPLACE: string;
+  PROBE_UNKNOWN_ACTION: () => string;
+};
+
+export {
+  Action,
+  ActionCreator,
+  ActionCreatorsMapObject,
+  ActionFromReducer,
+  ActionFromReducersMapObject,
+  AnyAction,
+  Dispatch,
+  Middleware,
+  MiddlewareAPI,
+  Observable,
+  Observer,
+  PreloadedStateShapeFromReducersMapObject,
+  Reducer,
+  ReducerFromReducersMapObject,
+  ReducersMapObject,
+  StateFromReducersMapObject,
+  Store,
+  StoreCreator,
+  StoreEnhancer,
+  StoreEnhancerStoreCreator,
+  UnknownAction,
+  Unsubscribe,
+  ActionTypes as __DO_NOT_USE__ActionTypes,
+  applyMiddleware,
+  createStore,
+  isAction,
+  isPlainObject,
+};

--- a/packages/react/src/server/redux/redux.js
+++ b/packages/react/src/server/redux/redux.js
@@ -1,0 +1,334 @@
+// src/utils/formatProdErrorMessage.ts
+function formatProdErrorMessage(code) {
+  return `Minified Redux error #${code}; visit https://redux.js.org/Errors?code=${code} for the full message or use the non-minified dev environment for full errors. `;
+}
+
+// src/utils/symbol-observable.ts
+var $$observable = /* @__PURE__ */ (() =>
+  (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();
+var symbol_observable_default = $$observable;
+
+// src/utils/actionTypes.ts
+var randomString = () =>
+  Math.random().toString(36).substring(7).split('').join('.');
+var ActionTypes = {
+  INIT: `@@redux/INIT${/* @__PURE__ */ randomString()}`,
+  REPLACE: `@@redux/REPLACE${/* @__PURE__ */ randomString()}`,
+  PROBE_UNKNOWN_ACTION: () => `@@redux/PROBE_UNKNOWN_ACTION${randomString()}`,
+};
+var actionTypes_default = ActionTypes;
+
+// src/utils/isPlainObject.ts
+function isPlainObject(obj) {
+  if (typeof obj !== 'object' || obj === null) return false;
+  let proto = obj;
+  while (Object.getPrototypeOf(proto) !== null) {
+    proto = Object.getPrototypeOf(proto);
+  }
+  return (
+    Object.getPrototypeOf(obj) === proto || Object.getPrototypeOf(obj) === null
+  );
+}
+
+// src/utils/kindOf.ts
+function miniKindOf(val) {
+  if (val === void 0) return 'undefined';
+  if (val === null) return 'null';
+  const type = typeof val;
+  switch (type) {
+    case 'boolean':
+    case 'string':
+    case 'number':
+    case 'symbol':
+    case 'function': {
+      return type;
+    }
+  }
+  if (Array.isArray(val)) return 'array';
+  if (isDate(val)) return 'date';
+  if (isError(val)) return 'error';
+  const constructorName = ctorName(val);
+  switch (constructorName) {
+    case 'Symbol':
+    case 'Promise':
+    case 'WeakMap':
+    case 'WeakSet':
+    case 'Map':
+    case 'Set':
+      return constructorName;
+  }
+  return Object.prototype.toString
+    .call(val)
+    .slice(8, -1)
+    .toLowerCase()
+    .replace(/\s/g, '');
+}
+function ctorName(val) {
+  return typeof val.constructor === 'function' ? val.constructor.name : null;
+}
+function isError(val) {
+  return (
+    val instanceof Error ||
+    (typeof val.message === 'string' &&
+      val.constructor &&
+      typeof val.constructor.stackTraceLimit === 'number')
+  );
+}
+function isDate(val) {
+  if (val instanceof Date) return true;
+  return (
+    typeof val.toDateString === 'function' &&
+    typeof val.getDate === 'function' &&
+    typeof val.setDate === 'function'
+  );
+}
+function kindOf(val) {
+  let typeOfVal = typeof val;
+  if (process.env.NODE_ENV !== 'production') {
+    typeOfVal = miniKindOf(val);
+  }
+  return typeOfVal;
+}
+
+// src/createStore.ts
+function createStore(reducer, preloadedState, enhancer) {
+  if (typeof reducer !== 'function') {
+    throw new Error(
+      process.env.NODE_ENV === 'production' ?
+        formatProdErrorMessage(2)
+      : `Expected the root reducer to be a function. Instead, received: '${kindOf(reducer)}'`,
+    );
+  }
+  if (
+    (typeof preloadedState === 'function' && typeof enhancer === 'function') ||
+    (typeof enhancer === 'function' && typeof arguments[3] === 'function')
+  ) {
+    throw new Error(
+      process.env.NODE_ENV === 'production' ?
+        formatProdErrorMessage(0)
+      : 'It looks like you are passing several store enhancers to createStore(). This is not supported. Instead, compose them together to a single function. See https://redux.js.org/tutorials/fundamentals/part-4-store#creating-a-store-with-enhancers for an example.',
+    );
+  }
+  if (typeof preloadedState === 'function' && typeof enhancer === 'undefined') {
+    enhancer = preloadedState;
+    preloadedState = void 0;
+  }
+  if (typeof enhancer !== 'undefined') {
+    if (typeof enhancer !== 'function') {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(1)
+        : `Expected the enhancer to be a function. Instead, received: '${kindOf(enhancer)}'`,
+      );
+    }
+    return enhancer(createStore)(reducer, preloadedState);
+  }
+  let currentReducer = reducer;
+  let currentState = preloadedState;
+  let currentListeners = /* @__PURE__ */ new Map();
+  let nextListeners = currentListeners;
+  let listenerIdCounter = 0;
+  let isDispatching = false;
+  function ensureCanMutateNextListeners() {
+    if (nextListeners === currentListeners) {
+      nextListeners = /* @__PURE__ */ new Map();
+      currentListeners.forEach((listener, key) => {
+        nextListeners.set(key, listener);
+      });
+    }
+  }
+  function getState() {
+    if (isDispatching) {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(3)
+        : 'You may not call store.getState() while the reducer is executing. The reducer has already received the state as an argument. Pass it down from the top reducer instead of reading it from the store.',
+      );
+    }
+    return currentState;
+  }
+  function subscribe(listener) {
+    if (typeof listener !== 'function') {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(4)
+        : `Expected the listener to be a function. Instead, received: '${kindOf(listener)}'`,
+      );
+    }
+    if (isDispatching) {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(5)
+        : 'You may not call store.subscribe() while the reducer is executing. If you would like to be notified after the store has been updated, subscribe from a component and invoke store.getState() in the callback to access the latest state. See https://redux.js.org/api/store#subscribelistener for more details.',
+      );
+    }
+    let isSubscribed = true;
+    ensureCanMutateNextListeners();
+    const listenerId = listenerIdCounter++;
+    nextListeners.set(listenerId, listener);
+    return function unsubscribe() {
+      if (!isSubscribed) {
+        return;
+      }
+      if (isDispatching) {
+        throw new Error(
+          process.env.NODE_ENV === 'production' ?
+            formatProdErrorMessage(6)
+          : 'You may not unsubscribe from a store listener while the reducer is executing. See https://redux.js.org/api/store#subscribelistener for more details.',
+        );
+      }
+      isSubscribed = false;
+      ensureCanMutateNextListeners();
+      nextListeners.delete(listenerId);
+      currentListeners = null;
+    };
+  }
+  function dispatch(action) {
+    if (!isPlainObject(action)) {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(7)
+        : `Actions must be plain objects. Instead, the actual type was: '${kindOf(action)}'. You may need to add middleware to your store setup to handle dispatching other values, such as 'redux-thunk' to handle dispatching functions. See https://redux.js.org/tutorials/fundamentals/part-4-store#middleware and https://redux.js.org/tutorials/fundamentals/part-6-async-logic#using-the-redux-thunk-middleware for examples.`,
+      );
+    }
+    if (typeof action.type === 'undefined') {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(8)
+        : 'Actions may not have an undefined "type" property. You may have misspelled an action type string constant.',
+      );
+    }
+    if (typeof action.type !== 'string') {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(17)
+        : `Action "type" property must be a string. Instead, the actual type was: '${kindOf(action.type)}'. Value was: '${action.type}' (stringified)`,
+      );
+    }
+    if (isDispatching) {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(9)
+        : 'Reducers may not dispatch actions.',
+      );
+    }
+    try {
+      isDispatching = true;
+      currentState = currentReducer(currentState, action);
+    } finally {
+      isDispatching = false;
+    }
+    const listeners = (currentListeners = nextListeners);
+    listeners.forEach(listener => {
+      listener();
+    });
+    return action;
+  }
+  function replaceReducer(nextReducer) {
+    if (typeof nextReducer !== 'function') {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(10)
+        : `Expected the nextReducer to be a function. Instead, received: '${kindOf(nextReducer)}`,
+      );
+    }
+    currentReducer = nextReducer;
+    dispatch({
+      type: actionTypes_default.REPLACE,
+    });
+  }
+  function observable() {
+    const outerSubscribe = subscribe;
+    return {
+      /**
+       * The minimal observable subscription method.
+       * @param observer Any object that can be used as an observer.
+       * The observer object should have a `next` method.
+       * @returns An object with an `unsubscribe` method that can
+       * be used to unsubscribe the observable from the store, and prevent further
+       * emission of values from the observable.
+       */
+      subscribe(observer) {
+        if (typeof observer !== 'object' || observer === null) {
+          throw new Error(
+            process.env.NODE_ENV === 'production' ?
+              formatProdErrorMessage(11)
+            : `Expected the observer to be an object. Instead, received: '${kindOf(observer)}'`,
+          );
+        }
+        function observeState() {
+          const observerAsObserver = observer;
+          if (observerAsObserver.next) {
+            observerAsObserver.next(getState());
+          }
+        }
+        observeState();
+        const unsubscribe = outerSubscribe(observeState);
+        return {
+          unsubscribe,
+        };
+      },
+      [symbol_observable_default]() {
+        return this;
+      },
+    };
+  }
+  dispatch({
+    type: actionTypes_default.INIT,
+  });
+  const store = {
+    dispatch,
+    subscribe,
+    getState,
+    replaceReducer,
+    [symbol_observable_default]: observable,
+  };
+  return store;
+}
+
+// src/compose.ts
+function compose(...funcs) {
+  if (funcs.length === 0) {
+    return arg => arg;
+  }
+  if (funcs.length === 1) {
+    return funcs[0];
+  }
+  return funcs.reduce(
+    (a, b) =>
+      (...args) =>
+        a(b(...args)),
+  );
+}
+
+// src/applyMiddleware.ts
+function applyMiddleware(...middlewares) {
+  return createStore2 => (reducer, preloadedState) => {
+    const store = createStore2(reducer, preloadedState);
+    let dispatch = () => {
+      throw new Error(
+        process.env.NODE_ENV === 'production' ?
+          formatProdErrorMessage(15)
+        : 'Dispatching while constructing your middleware is not allowed. Other middleware would not be applied to this dispatch.',
+      );
+    };
+    const middlewareAPI = {
+      getState: store.getState,
+      dispatch: (action, ...args) => dispatch(action, ...args),
+    };
+    const chain = middlewares.map(middleware => middleware(middlewareAPI));
+    dispatch = compose(...chain)(store.dispatch);
+    return {
+      ...store,
+      dispatch,
+    };
+  };
+}
+
+// src/utils/isAction.ts
+function isAction(action) {
+  return (
+    isPlainObject(action) && 'type' in action && typeof action.type === 'string'
+  );
+}
+export { applyMiddleware, createStore, isAction, isPlainObject };

--- a/scripts/copywebsitetypes.sh
+++ b/scripts/copywebsitetypes.sh
@@ -11,6 +11,7 @@ mkdir -p ./website/src/components/Playground/editor-types/@data-client/react
 cp ./packages/rest/next.d.ts ./website/src/components/Playground/editor-types/@data-client/rest/next.d.ts
 cp ./packages/core/next.d.ts ./website/src/components/Playground/editor-types/@data-client/core/next.d.ts
 cp ./packages/react/next.d.ts ./website/src/components/Playground/editor-types/@data-client/react/next.d.ts
+cp ./packages/react/nextjs.d.ts ./website/src/components/Playground/editor-types/@data-client/react/nextjs.d.ts
 cp ./node_modules/@types/react/index.d.ts ./website/src/components/Playground/editor-types/react.d.ts
 rm ./website/src/components/Playground/editor-types/globals.d.ts
 yarn run rollup --config ./scripts/globals.rollup.config.js

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -4,7 +4,7 @@ export { AbstractInstanceType, ActionTypes, Controller, DataClientDispatch, Defa
 import * as react_jsx_runtime from 'react/jsx-runtime';
 import React$1, { JSX, Context } from 'react';
 
-declare function Loading(): react_jsx_runtime.JSX.Element;
+declare function BackupLoading(): react_jsx_runtime.JSX.Element;
 
 type DevToolsPosition = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
 
@@ -233,4 +233,4 @@ declare namespace internal_d {
 /** Turns a dispatch function into one that resolves once its been commited */
 declare function usePromisifiedDispatch<R extends React$1.Reducer<any, any>>(dispatch: React$1.Dispatch<React$1.ReducerAction<R>>, state: React$1.ReducerState<R>): (action: React$1.ReducerAction<R>) => Promise<void>;
 
-export { _default as AsyncBoundary, Loading as BackupLoading, CacheProvider, ControllerContext, DevToolsPosition, ErrorBoundary, ErrorBoundary as NetworkErrorBoundary, ProviderProps, StateContext, Store, StoreContext, UniversalSuspense, internal_d as __INTERNAL__, getDefaultManagers, useCache, useController, useDLE, useError, useFetch, useLive, usePromisifiedDispatch, useQuery, useSubscription, useSuspense };
+export { _default as AsyncBoundary, BackupLoading, CacheProvider, ControllerContext, DevToolsPosition, ErrorBoundary, ErrorBoundary as NetworkErrorBoundary, ProviderProps, StateContext, Store, StoreContext, UniversalSuspense, internal_d as __INTERNAL__, getDefaultManagers, useCache, useController, useDLE, useError, useFetch, useLive, usePromisifiedDispatch, useQuery, useSubscription, useSuspense };

--- a/website/src/components/Playground/editor-types/@data-client/react/nextjs.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react/nextjs.d.ts
@@ -1,0 +1,24 @@
+import React$1, { JSX, ComponentProps } from 'react';
+import { Manager, State, Controller } from '@data-client/core';
+
+type DevToolsPosition = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
+
+interface Props {
+    children: React$1.ReactNode;
+    managers?: Manager[];
+    initialState?: State<unknown>;
+    Controller?: typeof Controller;
+    devButton?: DevToolsPosition | null | undefined;
+}
+/**
+ * Manages state, providing all context needed to use the hooks.
+ * @see https://dataclient.io/docs/api/CacheProvider
+ */
+declare function CacheProvider({ children, managers, initialState, Controller, devButton, }: Props): JSX.Element;
+
+declare function DataProvider({ children, ...props }: ProviderProps): React.ReactElement;
+type ProviderProps = Omit<Partial<ComponentProps<typeof CacheProvider>>, 'initialState'> & {
+    children: React.ReactNode;
+};
+
+export { DataProvider };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simpler installs - no longer need multiple extra packages

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```tsx
import { DataProvider } from '@data-client/react/nextjs';

export default function RootLayout({ children }) {
  return (
    <html>
      <body>
        <DataProvider>
          {children}
        </DataProvider>
      </body>
    </html>
  );
}
```

- We now bundle in the redux specific things to remove external dependencies.