### PR TITLE
fix: React Native specific module bundler issues

### DIFF
--- a/.changeset/weak-timers-joke.md
+++ b/.changeset/weak-timers-joke.md
@@ -1,0 +1,10 @@
+---
+'@data-client/react': patch
+---
+
+Fix React Native use correct native specific modules
+
+Fully realized path names (including .js at end of import)
+was breaking [platform specific extensions](https://docs.expo.dev/router/advanced/platform-specific-modules/#platform-specific-extensions). To workaround this issue, we
+simply create a custom react-native build that remaps any
+imports with full extension written ("file.native.js")

--- a/babel.config.js
+++ b/babel.config.js
@@ -43,7 +43,7 @@ module.exports = function (api) {
                     resolved + ext,
                   );
                   if (fs.existsSync(absolutePath)) {
-                    return resolved;
+                    return resolved + path.extname(sourcePath);
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "ignorePatterns": [
       "**/lib*/*",
       "**/dist*/*",
+      "packages/*/native/*",
       "**/node_modules*/*",
       "node_modules/*"
     ]

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,6 +1,7 @@
 /lib
 /dist
 /legacy
+/native
 /index.d.ts
 /next.d.ts
 /nextjs.d.ts

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,10 +52,11 @@
     "mutations"
   ],
   "sideEffects": [
-    "./lib/hooks/useFocusEffect.native.js"
+    "./lib/hooks/useFocusEffect.native.js",
+    "./native/hooks/useFocusEffect.native.js"
   ],
   "main": "dist/index.js",
-  "react-native": "legacy/index.js",
+  "react-native": "native/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
@@ -103,11 +104,15 @@
       "module": "./lib/index.js",
       "import": "./node.mjs",
       "require": "./dist/index.js",
+      "browser": "./lib/index.js",
+      "react-native": "./native/index.js",
       "default": "./lib/index.js"
     },
     "./next": {
       "types": "./lib/next/index.d.ts",
       "require": "./dist/next.js",
+      "browser": "./lib/next/index.js",
+      "react-native": "./native/next/index.js",
       "default": "./lib/next/index.js"
     },
     "./nextjs": {
@@ -122,6 +127,8 @@
     "./redux": {
       "types": "./lib/server/redux/index.d.ts",
       "require": "./dist/server/redux/index.js",
+      "browser": "./lib/server/redux/index.js",
+      "react-native": "./native/server/redux/index.js",
       "default": "./lib/server/redux/index.js"
     },
     "./package.json": "./package.json"
@@ -134,9 +141,10 @@
     "src",
     "dist",
     "lib",
+    "legacy",
+    "native",
     "ts3.4",
     "node.mjs",
-    "legacy",
     "LICENSE",
     "README.md",
     "./data_client_logo_and_text.svg",
@@ -145,12 +153,13 @@
   "scripts": {
     "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
     "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
+    "build:native:lib": "COMPILE_TARGET=native NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir native",
     "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
     "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
     "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
     "build:clean": "yarn g:clean ./index.d.ts",
     "build:legacy-types": "yarn g:downtypes lib ts3.4",
-    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "build": "run build:lib && run build:legacy:lib && run build:native:lib && run build:bundle",
     "dev": "run build:lib -w",
     "prepare": "run build:lib",
     "prepack": "run prepare && run build:legacy:lib && run build:bundle"


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #3079 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
React Native [platform specific extensions](https://docs.expo.dev/router/advanced/platform-specific-modules/#platform-specific-extensions) was previously not working, resulting in the browser version of modules being used.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Explicit extension names (".js") in imports are required for modern node ESM support. However, this breaks the metro bundler as it gets confused and doesn't look for .native.js. To workaround we introduce custom react native builds.

The builds are referenced in ['community condition' for package exports "react-native"](https://reactnative.dev/blog/2023/06/21/package-exports-support). We also have the "react-native" field for legacy versions. (equivalent to "main").

It is critical to add "browser" condition anywhere "react-native" condition is used, so react-native-web can be supported.