### PR TITLE
enhance: Call fetches immediately - do not wait for idle

### DIFF
--- a/.changeset/rich-stingrays-look.md
+++ b/.changeset/rich-stingrays-look.md
@@ -1,0 +1,13 @@
+---
+'@data-client/react': minor
+---
+
+Call fetches immediately - do not wait for idle
+
+[NetworkManager](https://dataclient.io/docs/api/NetworkManager) will fetch
+immediately, rather than waiting for idle. With React 18+ it is expected for
+React to better handle work with concurrent mode and batching. Due to this, it
+is not longer deemed the best performance to wait for idle and instead we should
+fetch immediately.
+
+`IdlingNetworkManager` is still available to keep the previous behavior.

--- a/packages/normalizr/README.md
+++ b/packages/normalizr/README.md
@@ -245,7 +245,7 @@ to allow greater flexibility in its usage.
 
 |                     | no cache | with cache |
 | ------------------- | -------- | ---------- |
-| normalize (long)    | 113%     | 113%       |
+| normalize (long)    | 119%     | 119%       |
 | denormalize (long)  | 158%     | 1,262%      |
 | denormalize (short) | 676%     | 2,367%     |
 

--- a/packages/react/src/managers/NetworkManager.native.ts
+++ b/packages/react/src/managers/NetworkManager.native.ts
@@ -1,7 +1,7 @@
 import { NetworkManager } from '@data-client/core';
 import { InteractionManager } from 'react-native';
 
-export default class NativeNetworkManager extends NetworkManager {
+export default class NativeIdlingNetworkManager extends NetworkManager {
   /** Calls the callback when client is not 'busy' with high priority interaction tasks
    *
    * Override for platform-specific implementations

--- a/packages/react/src/managers/NetworkManager.ts
+++ b/packages/react/src/managers/NetworkManager.ts
@@ -1,9 +1,9 @@
 import { NetworkManager } from '@data-client/core';
 
-export default class WebNetworkManager extends NetworkManager {
+export default class WebIdlingNetworkManager extends NetworkManager {
   static {
     if (typeof requestIdleCallback === 'function') {
-      WebNetworkManager.prototype.idleCallback = (...args) =>
+      WebIdlingNetworkManager.prototype.idleCallback = (...args) =>
         requestIdleCallback(...args);
     }
   }

--- a/packages/react/src/managers/index.ts
+++ b/packages/react/src/managers/index.ts
@@ -4,5 +4,6 @@ export {
   SubscriptionManager,
   DefaultConnectionListener,
   LogoutManager,
+  NetworkManager,
 } from '@data-client/core';
-export { default as NetworkManager } from './NetworkManager.js';
+export { default as IdlingNetworkManager } from './NetworkManager.js';

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -1,10 +1,10 @@
 import * as _data_client_core from '@data-client/core';
 import { NetworkManager, Manager, State, Controller, EndpointInterface as EndpointInterface$1, FetchFunction as FetchFunction$1, Schema as Schema$1, ResolveType as ResolveType$1, Denormalize as Denormalize$1, DenormalizeNullable as DenormalizeNullable$1, Queryable as Queryable$1, NI, SchemaArgs, NetworkError as NetworkError$1, UnknownError as UnknownError$1, ErrorTypes as ErrorTypes$2, __INTERNAL__, createReducer, applyManager, actions } from '@data-client/core';
-export { AbstractInstanceType, ActionTypes, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, Normalize, NormalizeNullable, PK, PollingSubscription, ResetAction, ResolveType, Schema, SetAction, SetResponseAction, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@data-client/core';
+export { AbstractInstanceType, ActionTypes, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, ResetAction, ResolveType, Schema, SetAction, SetResponseAction, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@data-client/core';
 import * as react_jsx_runtime from 'react/jsx-runtime';
 import React, { JSX, Context } from 'react';
 
-declare class WebNetworkManager extends NetworkManager {
+declare class WebIdlingNetworkManager extends NetworkManager {
 }
 
 declare function BackupLoading(): react_jsx_runtime.JSX.Element;
@@ -420,4 +420,4 @@ declare namespace internal_d {
 /** Turns a dispatch function into one that resolves once its been commited */
 declare function usePromisifiedDispatch<R extends React.Reducer<any, any>>(dispatch: React.Dispatch<React.ReducerAction<R>>, state: React.ReducerState<R>): (action: React.ReducerAction<R>) => Promise<void>;
 
-export { _default as AsyncBoundary, BackupLoading, DataProvider as CacheProvider, ControllerContext, DataProvider, DevToolsPosition, ErrorBoundary, ErrorBoundary as NetworkErrorBoundary, WebNetworkManager as NetworkManager, ProviderProps, StateContext, Store, StoreContext, UniversalSuspense, internal_d as __INTERNAL__, getDefaultManagers, useCache, useCancelling, useController, useDLE, useDebounce, useError, useFetch, useLive, useLoading, usePromisifiedDispatch, useQuery, useSubscription, useSuspense };
+export { _default as AsyncBoundary, BackupLoading, DataProvider as CacheProvider, ControllerContext, DataProvider, DevToolsPosition, ErrorBoundary, WebIdlingNetworkManager as IdlingNetworkManager, ErrorBoundary as NetworkErrorBoundary, ProviderProps, StateContext, Store, StoreContext, UniversalSuspense, internal_d as __INTERNAL__, getDefaultManagers, useCache, useCancelling, useController, useDLE, useDebounce, useError, useFetch, useLive, useLoading, usePromisifiedDispatch, useQuery, useSubscription, useSuspense };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

[NetworkManager](https://dataclient.io/docs/api/NetworkManager) will fetch
immediately, rather than waiting for idle. With React 18+ it is expected for
React to better handle work with concurrent mode and batching. Due to this, it
is not longer deemed the best performance to wait for idle and instead we should
fetch immediately.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Call fetches immediately - do not wait for idle

`IdlingNetworkManager` is still available to keep the previous behavior.
