### PR TITLE
fix: Collections work with polymorphic schemas and class name mangling

### DIFF
--- a/.changeset/empty-pillows-wait.md
+++ b/.changeset/empty-pillows-wait.md
@@ -1,0 +1,7 @@
+---
+'@data-client/endpoint': patch
+---
+
+Collection.key is shorter and more readable
+
+`[Todo]` for Arrays or `{Todo}` for Values

--- a/.changeset/fluffy-months-sleep.md
+++ b/.changeset/fluffy-months-sleep.md
@@ -1,0 +1,5 @@
+---
+'@data-client/normalizr': patch
+---
+
+Make normalize and memo arguments accept more valid types

--- a/.changeset/little-plants-hammer.md
+++ b/.changeset/little-plants-hammer.md
@@ -1,0 +1,5 @@
+---
+'@data-client/endpoint': patch
+---
+
+fix: Collection.key robust against class name mangling

--- a/.changeset/strong-garlics-wonder.md
+++ b/.changeset/strong-garlics-wonder.md
@@ -1,0 +1,7 @@
+---
+'@data-client/endpoint': patch
+---
+
+Collections now work with polymorhpic schemas like Union
+
+Collections.key on polymorphic types lists their possible Entity keys: `[PushEvent;PullRequestEvent]`

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -90,6 +90,7 @@ export interface EntityInterface<T = any> extends SchemaSimple {
 export interface PolymorphicInterface<T = any, Args extends any[] = any[]>
   extends SchemaSimple<T, Args> {
   readonly schema: any;
+  schemaKey(): string;
   // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
   _normalizeNullable(): any;
   // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -65,6 +65,7 @@ export class Array<S extends Schema = Schema> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
   normalize(
     input: any,
@@ -122,7 +123,9 @@ export class All<
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
+  schemaKey(): string;
   normalize(
     input: any,
     parent: any,
@@ -260,6 +263,7 @@ export interface UnionInstance<
   define(definition: Schema): void;
   inferSchema: SchemaAttributeFunction<Choices[keyof Choices]>;
   getSchemaAttribute: SchemaFunction<keyof Choices>;
+  schemaKey(): string;
   readonly schema: Choices;
   normalize(
     input: any,
@@ -327,6 +331,7 @@ export class Values<Choices extends Schema = any> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: Choices extends EntityMap ? false : true;
+  schemaKey(): string;
   inferSchema: SchemaAttributeFunction<
     Choices extends EntityMap ? Choices[keyof Choices] : Choices
   >;

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -84,10 +84,7 @@ export default class CollectionSchema<
         this.argsKey = params => ({ ...params });
       }
     }
-    // this assumes the definition of Array/Values is Entity
-    this.key = `COLLECT:${this.schema.constructor.name}(${
-      (this.schema.schema as any).key
-    })`;
+    this.key = keyFromSchema(this.schema);
     if ((options as any)?.nonFilterArgumentKeys) {
       const { nonFilterArgumentKeys } = options as {
         nonFilterArgumentKeys: ((key: string) => boolean) | string[] | RegExp;
@@ -357,9 +354,18 @@ function denormalize(
       (this.schema.denormalize(input, args, unvisit) as any)
     : (this.schema.denormalize([input], args, unvisit)[0] as any);
 }
-
 /**
  * We call schema.denormalize and schema.normalize directly
  * instead of visit/unvisit as we are not operating on new data
  * so the additional checks in those methods are redundant
  */
+
+function keyFromSchema(schema: PolymorphicInterface) {
+  if (schema instanceof ArraySchema) {
+    // this assumes the definition of Array/Values is Entity
+    return `[${schema.schemaKey()}]`;
+  } else if (schema instanceof Values) {
+    return `{${schema.schemaKey()}}`;
+  }
+  return `Collection:${schema.schemaKey()}`;
+}

--- a/packages/endpoint/src/schemas/Polymorphic.ts
+++ b/packages/endpoint/src/schemas/Polymorphic.ts
@@ -45,6 +45,13 @@ export default class PolymorphicSchema {
     return this.schema[attr];
   }
 
+  schemaKey(): string {
+    if (this.isSingleSchema) {
+      return this.schema.key;
+    }
+    return Object.values(this.schema).join(';');
+  }
+
   normalizeValue(value: any, parent: any, key: any, args: any[], visit: Visit) {
     if (!value) return value;
     const schema = this.inferSchema(value, parent, key);

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
@@ -31,12 +31,6 @@ exports[`CollectionSchema denormalization denormalizes top level collections 1`]
 exports[`CollectionSchema normalization normalizes already processed entities 1`] = `
 {
   "entities": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": [
-        "5",
-        "6",
-      ],
-    },
     "User": {
       "1": {
         "id": "1",
@@ -44,17 +38,23 @@ exports[`CollectionSchema normalization normalizes already processed entities 1`
         "username": "bob",
       },
     },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "5",
+        "6",
+      ],
+    },
   },
   "entityMeta": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": {
+    "User": {
+      "1": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
       },
     },
-    "User": {
-      "1": {
+    "[Todo]": {
+      "{"userId":"1"}": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
@@ -69,11 +69,6 @@ exports[`CollectionSchema normalization normalizes already processed entities 1`
 exports[`CollectionSchema normalization normalizes nested collections 1`] = `
 {
   "entities": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": [
-        "5",
-      ],
-    },
     "Todo": {
       "5": {
         "id": "5",
@@ -87,15 +82,13 @@ exports[`CollectionSchema normalization normalizes nested collections 1`] = `
         "username": "bob",
       },
     },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "5",
+      ],
+    },
   },
   "entityMeta": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": {
-        "date": 1557831718135,
-        "expiresAt": Infinity,
-        "fetchedAt": 0,
-      },
-    },
     "Todo": {
       "5": {
         "date": 1557831718135,
@@ -105,6 +98,13 @@ exports[`CollectionSchema normalization normalizes nested collections 1`] = `
     },
     "User": {
       "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "[Todo]": {
+      "{"userId":"1"}": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
@@ -119,12 +119,6 @@ exports[`CollectionSchema normalization normalizes nested collections 1`] = `
 exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
 {
   "entities": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": [
-        "5",
-        "10",
-      ],
-    },
     "Todo": {
       "10": {
         "id": "10",
@@ -142,15 +136,14 @@ exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
         "username": "bob",
       },
     },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "5",
+        "10",
+      ],
+    },
   },
   "entityMeta": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": {
-        "date": 1557831718135,
-        "expiresAt": Infinity,
-        "fetchedAt": 0,
-      },
-    },
     "Todo": {
       "10": {
         "date": 1557831718135,
@@ -170,6 +163,13 @@ exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
         "fetchedAt": 0,
       },
     },
+    "[Todo]": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
   },
   "indexes": {},
   "result": [
@@ -181,28 +181,28 @@ exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
 exports[`CollectionSchema normalization normalizes top level collections (no args) 1`] = `
 {
   "entities": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": [
-        "5",
-      ],
-    },
     "Todo": {
       "5": {
         "id": "5",
         "title": "finish collections",
       },
     },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "5",
+      ],
+    },
   },
   "entityMeta": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": {
+    "Todo": {
+      "5": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
       },
     },
-    "Todo": {
-      "5": {
+    "[Todo]": {
+      "{"userId":"1"}": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
@@ -217,28 +217,28 @@ exports[`CollectionSchema normalization normalizes top level collections (no arg
 exports[`CollectionSchema normalization normalizes top level collections 1`] = `
 {
   "entities": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": [
-        "5",
-      ],
-    },
     "Todo": {
       "5": {
         "id": "5",
         "title": "finish collections",
       },
     },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "5",
+      ],
+    },
   },
   "entityMeta": {
-    "COLLECT:ArraySchema(Todo)": {
-      "{"userId":"1"}": {
+    "Todo": {
+      "5": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
       },
     },
-    "Todo": {
-      "5": {
+    "[Todo]": {
+      "{"userId":"1"}": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
@@ -247,6 +247,68 @@ exports[`CollectionSchema normalization normalizes top level collections 1`] = `
   },
   "indexes": {},
   "result": "{"userId":"1"}",
+}
+`;
+
+exports[`CollectionSchema normalization polymorphism works with Union members 1`] = `"{"fakeFilter":"false"}"`;
+
+exports[`CollectionSchema normalization polymorphism works with Union members 2`] = `
+{
+  "Group": {
+    "2": {
+      "id": "2",
+      "type": "groups",
+    },
+  },
+  "User": {
+    "1": {
+      "id": "1",
+      "type": "users",
+    },
+  },
+  "[User;Group]": {
+    "{"fakeFilter":"false"}": [
+      {
+        "id": "1",
+        "schema": "users",
+      },
+      {
+        "id": "2",
+        "schema": "groups",
+      },
+    ],
+  },
+}
+`;
+
+exports[`CollectionSchema normalization polymorphism works with polymorphic members 1`] = `"{"fakeFilter":"false"}"`;
+
+exports[`CollectionSchema normalization polymorphism works with polymorphic members 2`] = `
+{
+  "Group": {
+    "2": {
+      "id": "2",
+      "type": "groups",
+    },
+  },
+  "User": {
+    "1": {
+      "id": "1",
+      "type": "users",
+    },
+  },
+  "[User;Group]": {
+    "{"fakeFilter":"false"}": [
+      {
+        "id": "1",
+        "schema": "users",
+      },
+      {
+        "id": "2",
+        "schema": "groups",
+      },
+    ],
+  },
 }
 `;
 
@@ -262,7 +324,7 @@ exports[`CollectionSchema normalization should throw a custom error if data load
     "schema": {},
     "key": "Todo"
   },
-  "key": "COLLECT:ArraySchema(Todo)"
+  "key": "[Todo]"
 }
           Input: "abc""
 `;
@@ -277,7 +339,7 @@ exports[`CollectionSchema normalization should throw a custom error if data load
     "schema": {},
     "key": "Todo"
   },
-  "key": "COLLECT:ArraySchema(Todo)"
+  "key": "[Todo]"
 }
           Input: "null""
 `;

--- a/packages/normalizr/src/memo/MemoCache.ts
+++ b/packages/normalizr/src/memo/MemoCache.ts
@@ -58,7 +58,7 @@ export default class MemoCache {
     schema: S,
     args: readonly any[],
     entities:
-      | Record<string, Record<string, object>>
+      | Record<string, Record<string, any> | undefined>
       | {
           getIn(k: string[]): any;
         },
@@ -84,7 +84,7 @@ export default class MemoCache {
     schema: S,
     args: readonly any[],
     entities:
-      | Record<string, Record<string, object>>
+      | Record<string, Record<string, any> | undefined>
       | {
           getIn(k: string[]): any;
         },

--- a/packages/normalizr/src/normalizr/normalize.ts
+++ b/packages/normalizr/src/normalizr/normalize.ts
@@ -2,7 +2,12 @@ import { addEntities } from './addEntities.js';
 import { getVisit } from './getVisit.js';
 import type { Schema, NormalizedIndex } from '../interface.js';
 import { createGetEntity } from '../memo/MemoCache.js';
-import type { NormalizeNullable, NormalizedSchema } from '../types.js';
+import type {
+  NormalizeMeta,
+  NormalizeNullable,
+  NormalizedSchema,
+  StoreData,
+} from '../types.js';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const normalize = <
@@ -109,23 +114,3 @@ const emptyStore: StoreData<any> = {
   indexes: {},
   entityMeta: {},
 };
-
-interface StoreData<E> {
-  entities: Readonly<E>;
-  indexes: Readonly<NormalizedIndex>;
-  entityMeta: {
-    readonly [entityKey: string]: {
-      readonly [pk: string]: {
-        readonly fetchedAt: number;
-        readonly date: number;
-        readonly expiresAt: number;
-      };
-    };
-  };
-}
-
-interface NormalizeMeta {
-  expiresAt: number;
-  date: number;
-  fetchedAt: number;
-}

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -105,20 +105,37 @@ export type NormalizeNullable<S> =
   : S extends { [K: string]: any } ? NormalizedNullableObject<S>
   : S;
 
-export type NormalizedSchema<E, R> = {
+export type NormalizedSchema<
+  E extends Record<string, Record<string, any> | undefined>,
+  R,
+> = {
   entities: E;
   result: R;
   indexes: NormalizedIndex;
-  entityMeta: {
-    readonly [entityKey: string]: {
-      readonly [pk: string]: {
-        readonly date: number;
-        readonly expiresAt: number;
-        readonly fetchedAt: number;
-      };
-    };
+  entityMeta: EntitiesToMeta<E>;
+};
+
+export interface StoreData<
+  E extends Record<string, Record<string, any> | undefined>,
+> {
+  entities: Readonly<E>;
+  indexes: Readonly<NormalizedIndex>;
+  entityMeta: EntitiesToMeta<E>;
+}
+
+export type EntitiesToMeta<
+  E extends Record<string, Record<string, any> | undefined>,
+> = {
+  readonly [entityKey in keyof E]: {
+    readonly [pk in keyof E[entityKey]]: NormalizeMeta;
   };
 };
+
+export interface NormalizeMeta {
+  expiresAt: number;
+  date: number;
+  fetchedAt: number;
+}
 
 export type EntityMap<T = any> = Record<string, EntityInterface<T>>;
 

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -145,12 +145,12 @@ declare class MemoCache {
         paths: EntityPath[];
     };
     /** Compute denormalized form maintaining referential equality for same inputs */
-    query<S extends Schema>(schema: S, args: readonly any[], entities: Record<string, Record<string, object>> | {
+    query<S extends Schema>(schema: S, args: readonly any[], entities: Record<string, Record<string, any> | undefined> | {
         getIn(k: string[]): any;
     }, indexes: NormalizedIndex | {
         getIn(k: string[]): any;
     }, argsKey?: string): DenormalizeNullable<S> | undefined;
-    buildQueryKey<S extends Schema>(schema: S, args: readonly any[], entities: Record<string, Record<string, object>> | {
+    buildQueryKey<S extends Schema>(schema: S, args: readonly any[], entities: Record<string, Record<string, any> | undefined> | {
         getIn(k: string[]): any;
     }, indexes: NormalizedIndex | {
         getIn(k: string[]): any;

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -160,6 +160,7 @@ interface EntityInterface<T = any> extends SchemaSimple {
 /** Represents Array or Values */
 interface PolymorphicInterface<T = any, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
     readonly schema: any;
+    schemaKey(): string;
     _normalizeNullable(): any;
     _denormalizeNullable(): any;
 }
@@ -649,6 +650,7 @@ declare class Array$1<S extends Schema = Schema> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
   normalize(
     input: any,
@@ -706,7 +708,9 @@ declare class All<
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
+  schemaKey(): string;
   normalize(
     input: any,
     parent: any,
@@ -844,6 +848,7 @@ interface UnionInstance<
   define(definition: Schema): void;
   inferSchema: SchemaAttributeFunction<Choices[keyof Choices]>;
   getSchemaAttribute: SchemaFunction<keyof Choices>;
+  schemaKey(): string;
   readonly schema: Choices;
   normalize(
     input: any,
@@ -911,6 +916,7 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: Choices extends EntityMap ? false : true;
+  schemaKey(): string;
   inferSchema: SchemaAttributeFunction<
     Choices extends EntityMap ? Choices[keyof Choices] : Choices
   >;

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -160,6 +160,7 @@ interface EntityInterface<T = any> extends SchemaSimple {
 /** Represents Array or Values */
 interface PolymorphicInterface<T = any, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
     readonly schema: any;
+    schemaKey(): string;
     _normalizeNullable(): any;
     _denormalizeNullable(): any;
 }
@@ -649,6 +650,7 @@ declare class Array$1<S extends Schema = Schema> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
   normalize(
     input: any,
@@ -706,7 +708,9 @@ declare class All<
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
+  schemaKey(): string;
   normalize(
     input: any,
     parent: any,
@@ -844,6 +848,7 @@ interface UnionInstance<
   define(definition: Schema): void;
   inferSchema: SchemaAttributeFunction<Choices[keyof Choices]>;
   getSchemaAttribute: SchemaFunction<keyof Choices>;
+  schemaKey(): string;
   readonly schema: Choices;
   normalize(
     input: any,
@@ -911,6 +916,7 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: Choices extends EntityMap ? false : true;
+  schemaKey(): string;
   inferSchema: SchemaAttributeFunction<
     Choices extends EntityMap ? Choices[keyof Choices] : Choices
   >;

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -162,6 +162,7 @@ interface EntityInterface<T = any> extends SchemaSimple {
 /** Represents Array or Values */
 interface PolymorphicInterface<T = any, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
     readonly schema: any;
+    schemaKey(): string;
     _normalizeNullable(): any;
     _denormalizeNullable(): any;
 }
@@ -647,6 +648,7 @@ declare class Array$1<S extends Schema = Schema> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
   normalize(
     input: any,
@@ -704,7 +706,9 @@ declare class All<
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
+  schemaKey(): string;
   normalize(
     input: any,
     parent: any,
@@ -842,6 +846,7 @@ interface UnionInstance<
   define(definition: Schema): void;
   inferSchema: SchemaAttributeFunction<Choices[keyof Choices]>;
   getSchemaAttribute: SchemaFunction<keyof Choices>;
+  schemaKey(): string;
   readonly schema: Choices;
   normalize(
     input: any,
@@ -909,6 +914,7 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: Choices extends EntityMap ? false : true;
+  schemaKey(): string;
   inferSchema: SchemaAttributeFunction<
     Choices extends EntityMap ? Choices[keyof Choices] : Choices
   >;

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -166,6 +166,7 @@ interface EntityInterface<T = any> extends SchemaSimple {
 /** Represents Array or Values */
 interface PolymorphicInterface<T = any, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
     readonly schema: any;
+    schemaKey(): string;
     _normalizeNullable(): any;
     _denormalizeNullable(): any;
 }
@@ -651,6 +652,7 @@ declare class Array$1<S extends Schema = Schema> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
   normalize(
     input: any,
@@ -708,7 +710,9 @@ declare class All<
 
   define(definition: Schema): void;
   readonly isSingleSchema: S extends EntityMap ? false : true;
+  schemaKey(): string;
   readonly schema: S;
+  schemaKey(): string;
   normalize(
     input: any,
     parent: any,
@@ -846,6 +850,7 @@ interface UnionInstance<
   define(definition: Schema): void;
   inferSchema: SchemaAttributeFunction<Choices[keyof Choices]>;
   getSchemaAttribute: SchemaFunction<keyof Choices>;
+  schemaKey(): string;
   readonly schema: Choices;
   normalize(
     input: any,
@@ -913,6 +918,7 @@ declare class Values<Choices extends Schema = any> implements SchemaClass {
 
   define(definition: Schema): void;
   readonly isSingleSchema: Choices extends EntityMap ? false : true;
+  schemaKey(): string;
   inferSchema: SchemaAttributeFunction<
     Choices extends EntityMap ? Choices[keyof Choices] : Choices
   >;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Production builds often mangle class names: Collection.key used to rely on schema.constructor.name, which could result in client/server serialization mismatches at the worst, and at the best made production build stores unreadable
- Collections would not work with polymorphic members - including [Unions](https://dataclient.io/rest/api/Union) or when Array/Values had a [polymorphic constructor](https://dataclient.io/rest/api/Array#polymorphic-types


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Rework Collect.key:

Now relies on its schema to have schemaKey() (which is defined in Polymorphic, so it is inherited by Array, Values, and Union).

```ts
new Collection([Todo]).key
```

'COLLECT:ArraySchema(Todo)' -> '[Todo]'

```ts
new Collection(
      new Array(
        {
          users: User,
          groups: Group,
        },
        'type',
      ),
    ).key
```

*FAILED* -> '[User;Group]'
