### PR TITLE
docs: Don't SSR hidden editor tabs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -319,6 +319,14 @@ const config: Config = {
             from: ['/docs/getting-started/endpoint'],
           },
           {
+            to: '/docs/api/useQuery',
+            from: ['/rest/api/IndexEndpoint'],
+          },
+          {
+            to: '/rest/api/schema',
+            from: ['/rest/api/Schema'],
+          },
+          {
             to: '/blog/2023/07/04/v0.2-release-announcement',
             from: ['/blog/2023/07/04/v8-release-announcement'],
           },

--- a/website/src/components/DiffEditorMonaco.tsx
+++ b/website/src/components/DiffEditorMonaco.tsx
@@ -4,8 +4,8 @@ import clsx from 'clsx';
 import { useMemo } from 'react';
 
 import { extensionToMonacoLanguage } from './Playground/extensionToMonacoLanguage';
+import { options } from './Playground/monacoOptions';
 import MonacoPreloads from './Playground/MonacoPreloads';
-import { options } from './Playground/PlaygroundMonacoEditor';
 import styles from './Playground/styles.module.css';
 import useAutoHeight from './Playground/useAutoHeight';
 

--- a/website/src/components/Playground/PlaygroundMonacoEditor.tsx
+++ b/website/src/components/Playground/PlaygroundMonacoEditor.tsx
@@ -7,6 +7,7 @@ import { LiveEditor } from 'react-live';
 import './monaco-init';
 
 import { extensionToMonacoLanguage } from './extensionToMonacoLanguage';
+import { largeOptions, options } from './monacoOptions';
 import useAutoHeight from './useAutoHeight';
 
 export default function PlaygroundMonacoEditor({
@@ -15,13 +16,12 @@ export default function PlaygroundMonacoEditor({
   path = '',
   onFocus,
   tabIndex,
-  highlights,
+  highlights = undefined,
   autoFocus = false,
   large = false,
   isFocused = false,
   language = 'tsx',
-  original,
-  readOnly,
+  readOnly = false,
   ...rest
 }) {
   const editorOptions = useMemo(
@@ -103,59 +103,3 @@ export default function PlaygroundMonacoEditor({
     />
   );
 }
-
-export const options = {
-  scrollbar: { alwaysConsumeMouseWheel: false },
-  minimap: { enabled: false },
-  wordWrap: 'on',
-  scrollBeyondLastLine: false,
-  wrappingIndent: 'indent',
-  lineNumbers: 'off',
-  //glyphMargin: false,
-  folding: false,
-  // Undocumented see https://github.com/Microsoft/vscode/issues/30795#issuecomment-410998882
-  //lineDecorationsWidth: 0,
-  //lineNumbersMinChars: 0,
-  fontLigatures: true,
-  fontFamily:
-    '"Roboto Mono",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',
-  fontSize: 13,
-  lineHeight: 19,
-} as const;
-
-const largeOptions = {
-  ...options,
-  fontSize: 14,
-  lineHeight: 20,
-};
-
-/*function useMonacoWorker(
-  callback: (worker: languages.typescript.TypeScriptWorker) => void,
-): MutableRefObject<languages.typescript.TypeScriptWorker | undefined> {
-  const monaco = useMonaco();
-  const workerRef = useRef<languages.typescript.TypeScriptWorker | undefined>();
-  useEffect(() => {
-    if (!monaco) return;
-    monaco.languages.typescript
-      .getTypeScriptWorker()
-      .then(a => a())
-      .then(worker => {
-        workerRef.current = worker;
-        //callback(worker);
-      });
-  }, [monaco]);
-  return workerRef;
-}
-
-function useWorkerCB(
-  callback: (worker: languages.typescript.TypeScriptWorker) => void,
-  deps: any[],
-) {
-  const tsWorkerRef = useMonacoWorker(callback);
-
-  return useCallback((...args) => {
-    if (!tsWorkerRef.current) return;
-    callback(tsWorkerRef.current);
-  }, deps);
-}
-*/

--- a/website/src/components/Playground/monacoOptions.tsx
+++ b/website/src/components/Playground/monacoOptions.tsx
@@ -1,0 +1,24 @@
+export const options = {
+  scrollbar: { alwaysConsumeMouseWheel: false },
+  minimap: { enabled: false },
+  wordWrap: 'on',
+  scrollBeyondLastLine: false,
+  wrappingIndent: 'indent',
+  lineNumbers: 'off',
+  //glyphMargin: false,
+  folding: false,
+  // Undocumented see https://github.com/Microsoft/vscode/issues/30795#issuecomment-410998882
+  //lineDecorationsWidth: 0,
+  //lineNumbersMinChars: 0,
+  fontLigatures: true,
+  fontFamily:
+    '"Roboto Mono",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',
+  fontSize: 13,
+  lineHeight: 19,
+} as const;
+
+export const largeOptions = {
+  ...options,
+  fontSize: 14,
+  lineHeight: 20,
+};


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`WARNING : Html size is too long` in bing & google.

This also means pages with editors are huge and take a long time to show initial html for users with slower connections.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Don't SSR hidden tabs. The shown tabs are the important context for that docs page - usually hidden tabs just provide further context for the example, and don't provide any unique insights for that page.

TODO:
- Perhaps later have links to show just the playground where all tabs and rendered - this way the example code is crawlable for AI codegen engines.
- Try to SSR without all the syntax highlighting as the large amount of extra tags is also problematic for crawlers. This will likely require docusaurus changes.