### PR TITLE
docs: Improve site metadata for SEO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ typings/
 
 # build info
 **/tsconfig*.tsbuildinfo
+
+/codemods/

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -1,6 +1,7 @@
 ---
-title: The Reactive Data Client
+title: Introducing the Reactive Data Client
 sidebar_label: Introduction
+description: Building delightful dynamic applications with NextJS, Expo, React Native and more.
 slug: /
 ---
 
@@ -14,10 +15,10 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import Link from '@docusaurus/Link';
 
 <head>
-  <title>Introducing the Reactive Data Client</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 
+# The Reactive Data Client
 
 Reactive Data Client provides safe and performant [client access](./api/useSuspense.md) and [mutation](./api/Controller.md#fetch) over [remote data protocols](https://www.freecodecamp.org/news/what-is-an-api-in-english-please-b880a3214a82/).
 Both pull/fetch ([REST](/rest) and [GraphQL](/graphql)) and push/stream ([WebSockets or Server Sent Events](./api/Manager.md#data-stream)) can be used simultaneously.

--- a/docs/core/api/AsyncBoundary.md
+++ b/docs/core/api/AsyncBoundary.md
@@ -1,11 +1,14 @@
 ---
-title: '<AsyncBoundary />'
+title: AsyncBoundary - Centralize loading and error handling
+sidebar_label: <AsyncBoundary />
+description: Handles loading and error conditions of Suspense.
 ---
 
 <head>
-  <title>AsyncBoundary - Centralize loading and error handling</title>
   <meta name="docsearch:pagerank" content="20"/>
 </head>
+
+# &lt;AsyncBoundary />
 
 Handles loading and error conditions of Suspense.
 

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -1,9 +1,9 @@
 ---
-title: Controller
+title: Controller - Typesafe imperative store access
+sidebar_label: Controller
 ---
 
 <head>
-  <title>Controller - Typesafe imperative store access</title>
   <meta name="docsearch:pagerank" content="30"/>
 </head>
 
@@ -11,6 +11,8 @@ import LanguageTabs from '@site/src/components/LanguageTabs';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import StackBlitz from '@site/src/components/StackBlitz';
+
+# Controller
 
 `Controller` is a singleton providing safe access to the Reactive Data Client [flux store and lifecycle](./Manager.md#control-flow).
 `Controller` memoizes all store access, allowing a global referential equality guarantee and the fastest rendering

--- a/docs/core/api/DataProvider.md
+++ b/docs/core/api/DataProvider.md
@@ -1,14 +1,14 @@
 ---
-title: '<DataProvider />'
+title: DataProvider - Normalized async data management in React
+sidebar_label: <DataProvider />
+description: High performance, globally consistent data management in React
 ---
-
-<head>
-  <title>DataProvider - Normalized async data management in React</title>
-</head>
 
 import Installation from '../shared/\_installation.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
+# &lt;DataProvider />
 
 Manages state, providing all context needed to use the hooks. Should be placed as high as possible
 in application tree as any usage of the hooks is only possible for components below the provider

--- a/docs/core/api/Fixtures.md
+++ b/docs/core/api/Fixtures.md
@@ -1,13 +1,12 @@
 ---
-title: Fixtures and Interceptors
+title: 'Fixtures and Interceptors: declarative data mocking for tests and stories'
 sidebar_label: Fixtures and Interceptors
+description: Fixtures and Interceptors allow universal data mocking without the need for monkeypatching fetch behaviors.
 ---
 
-<head>
-  <title>Fixtures and Interceptors: declarative data mocking for tests and stories</title>
-</head>
-
 import GenericsTabs from '@site/src/components/GenericsTabs';
+
+# Fixtures and Interceptors
 
 Fixtures and Interceptors allow universal data mocking without the need for monkeypatching
 fetch behaviors. Fixtures define static responses to specific endpoint arg combinations. This

--- a/docs/core/api/LogoutManager.md
+++ b/docs/core/api/LogoutManager.md
@@ -1,5 +1,5 @@
 ---
-title: 'LogoutManager'
+title: LogoutManager - Handling 401s and other deauthorization triggers
 sidebar_label: LogoutManager
 ---
 
@@ -7,9 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import StackBlitz from '@site/src/components/StackBlitz';
 
-<head>
-  <title>LogoutManager - Handling 401s and other deauthorization triggers</title>
-</head>
+# LogoutManager
 
 Logs out based on fetch responses. By default this is triggered by [401 (Unauthorized)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) status responses.
 

--- a/docs/core/api/Manager.md
+++ b/docs/core/api/Manager.md
@@ -1,5 +1,6 @@
 ---
-title: Manager
+title: Manager - Powerful middlewares with global store knowledge
+sidebar_label: Manager
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,9 +9,10 @@ import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 <head>
-  <title>Manager - Powerful middlewares with global store knowledge</title>
   <meta name="docsearch:pagerank" content="20"/>
 </head>
+
+# Manager
 
 Managers are singletons that orchestrate the complex asynchronous behavior of `Reactive Data Client`.
 Several managers are provided by `Reactive Data Client` and used by default; however there is nothing

--- a/docs/core/api/MockResolver.md
+++ b/docs/core/api/MockResolver.md
@@ -1,10 +1,9 @@
 ---
-title: '<MockResolver />'
+title: MockResolver - Data Mocking for React
+sidebar_label: <MockResolver />
 ---
 
-<head>
-  <title>MockResolver - Data Mocking for React</title>
-</head>
+# &lt;MockResolver />
 
 ```typescript
 function MockResolver<T>(props: {

--- a/docs/core/api/NetworkManager.md
+++ b/docs/core/api/NetworkManager.md
@@ -1,12 +1,9 @@
 ---
-title: NetworkManager
+title: NetworkManager - Orchestrating efficient race-condition free fetching
 sidebar_label: NetworkManager
 ---
 
-<head>
-  <title>NetworkManager - Orchestrating efficient race-condition free fetching</title>
-</head>
-
+# NetworkManager
 
 NetworkManager orchestrates asynchronous fetches. By keeping track of all in-flight requests
 it is able to dedupe identical requests if they are made using the throttle flag.

--- a/docs/core/api/Snapshot.md
+++ b/docs/core/api/Snapshot.md
@@ -1,10 +1,9 @@
 ---
-title: Snapshot
+title: Snapshot - Safe data access with zero race conditions
+sidebar_label: Snapshot
 ---
 
-<head>
-  <title>Snapshot - Safe data access with zero race conditions</title>
-</head>
+# Snapshot
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/core/api/useCache.md
+++ b/docs/core/api/useCache.md
@@ -1,16 +1,16 @@
 ---
-title: useCache()
+title: useCache() - Normalized data store access in React
+sidebar_label: useCache()
+description: Data rendering without the fetch. Access any Endpoint's response.
 ---
-
-<head>
-  <title>useCache() - Normalized data store access in React</title>
-</head>
 
 import GenericsTabs from '@site/src/components/GenericsTabs';
 import ConditionalDependencies from '../shared/\_conditional_dependencies.mdx';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import StackBlitz from '@site/src/components/StackBlitz';
 import { RestEndpoint } from '@data-client/rest';
+
+# useCache()
 
 Data rendering without the fetch.
 

--- a/docs/core/api/useCancelling.md
+++ b/docs/core/api/useCancelling.md
@@ -1,14 +1,14 @@
 ---
-title: useCancelling()
+title: useCancelling() - Declarative fetch aborting for React
+sidebar_label: useCancelling()
+description: Builds an Endpoint that cancels fetch everytime parameters change. Aborts inflight request on param change.
 ---
 
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import PkgInstall from '@site/src/components/PkgInstall';
 import UseCancelling from '../shared/\_useCancelling.mdx';
 
-<head>
-  <title>useCancelling() - Declarative fetch aborting for React</title>
-</head>
+# useCancelling()
 
 Builds an Endpoint that cancels fetch everytime parameters change
 

--- a/docs/core/api/useController.md
+++ b/docs/core/api/useController.md
@@ -1,14 +1,17 @@
 ---
-title: useController()
+title: useController() - Type safe store manipulation in React
+sidebar_label: useController()
+description: Controller provides type-safe methods to access and dispatch actions to the store.
 ---
 
 <head>
-  <title>useController() - Type safe store manipulation in React</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 import StackBlitz from '@site/src/components/StackBlitz';
+
+# useController()
 
 [Controller](./Controller.md) provides type-safe methods to access and dispatch actions to the store.
 

--- a/docs/core/api/useDLE.md
+++ b/docs/core/api/useDLE.md
@@ -1,6 +1,7 @@
 ---
-title: useDLE() - [D]ata [L]oading [E]rror
+title: useDLE() - [D]ata [L]oading [E]rror React State
 sidebar_label: useDLE()
+description: High performance async data rendering without overfetching. With fetch meta data.
 ---
 
 import HooksPlayground from '@site/src/components/HooksPlayground';
@@ -12,9 +13,7 @@ import ConditionalDependencies from '../shared/\_conditional_dependencies.mdx';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 import StackBlitz from '@site/src/components/StackBlitz';
 
-<head>
-  <title>useDLE() - [D]ata [L]oading [E]rror React State</title>
-</head>
+# useDLE() - [D]ata [L]oading [E]rror
 
 High performance async data rendering without overfetching. With fetch meta data.
 

--- a/docs/core/api/useDebounce.md
+++ b/docs/core/api/useDebounce.md
@@ -1,13 +1,13 @@
 ---
-title: useDebounce()
+title: useDebounce() - Declarative value delays for React
+sidebar_label: useDebounce()
+description: Delays updating the parameters by debouncing. Avoid excessive network requests due to quick parameter changes like typeaheads.
 ---
 
 import PkgInstall from '@site/src/components/PkgInstall';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 
-<head>
-  <title>useDebounce() - Declarative value delays for React</title>
-</head>
+# useDebounce()
 
 Delays updating the parameters by [debouncing](https://css-tricks.com/debouncing-throttling-explained-examples/).
 

--- a/docs/core/api/useError.md
+++ b/docs/core/api/useError.md
@@ -1,10 +1,9 @@
 ---
-title: useError()
+title: useError() - Accessing error metadata
+sidebar_label: useError()
 ---
 
-<head>
-  <title>useError() - Accessing error metadata</title>
-</head>
+# useError()
 
 ```typescript
 export interface SyntheticError extends Error {

--- a/docs/core/api/useFetch.md
+++ b/docs/core/api/useFetch.md
@@ -1,14 +1,17 @@
 ---
-title: useFetch()
+title: useFetch() - Declarative fetch triggers for React
+sidebar_label: useFetch()
+description: Fetch without the data rendering. Prevent fetch waterfalls by prefetching without duplicate requests.
 ---
 
 import GenericsTabs from '@site/src/components/GenericsTabs';
 import ConditionalDependencies from '../shared/\_conditional_dependencies.mdx';
 
 <head>
-  <title>useFetch() - Declarative fetch triggers for React</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
+
+# useFetch()
 
 Fetch without the data rendering.
 

--- a/docs/core/api/useLive.md
+++ b/docs/core/api/useLive.md
@@ -1,9 +1,10 @@
 ---
-title: useLive()
+title: useLive() - Rendering dynamic data in React
+sidebar_label: useLive()
+description: Async rendering of remotely triggered data mutations. useSuspense() + useSubscription() in one hook.
 ---
 
 <head>
-  <title>useLive() - Rendering dynamic data in React</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 
@@ -13,6 +14,8 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import {RestEndpoint} from '@data-client/rest';
 import StackBlitz from '@site/src/components/StackBlitz';
 import UseLive from '../shared/\_useLive.mdx';
+
+# useLive()
 
 Async rendering of remotely triggered data mutations.
 

--- a/docs/core/api/useLoading.md
+++ b/docs/core/api/useLoading.md
@@ -1,14 +1,14 @@
 ---
-title: useLoading()
+title: useLoading() - Turn any promise into React State
+sidebar_label: useLoading()
+description: Track loading and error state of any async function.
 ---
 
 import UseLoading from '../shared/\_useLoading.mdx';
 import PkgInstall from '@site/src/components/PkgInstall';
 import StackBlitz from '@site/src/components/StackBlitz';
 
-<head>
-  <title>useLoading() - Turn any promise into React State</title>
-</head>
+# useLoading()
 
 Helps track loading state of imperative async functions.
 

--- a/docs/core/api/useQuery.md
+++ b/docs/core/api/useQuery.md
@@ -1,10 +1,8 @@
 ---
-title: useQuery()
+title: useQuery() - Normalized data store access in React
+sidebar_label: useQuery()
+description: Data rendering without the fetch. Access any Schema's memoized store value.
 ---
-
-<head>
-  <title>useQuery() - Normalized data store access in React</title>
-</head>
 
 import GenericsTabs from '@site/src/components/GenericsTabs';
 import ConditionalDependencies from '../shared/\_conditional_dependencies.mdx';
@@ -12,6 +10,8 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import StackBlitz from '@site/src/components/StackBlitz';
 import { RestEndpoint } from '@data-client/rest';
 import VoteDemo from '../shared/\_VoteDemo.mdx';
+
+# useQuery()
 
 Query the store.
 

--- a/docs/core/api/useSubscription.md
+++ b/docs/core/api/useSubscription.md
@@ -1,15 +1,14 @@
 ---
-title: useSubscription()
+title: useSubscription() - Updating frequent data changes in React
+sidebar_label: useSubscription()
+description: Keeps data fresh, but only when component is active. Supports polling, websockets, and SSE.
 ---
-
-<head>
-  <title>useSubscription() - Updating frequent data changes in React</title>
-</head>
 
 import GenericsTabs from '@site/src/components/GenericsTabs';
 import ConditionalDependencies from '../shared/\_conditional_dependencies.mdx';
 import StackBlitz from '@site/src/components/StackBlitz';
 
+# useSubscription()
 
 Great for keeping resources up-to-date with frequent changes.
 

--- a/docs/core/api/useSuspense.md
+++ b/docs/core/api/useSuspense.md
@@ -1,9 +1,10 @@
 ---
-title: useSuspense()
+title: useSuspense() - Simplified data fetching for React
+sidebar_label: useSuspense()
+description: High performance async data rendering without overfetching. useSuspense() is like await for React components.
 ---
 
 <head>
-  <title>useSuspense() - Simplified data fetching for React</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 
@@ -16,6 +17,8 @@ import { RestEndpoint } from '@data-client/rest';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 import StackBlitz from '@site/src/components/StackBlitz';
 import { detailFixtures, listFixtures } from '@site/src/fixtures/profiles';
+
+# useSuspense()
 
 <p class="tagline">
 High performance async data rendering without overfetching.

--- a/docs/core/concepts/atomic-mutations.md
+++ b/docs/core/concepts/atomic-mutations.md
@@ -1,10 +1,9 @@
 ---
-title: Atomic Mutations ⚛
+title: '⚛ Atomic Mutations: Safe, high performance async mutations'
 sidebar_label: Atomic Mutations
 ---
 
 <head>
-  <title>⚛ Atomic Mutations: Safe, high performance async mutations</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 

--- a/docs/core/concepts/error-policy.md
+++ b/docs/core/concepts/error-policy.md
@@ -1,15 +1,17 @@
 ---
-title: Endpoint Error Policy
+title: Distinguishing recoverable fetch errors in React
 sidebar_label: Error Policy
+description: Controlling how errors affect revalidation strategies in Reactive Data Client.
 ---
 
 <head>
-  <title>Distinguishing recoverable fetch errors in React</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
 
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import {RestEndpoint} from '@data-client/rest';
+
+# Endpoint Error Policy
 
 [Endpoint.errorPolicy](/rest/api/Endpoint#errorpolicy) controls cache behavior upon a fetch rejection.
 It uses the rejection error to determine whether it should be treated as 'soft' or 'hard' error.

--- a/docs/core/concepts/expiry-policy.md
+++ b/docs/core/concepts/expiry-policy.md
@@ -1,15 +1,17 @@
 ---
-title: Endpoint Expiry Policy
+title: Controlling automatic fetch behavior with declarative Expiry Policies
 sidebar_label: Expiry Policy
+description: When data is considere Fresh, Stale, or Invalid. And how that state affects fetching and rendering.
 ---
 
 <head>
-  <title>Controlling automatic fetch behavior with declarative Expiry Policies</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
 
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import {RestEndpoint} from '@data-client/rest';
+
+# Endpoint Expiry Policy
 
 By default, Reactive Data Client cache policy can be described as [stale-while-revalidate](https://web.dev/stale-while-revalidate/).
 This means that when data is available it can avoid blocking the application by using the stale data. However, in the background

--- a/docs/core/concepts/managers.md
+++ b/docs/core/concepts/managers.md
@@ -1,6 +1,8 @@
 ---
-title: Managers and Middleware
+title: Centralized side-effect orchestration with React
 sidebar_label: Managers and Middleware
+description: Safe programmatic access to the global store. Enables fully extensible and scalable side-effects.
+image: /img/flux-full.png
 ---
 
 import ThemedImage from '@theme/ThemedImage';
@@ -8,9 +10,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import StackBlitz from '@site/src/components/StackBlitz';
 
 <head>
-  <title>Centralized side-effect orchestration with React</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
+
+# Managers and Middleware
 
 Reactive Data Client uses the [flux store](https://facebookarchive.github.io/flux/docs/in-depth-overview/) pattern, which is
 characterized by an easy to [understand and debug](../guides/debugging.md) the store's [undirectional data flow](<https://en.wikipedia.org/wiki/Unidirectional_Data_Flow_(computer_science)>). State updates are performed by a [reducer function](https://github.com/reactive/data-client/blob/master/packages/core/src/state/reducer/createReducer.ts#L19).

--- a/docs/core/concepts/validation.md
+++ b/docs/core/concepts/validation.md
@@ -1,15 +1,16 @@
 ---
-title: API Validation
+title: Validating fetch responses in React
 sidebar_label: Validation
 ---
 
 <head>
-  <title>Validating fetch responses in React</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
 
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import {RestEndpoint} from '@data-client/rest';
+
+# API Validation
 
 [Entity.validate()](/rest/api/Entity#validate) is called during normalization and denormalization.
 `undefined` indicates no error, and a string error message if there is an error.

--- a/docs/core/getting-started/data-dependency.md
+++ b/docs/core/getting-started/data-dependency.md
@@ -1,10 +1,9 @@
 ---
-title: Rendering Asynchronous Data
+title: Rendering Asynchronous Data in React
 sidebar_label: Render Data
 ---
 
 <head>
-  <title>Rendering Asynchronous Data in React</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
 
@@ -18,6 +17,8 @@ import ConditionalDependencies from '../shared/\_conditional_dependencies.mdx';
 import { postFixtures } from '@site/src/fixtures/posts';
 import { detailFixtures, listFixtures } from '@site/src/fixtures/profiles';
 import UseLive from '../shared/\_useLive.mdx';
+
+# Rendering Asynchronous Data
 
 Make your components reusable by binding the data where you **use** it with the one-line [useSuspense()](../api/useSuspense.md),
 which guarantees data like [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await).

--- a/docs/core/getting-started/installation.md
+++ b/docs/core/getting-started/installation.md
@@ -1,11 +1,9 @@
 ---
 id: installation
-title: Installation
+title: Getting Started with Reactive Data Client
+sidebar_label: Installation
+hide_title: true
 ---
-
-<head>
-  <title>Getting Started with Reactive Data Client</title>
-</head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/core/getting-started/mutations.md
+++ b/docs/core/getting-started/mutations.md
@@ -1,6 +1,7 @@
 ---
-title: Data mutations
+title: Mutating Asynchronous Data in React
 sidebar_label: Mutate Data
+description: Safe and high performance data mutations without refetching or writing state management.
 ---
 
 import ProtocolTabs from '@site/src/components/ProtocolTabs';
@@ -12,9 +13,10 @@ import UseLoading from '../shared/\_useLoading.mdx';
 import VoteDemo from '../shared/\_VoteDemo.mdx';
 
 <head>
-  <title>Mutating Asynchronous Data in React</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
+
+# Data mutations
 
 Using our [Create, Update, and Delete](/docs/concepts/atomic-mutations) endpoints with
 [Controller.fetch()](../api/Controller.md#fetch) reactively updates _all_ appropriate components atomically (at the same time).

--- a/docs/core/getting-started/resource.md
+++ b/docs/core/getting-started/resource.md
@@ -1,10 +1,9 @@
 ---
-title: Define Resources
+title: Defining Resources for Reactive Data Client
 sidebar_label: Define Data
 ---
 
 <head>
-  <title>Defining Resources for Reactive Data Client</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
 
@@ -16,6 +15,8 @@ import LanguageTabs from '@site/src/components/LanguageTabs';
 import ProtocolTabs from '@site/src/components/ProtocolTabs';
 import PkgInstall from '@site/src/components/PkgInstall';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
+
+# Define Resources
 
 [Resources](/rest/api/createResource) are a collection of `methods` for a given `data model`.
 

--- a/docs/core/guides/custom-protocol.md
+++ b/docs/core/guides/custom-protocol.md
@@ -3,14 +3,12 @@ title: TypeScript Standard Endpoints
 sidebar_label: Custom Protocol
 ---
 
-<head>
-  <title>TypeScript Standard Endpoints</title>
-</head>
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import PkgTabs from '@site/src/components/PkgTabs';
+
+# TypeScript Standard Endpoints
 
 [Endpoints](/rest/api/Endpoint) describe an asynchronous [API](https://www.freecodecamp.org/news/what-is-an-api-in-english-please-b880a3214a82/). This includes both runtime behavior as well as (optionally) typing.
 

--- a/docs/core/guides/img-media.md
+++ b/docs/core/guides/img-media.md
@@ -1,14 +1,13 @@
 ---
-title: Images and other Media
+title: React 18 Suspense with Images and other Media
+sidebar_label: Images and other Media
 ---
-
-<head>
-  <title>React 18 Suspense with Images and other Media</title>
-</head>
 
 import PkgTabs from '@site/src/components/PkgTabs';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
+# Images and other Media
 
 After setting up Reactive Data Client for structured data fetching, you might want to incorporate
 some media fetches as well to take advantage of suspense and [concurrent mode support](/docs/guides/render-as-you-fetch).

--- a/docs/core/guides/redux.md
+++ b/docs/core/guides/redux.md
@@ -1,15 +1,14 @@
 ---
 id: redux
-title: Redux integration
+title: Empowering Redux with Reactive Data Client
+sidebar_label: Redux integration
 ---
-
-<head>
-    <title>Empowering Redux with Reactive Data Client</title>
-</head>
 
 import PkgTabs from '@site/src/components/PkgTabs';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
+# Redux integration
 
 Using [redux](https://redux.js.org/) is completely optional. However, for many it means easy integration or migration
 with existing projects, or just a nice centralized state management abstraction.

--- a/docs/core/guides/ssr.md
+++ b/docs/core/guides/ssr.md
@@ -1,15 +1,17 @@
 ---
 id: ssr
-title: Server Side Rendering
+title: Server Side Rendering with NextJS, Express, and more
+sidebar_label: Server Side Rendering
 ---
 
 import PkgTabs from '@site/src/components/PkgTabs';
 import StackBlitz from '@site/src/components/StackBlitz';
 
 <head>
-  <title>Server Side Rendering with NextJS, Express, and more</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
+
+# Server Side Rendering
 
 Server Side Rendering (SSR) can improve the first-load performance of your application. Reactive Data
 Client takes this one step further by pre-populating the data store. Unlike other SSR methodologies,

--- a/docs/core/guides/storybook.md
+++ b/docs/core/guides/storybook.md
@@ -1,14 +1,16 @@
 ---
 title: Mocking data for Storybook
+sidebar_label: Mocking data for Storybook
 ---
 
 <head>
-  <title>Mocking data for Storybook</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
+# Mocking data for Storybook
 
 [Storybook](https://storybook.js.org/) is a great utility to do isolated development and
 testing, potentially speeding up development time greatly.

--- a/docs/graphql/README.md
+++ b/docs/graphql/README.md
@@ -1,12 +1,9 @@
 ---
 id: README
-title: GraphQL Usage
+title: GraphQL Usage with Reactive Data Client
 sidebar_label: Usage
+hide_title: true
 ---
-
-<head>
-  <title>GraphQL Usage with Reactive Data Client</title>
-</head>
 
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import Tabs from '@theme/Tabs';

--- a/docs/graphql/auth.md
+++ b/docs/graphql/auth.md
@@ -1,13 +1,12 @@
 ---
-title: GraphQL Authentication
+title: GraphQL Authentication patterns for Reactive Data Client
 sidebar_label: Authentication
 ---
-<head>
-  <title>GraphQL Authentication patterns for Reactive Data Client</title>
-</head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
+# GraphQL Authentication
 
 ## Cookie Auth
 

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -1,12 +1,10 @@
 ---
 id: README
-title: REST Usage
+title: Using REST APIs with Reactive Data Client
 sidebar_label: Usage
+description: Writing TypeScript REST APIs quickly using path templates and Schemas.
+hide_title: true
 ---
-
-<head>
-  <title>Using REST APIs with Reactive Data Client</title>
-</head>
 
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import Tabs from '@theme/Tabs';
@@ -18,7 +16,7 @@ import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 
 :::tip TypeScript 4
 
-When using TypeScript, version 4.0 or above is required.
+When using TypeScript (optional), version 4.0 or above is required.
 
 :::
 

--- a/docs/rest/api/All.md
+++ b/docs/rest/api/All.md
@@ -1,16 +1,15 @@
 ---
-title: schema.All
+title: schema.All - Access every entity in the Reactive Data Client store
+sidebar_label: schema.All
 ---
-
-<head>
-  <title>schema.All - Access every entity in the Reactive Data Client store</title>
-</head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
+
+# schema.All
 
 Retrieves all entities in cache as an Array.
 

--- a/docs/rest/api/Array.md
+++ b/docs/rest/api/Array.md
@@ -1,16 +1,15 @@
 ---
-title: schema.Array
+title: schema.Array - Declarative list data for React
+sidebar_label: schema.Array
 ---
-
-<head>
-  <title>schema.Array - Declarative list data for React</title>
-</head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
+
+# schema.Array
 
 Creates a schema to normalize an array of schemas. If the input value is an [Object](./Object.md) instead of an `Array`,
 the normalized result will be an `Array` of the [Object](./Object.md)'s values.

--- a/docs/rest/api/Collection.md
+++ b/docs/rest/api/Collection.md
@@ -1,10 +1,7 @@
 ---
-title: schema.Collection
+title: schema.Collection - Entities of Arrays or Values
+sidebar_label: schema.Collection
 ---
-
-<head>
-  <title>schema.Collection - Entities of Arrays or Values</title>
-</head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -13,6 +10,8 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
 import { v4 as uuid } from 'uuid';
 import { postFixtures,getInitialInterceptorData } from '@site/src/fixtures/posts-collection';
+
+# schema.Collection
 
 `Collections` are entities but for [Arrays](./Array.md) or [Values](./Values.md).
 

--- a/docs/rest/api/Endpoint.md
+++ b/docs/rest/api/Endpoint.md
@@ -1,14 +1,13 @@
 ---
-title: Endpoint
+title: Endpoint - Strongly typed API definitions
+sidebar_label: Endpoint
 ---
-
-<head>
-  <title>Endpoint - Strongly typed API definitions</title>
-</head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HooksPlayground from '@site/src/components/HooksPlayground';
+
+# Endpoint
 
 `Endpoint` are for any asynchronous function (one that returns a Promise).
 

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -1,9 +1,9 @@
 ---
-title: Entity
+title: Entity - Declarative unique objects for React
+sidebar_label: Entity
 ---
 
 <head>
-  <title>Entity - Declarative unique objects for React</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 
@@ -11,6 +11,8 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import { RestEndpoint } from '@data-client/rest';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
+
+# Entity
 
 <div style={{float:'right'}}>
 

--- a/docs/rest/api/Invalidate.md
+++ b/docs/rest/api/Invalidate.md
@@ -1,12 +1,12 @@
 ---
-title: schema.Invalidate
+title: schema.Invalidate - Invalidating Entities
+sidebar_label: schema.Invalidate
 ---
-<head>
-  <title>schema.Invalidate - Invalidating Entities</title>
-</head>
 
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
+
+# schema.Invalidate
 
 Describes entities to be marked as [INVALID](/docs/concepts/expiry-policy#invalid). This removes items from a
 collection, or [forces suspense](/docs/concepts/expiry-policy#any-endpoint-with-an-entity) for endpoints where the entity is required. 

--- a/docs/rest/api/Object.md
+++ b/docs/rest/api/Object.md
@@ -1,14 +1,13 @@
 ---
-title: schema.Object
+title: schema.Object - Declarative Object data for React
+sidebar_label: schema.Object
 ---
-
-<head>
-  <title>schema.Object - Declarative Object data for React</title>
-</head>
 
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
+
+# schema.Object
 
 Define a plain object mapping that has values needing to be normalized into Entities. _Note: The same behavior can be defined with shorthand syntax: `{ ... }`_
 

--- a/docs/rest/api/Query.md
+++ b/docs/rest/api/Query.md
@@ -1,14 +1,16 @@
 ---
-title: schema.Query
+title: Query - Programmatic memoized store access
+sidebar_label: schema.Query
 ---
 
 <head>
-  <title>Query - Programmatic performant store access</title>
   <meta name="docsearch:pagerank" content="30"/>
 </head>
 
 import { RestEndpoint } from '@data-client/rest';
 import HooksPlayground from '@site/src/components/HooksPlayground';
+
+# schema.Query
 
 `Query` provides programmatic access to the Reactive Data Client cache while maintaining
 the same high performance and referential equality guarantees expected of Reactive Data Client.

--- a/docs/rest/api/RestEndpoint.md
+++ b/docs/rest/api/RestEndpoint.md
@@ -1,10 +1,10 @@
 ---
-title: RestEndpoint
-description: Strongly typed path-based API definitions.
+title: RestEndpoint - Strongly typed path-based HTTP API definitions
+sidebar_label: RestEndpoint
+description: Strongly typed path-based extensible HTTP API definitions.
 ---
 
 <head>
-  <title>RestEndpoint - Strongly typed path-based HTTP API definitions</title>
   <meta name="docsearch:pagerank" content="30"/>
 </head>
 
@@ -14,6 +14,8 @@ import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 import EndpointPlayground from '@site/src/components/HTTP/EndpointPlayground';
 import Grid from '@site/src/components/Grid';
 import Link from '@docusaurus/Link';
+
+# RestEndpoint
 
 `RestEndpoints` are for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) based protocols like REST.
 
@@ -160,7 +162,7 @@ export const updateTodo = getTodo.extend({ method: 'PUT' });
 
 </TypeScriptEditor>
 
-Using a [Schema](./schema.md) enables automatic data consistency without the need to hurt performance with [refetching](/docs/api/Controller#expireAll).
+Using a [Schema](./schema.md) enables [automatic data consistency](/docs/concepts/normalization) without the need to hurt performance with [refetching](/docs/api/Controller#expireAll).
 
 ### Typing
 

--- a/docs/rest/api/Union.md
+++ b/docs/rest/api/Union.md
@@ -1,14 +1,14 @@
 ---
-title: schema.Union
+titlke: schema.Union - Declarative polymorphic data for React
+sidebar_label: schema.Union
 ---
-<head>
-  <title>schema.Union - Declarative polymorphic data for React</title>
-</head>
 
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
 import StackBlitz from '@site/src/components/StackBlitz';
+
+# schema.Union
 
 Describe a schema which is a union of multiple schemas. This is useful if you need the polymorphic behavior provided by [schema.Array](./Array.md) or [schema.Values](./Values.md) but for non-collection fields.
 

--- a/docs/rest/api/Values.md
+++ b/docs/rest/api/Values.md
@@ -1,14 +1,13 @@
 ---
-title: schema.Values
+title: schema.Values - Declarative map data for React
+sidebar_label: schema.Values
 ---
-
-<head>
-  <title>schema.Values - Declarative map data for React</title>
-</head>
 
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
+
+# schema.Values
 
 Like [Array](./Array), `Values` are unbounded in size. The definition here describes the types of values to expect,
 with keys being any string.

--- a/docs/rest/api/createResource.md
+++ b/docs/rest/api/createResource.md
@@ -1,10 +1,10 @@
 ---
 id: createResource
-title: createResource
+title: createResource() - TypeScript definition for REST API resources
+sidebar_label: createResource
 ---
 
 <head>
-  <title>createResource() - TypeScript definition for REST API resources</title>
   <meta name="docsearch:pagerank" content="30"/>
 </head>
 
@@ -13,6 +13,8 @@ import StackBlitz from '@site/src/components/StackBlitz';
 import EndpointPlayground from '@site/src/components/HTTP/EndpointPlayground';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 import DeleteProcess from './\_DeleteProcess.mdx';
+
+# createResource
 
 `Resources` are a collection of [RestEndpoints](./RestEndpoint.md) that operate on a common
 data by sharing a [schema](./schema.md)

--- a/docs/rest/api/hookifyResource.md
+++ b/docs/rest/api/hookifyResource.md
@@ -1,15 +1,17 @@
 ---
-title: hookifyResource
+title: hookifyResource() - Collection of CRUD hook Endpoints
+sidebar_label: hookifyResource
 ---
 
 <head>
-  <title>hookifyResource() - Collection of CRUD hook Endpoints</title>
   <meta name="docsearch:pagerank" content="20"/>
 </head>
 
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
+
+# hookfiyResource
 
 `hookifyResource()` Turns any [Resource](./createResource.md) (collection of [RestEndpoints](./RestEndpoint.md)) into a collection
 of hooks that return [RestEndpoints](./RestEndpoint.md).

--- a/docs/rest/api/schema.Entity.md
+++ b/docs/rest/api/schema.Entity.md
@@ -1,9 +1,9 @@
 ---
-title: schema.Entity
+title: schema.Entity - Entity mixin
+sidebar_label: schema.Entity
 ---
 
 <head>
-  <title>schema.Entity - Entity mixin</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 
@@ -11,6 +11,8 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import { RestEndpoint } from '@data-client/rest';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
+
+# schema.Entity
 
 `Entity` defines a single _unique_ object.
 

--- a/docs/rest/guides/optimistic-updates.md
+++ b/docs/rest/guides/optimistic-updates.md
@@ -1,9 +1,9 @@
 ---
-title: Optimistic Updates
+title: Making React 100x faster with Optimistic Updates
+sidebar_label: Optimistic Updates
 ---
 
 <head>
-  <title>Making React 100x faster with Optimistic Updates</title>
   <meta name="docsearch:pagerank" content="40"/>
 </head>
 
@@ -11,6 +11,8 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import {RestEndpoint} from '@data-client/rest';
 import { todoFixtures } from '@site/src/fixtures/todos';
 import OptimisticTransform from '../shared/\_optimisticTransform.mdx';
+
+# Optimistic Updates
 
 Optimistic updates enable highly responsive and fast interfaces by avoiding network wait times.
 An update is optimistic by assuming the network is successful.

--- a/docs/rest/guides/pagination.md
+++ b/docs/rest/guides/pagination.md
@@ -1,5 +1,5 @@
 ---
-title: Rest Pagination
+title: Pagination of REST data with Reactive Data Client
 sidebar_label: Pagination
 ---
 
@@ -7,9 +7,7 @@ import StackBlitz from '@site/src/components/StackBlitz';
 import { postPaginatedFixtures } from '@site/src/fixtures/posts';
 import HooksPlayground from '@site/src/components/HooksPlayground';
 
-<head>
-  <title>Pagination of REST data with Reactive Data Client</title>
-</head>
+# Rest Pagination
 
 ## Expanding Lists
 

--- a/docs/rest/guides/relational-data.md
+++ b/docs/rest/guides/relational-data.md
@@ -1,15 +1,13 @@
 ---
-title: Relational data
+title: Simplified relational data rendering in React
 sidebar_label: Relational data
 ---
-
-<head>
-  <title>Simplified relational data rendering in React</title>
-</head>
 
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { RestEndpoint } from '@data-client/rest';
 import StackBlitz from '@site/src/components/StackBlitz';
+
+# Relational data
 
 Reactive Data Client handles one-to-one, many-to-one and many-to-many relationships on [entities][1]
 using [Entity.schema][3]

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -51,7 +51,7 @@ const config: Config = {
       tagName: 'link',
       attributes: {
         name: 'application-name',
-        content: 'Reactive Data Client',
+        content: 'Data Client',
       },
     },
     {
@@ -424,9 +424,10 @@ const config: Config = {
           }, TODO: Add back when we have versions to upgrade*/
         {
           to: 'demos',
-          //label: '🎮 Demos',
-          position: 'right',
-          className: 'header-demos-link',
+          label: 'Demos',
+          position: 'left',
+          // TODO: move this to right once we get a better image that is more obvious (cube with play triangle inside)
+          //className: 'header-demos-link',
           'aria-label': 'Demo Applications',
         },
         {

--- a/website/src/theme/DocItem/Metadata/index.tsx
+++ b/website/src/theme/DocItem/Metadata/index.tsx
@@ -1,0 +1,26 @@
+import Head from '@docusaurus/Head';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import type { WrapperProps } from '@docusaurus/types';
+import type MetadataType from '@theme/DocItem/Metadata';
+import Metadata from '@theme-original/DocItem/Metadata';
+import React from 'react';
+
+type Props = WrapperProps<typeof MetadataType>;
+
+export default function MetadataWrapper(props: Props): JSX.Element {
+  const {
+    metadata: { title },
+  } = useDoc();
+  // for short titles, without subheaders
+  if (title.length < 28 && !title.includes(' - '))
+    return <Metadata {...props} />;
+  return (
+    <>
+      <Metadata {...props} />
+      <Head>
+        {title && <title>{title}</title>}
+        {title && <meta property="og:title" content={title} />}
+      </Head>
+    </>
+  );
+}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Getting a lot of title/description properties affecting search results in a non-desirable way.

```html
<meta data-rh="true" property="og:title" content="useSuspense() | Reactive Data Client">
<meta data-rh="true" name="description" content="useSuspense() - Simplified data fetching for React">
```


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

[Docusaurus uses front matter](https://docusaurus.io/docs/seo#single-page-metadata) to define seo meta-data, so we need to use it when defining title, and description

- Remove <title> and move that to from matter `title:`
- Move `title:` to `# header` to become h1 for page
- Also copy `title:` to `sidebar_label:` if it isn't already overriden
- Add description if the first paragraphs won't be useful for search results
- Set title to not append site title unless the title is short and includes no `-` subheaders
  - Do this by [swizzling](https://docusaurus.io/docs/swizzling#wrapping-theme-components) to override the [doc metadata component](https://github.com/facebook/docusaurus/blob/aab1f4868bdd4ebe858f0c284f729862539b7ced/packages/docusaurus-theme-classic/src/theme/DocItem/Metadata/index.tsx)

### Also

- Update 'application-name' to "Data Client" so it's short enough for google to use it
- Move demos link to leftside (for now) since our logo is unclear