### PR TITLE
enhance: createResource() -> resource()

### DIFF
--- a/.changeset/silent-bananas-relax.md
+++ b/.changeset/silent-bananas-relax.md
@@ -1,0 +1,7 @@
+---
+'@data-client/rest': patch
+---
+
+createResource() -> [resource()](https://dataclient.io/rest/api/resource)
+
+Note: `createResource` is still exported (it is the same)

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ class Article extends Entity {
 ### Create [collection of API Endpoints](https://dataclient.io/docs/getting-started/resource)
 
 ```typescript
-const UserResource = createResource({
+const UserResource = resource({
   path: '/users/:id',
   schema: User,
   optimistic: true,
 });
 
-const ArticleResource = createResource({
+const ArticleResource = resource({
   path: '/articles/:id',
   schema: Article,
   searchParams: {} as { author?: string },
@@ -276,7 +276,7 @@ For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://da
 
 - Networking definition
   - [Endpoints](https://dataclient.io/rest/api/Endpoint): [RestEndpoint](https://dataclient.io/rest/api/RestEndpoint), [GQLEndpoint](https://dataclient.io/graphql/api/GQLEndpoint)
-  - [Resources](https://dataclient.io/docs/getting-started/resource): [createResource()](https://dataclient.io/rest/api/createResource), [hookifyResource()](https://dataclient.io/rest/api/hookifyResource)
+  - [Resources](https://dataclient.io/docs/getting-started/resource): [resource()](https://dataclient.io/rest/api/resource), [hookifyResource()](https://dataclient.io/rest/api/hookifyResource)
 - [Data model](https://dataclient.io/docs/concepts/normalization)
   - [Entity](https://dataclient.io/rest/api/Entity), [schema.Entity](https://dataclient.io/rest/api/schema.Entity) mixin, [GQLEntity](https://dataclient.io/graphql/api/GQLEntity)
   - [Object](https://dataclient.io/rest/api/Object)

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -1,7 +1,7 @@
 import {
   schema,
   Endpoint,
-  createResource,
+  resource,
   RestEndpoint,
   Schema,
   Entity,
@@ -78,7 +78,7 @@ export class VisEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
     return super.getRequestInit(body);
   }
 }
-const VisSettingsResourceBase = createResource({
+const VisSettingsResourceBase = resource({
   path: 'http\\://test.com/vis-settings/:id',
   schema: VisSettings,
   Endpoint: VisEndpoint,
@@ -114,7 +114,7 @@ export const VisSettingsResource = {
     },
   }),
 };
-const VisSettingsResourceBaseFromMixin = createResource({
+const VisSettingsResourceBaseFromMixin = resource({
   path: 'http\\://test.com/vis-settings/:id',
   schema: VisSettingsFromMixin,
   Endpoint: VisEndpoint,
@@ -167,7 +167,7 @@ export class User extends Entity {
     return this.id?.toString();
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   path: 'http\\://test.com/user/:id',
   schema: User,
 });
@@ -207,15 +207,15 @@ export class ArticleFromMixin extends schema.Entity(ArticleData, {
 class ArticleEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {}
 
 interface ArticleGenerics {
-  /** @see https://dataclient.io/rest/api/createResource#path */
+  /** @see https://dataclient.io/rest/api/resource#path */
   readonly path?: string;
-  /** @see https://dataclient.io/rest/api/createResource#schema */
+  /** @see https://dataclient.io/rest/api/resource#schema */
   readonly schema: Schema;
   /** Only used for types */
-  /** @see https://dataclient.io/rest/api/createResource#body */
+  /** @see https://dataclient.io/rest/api/resource#body */
   readonly body?: any;
   /** Only used for types */
-  /** @see https://dataclient.io/rest/api/createResource#searchParams */
+  /** @see https://dataclient.io/rest/api/resource#searchParams */
   readonly searchParams?: any;
 }
 function createArticleResource<O extends ArticleGenerics>({
@@ -237,7 +237,7 @@ function createArticleResource<O extends ArticleGenerics>({
   > extends Endpoint<O> {
     urlPrefix = `http://test.com/${urlRoot}`;
   }
-  const resource = createResource({
+  const BaseResource = resource({
     path: '/:id',
     schema,
     Endpoint: EndpointUrlRootOverride,
@@ -256,7 +256,7 @@ function createArticleResource<O extends ArticleGenerics>({
       }),
     }));
   if (!optimistic) {
-    return (resource as any).extend({
+    return (BaseResource as any).extend({
       partialUpdate: {
         getOptimisticResponse: (snap, params, body) => ({
           id: params.id,
@@ -268,7 +268,7 @@ function createArticleResource<O extends ArticleGenerics>({
       },
     });
   }
-  return resource as any;
+  return BaseResource as any;
 }
 export const ArticleResource = createArticleResource({ schema: Article });
 export const ArticleSlugResource = createArticleResource({
@@ -277,7 +277,7 @@ export const ArticleSlugResource = createArticleResource({
 
 export const AuthContext = createContext('');
 
-const ContextAuthdArticleResourceBase = createResource({
+const ContextAuthdArticleResourceBase = resource({
   path: 'http\\://test.com/article/:id',
   schema: Article,
 });
@@ -527,7 +527,7 @@ export const CoolerArticleDetail = new Endpoint(
 export class IndexedUser extends User {
   static readonly indexes = ['username'];
 }
-export const IndexedUserResource = createResource({
+export const IndexedUserResource = resource({
   path: 'http\\://test.com/user/:id',
   schema: IndexedUser,
 });
@@ -642,7 +642,7 @@ export const UnionSchema = new schema.Union(
   },
   'type',
 );
-const UnionResourceBase = createResource({
+const UnionResourceBase = resource({
   path: '/union/:id',
   schema: UnionSchema,
 });

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -336,10 +336,10 @@ At this point we've defined `todoDetail`, `todoList` and `todoUpdate`. You might
 that these endpoint definitions share some logic and information. For this reason Reactive Data Client
 encourages extracting shared logic among endpoints.
 
-[Resources](/rest/api/createResource) are collections of endpoints that operate on the same data.
+[Resources](/rest/api/resource) are collections of endpoints that operate on the same data.
 
 ```typescript
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 class Todo extends Entity {
   id = 0;
@@ -352,7 +352,7 @@ class Todo extends Entity {
   }
 }
 
-const TodoResource = createResource({
+const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -257,7 +257,7 @@ To refresh while continuing to display stale data - [Controller.fetch](#fetch).
 
 Use [schema.Invalidate](/rest/api/Invalidate) to invalidate every endpoint that contains a given entity.
 
-For REST try using [Resource.delete](/rest/api/createResource#delete)
+For REST try using [Resource.delete](/rest/api/resource#delete)
 
 ```ts
 // deletes MyResource(5)

--- a/docs/core/api/useCache.md
+++ b/docs/core/api/useCache.md
@@ -31,7 +31,7 @@ delay: 500,
 ]} row>
 
 ```ts title="UserResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class User extends Entity {
   id = '';
@@ -42,7 +42,7 @@ export class User extends Entity {
   }
   static key = 'User';
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   path: '/users/:id',
   schema: User,
 }).extend('current', {
@@ -115,7 +115,7 @@ more information about type handling
 
 | Expiry Status | Returns      | Conditions                                                                                                                                                                   |
 | ------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Invalid       | `undefined`  | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../concepts/expiry-policy.md#endpointinvalidifstale) |
+| Invalid       | `undefined`  | not in store, [deletion](/rest/api/resource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../concepts/expiry-policy.md#endpointinvalidifstale) |
 | Stale         | denormalized | (first-render, arg change) & [expiry &lt; now](../concepts/expiry-policy.md)                                                                                                 |
 | Valid         | denormalized | fetch completion                                                                                                                                                             |
 |               | `undefined`  | `null` used as second argument                                                                                                                                               |

--- a/docs/core/api/useDLE.md
+++ b/docs/core/api/useDLE.md
@@ -26,7 +26,7 @@ In case you cannot use [suspense](../getting-started/data-dependency.md#async-fa
 <HooksPlayground fixtures={listFixtures} row>
 
 ```typescript title="ProfileResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Profile extends Entity {
   id: number | undefined = undefined;
@@ -40,7 +40,7 @@ export class Profile extends Entity {
   static key = 'Profile';
 }
 
-export const ProfileResource = createResource({
+export const ProfileResource = resource({
   path: '/profiles/:id',
   schema: Profile,
 });
@@ -77,7 +77,7 @@ render(<ProfileList />);
 
 | Expiry Status | Fetch           | Data         | Loading | Error             | Conditions                                                                                                                                                                   |
 | ------------- | --------------- | ------------ | ------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Invalid       | yes<sup>1</sup> | `undefined`  | true    | false             | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../concepts/expiry-policy.md#endpointinvalidifstale) |
+| Invalid       | yes<sup>1</sup> | `undefined`  | true    | false             | not in store, [deletion](/rest/api/resource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../concepts/expiry-policy.md#endpointinvalidifstale) |
 | Stale         | yes<sup>1</sup> | denormalized | false   | false             | (first-render, arg change) & [expiry &lt; now](../concepts/expiry-policy.md)                                                                                                 |
 | Valid         | no              | denormalized | false   | maybe<sup>2</sup> | fetch completion                                                                                                                                                             |
 |               | no              | `undefined`  | false   | false             | `null` used as second argument                                                                                                                                               |
@@ -140,7 +140,7 @@ function useDLE<
 <HooksPlayground fixtures={detailFixtures} row>
 
 ```typescript title="ProfileResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Profile extends Entity {
   id: number | undefined = undefined;
@@ -154,7 +154,7 @@ export class Profile extends Entity {
   static key = 'Profile';
 }
 
-export const ProfileResource = createResource({
+export const ProfileResource = resource({
   path: '/profiles/:id',
   schema: Profile,
 });
@@ -194,7 +194,7 @@ render(<ProfileDetail />);
 <TypeScriptEditor row={false}>
 
 ```ts title="Resources" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Post extends Entity {
   id = 0;
@@ -207,7 +207,7 @@ export class Post extends Entity {
   }
   static key = 'Post';
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
 });
@@ -229,7 +229,7 @@ export class User extends Entity {
   }
   static key = 'User';
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,

--- a/docs/core/api/useFetch.md
+++ b/docs/core/api/useFetch.md
@@ -37,7 +37,7 @@ function MasterPost({ id }: { id: number }) {
 
 | Expiry Status | Fetch           | Returns     | Conditions                                                                                            |
 | ------------- | --------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| Invalid       | yes<sup>1</sup> | Promise     | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate) |
+| Invalid       | yes<sup>1</sup> | Promise     | not in store, [deletion](/rest/api/resource#delete), [invalidation](./Controller.md#invalidate) |
 | Stale         | yes<sup>1</sup> | Promise     | (first-render, arg change) & [expiry &lt; now](../concepts/expiry-policy.md)                          |
 | Valid         | no              | `undefined` | fetch completion                                                                                      |
 |               | no              | `undefined` | `null` used as second argument                                                                        |

--- a/docs/core/api/useQuery.md
+++ b/docs/core/api/useQuery.md
@@ -100,7 +100,7 @@ export class User extends Entity {
   }
   static key = 'User';
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   path: '/users/:id',
   schema: User,
 });

--- a/docs/core/api/useSuspense.md
+++ b/docs/core/api/useSuspense.md
@@ -44,7 +44,7 @@ values={[
 <HooksPlayground fixtures={detailFixtures} row>
 
 ```typescript title="ProfileResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Profile extends Entity {
   id: number | undefined = undefined;
@@ -58,7 +58,7 @@ export class Profile extends Entity {
   static key = 'Profile';
 }
 
-export const ProfileResource = createResource({
+export const ProfileResource = resource({
   path: '/profiles/:id',
   schema: Profile,
 });
@@ -139,7 +139,7 @@ Cache policy is [Stale-While-Revalidate](https://tools.ietf.org/html/rfc5861) by
 
 | Expiry Status | Fetch           | Suspend | Error             | Conditions                                                                                                                                                                   |
 | ------------- | --------------- | ------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Invalid       | yes<sup>1</sup> | yes     | no                | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../concepts/expiry-policy.md#endpointinvalidifstale) |
+| Invalid       | yes<sup>1</sup> | yes     | no                | not in store, [deletion](/rest/api/resource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../concepts/expiry-policy.md#endpointinvalidifstale) |
 | Stale         | yes<sup>1</sup> | no      | no                | (first-render, arg change) & [expiry &lt; now](../concepts/expiry-policy.md)                                                                                                 |
 | Valid         | no              | no      | maybe<sup>2</sup> | fetch completion                                                                                                                                                             |
 |               | no              | no      | no                | `null` used as second argument                                                                                                                                               |
@@ -196,7 +196,7 @@ function useSuspense<
 <HooksPlayground fixtures={listFixtures} row>
 
 ```typescript title="ProfileResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Profile extends Entity {
   id: number | undefined = undefined;
@@ -210,7 +210,7 @@ export class Profile extends Entity {
   static key = 'Profile';
 }
 
-export const ProfileResource = createResource({
+export const ProfileResource = resource({
   path: '/profiles/:id',
   schema: Profile,
 });
@@ -268,7 +268,7 @@ function PostWithAuthor() {
 <TypeScriptEditor row={false}>
 
 ```ts title="Resources" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Post extends Entity {
   id = 0;
@@ -281,7 +281,7 @@ export class Post extends Entity {
   }
   static key = 'Post';
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
 });
@@ -303,7 +303,7 @@ export class User extends Entity {
   }
   static key = 'User';
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,

--- a/docs/core/concepts/atomic-mutations.md
+++ b/docs/core/concepts/atomic-mutations.md
@@ -24,14 +24,14 @@ Reactive Data Client uses your schema definitions to understand how to normalize
 an `entity table` and `result table`. Of course, this means that there is only ever one copy
 of a given `entity`. Aside from providing consistency when using different response endpoints,
 this means that by providing an accurate schema definition, Reactive Data Client can automatically keep
-all data uses consistent and fresh. The default update endpoints [Resource.update](/rest/api/createResource#update) and
-[Resource.partialUpdate](/rest/api/createResource#partialupdate) both do this automatically. [Read more about defining other
+all data uses consistent and fresh. The default update endpoints [Resource.update](/rest/api/resource#update) and
+[Resource.partialUpdate](/rest/api/resource#partialupdate) both do this automatically. [Read more about defining other
 update endpoints](/rest/guides/side-effects)
 
 ## Delete
 
 Reactive Data Client automatically deletes entity entries [schema.Invalidate](/rest/api/Invalidate) is used.
-[Resource.delete](/rest/api/createResource#delete)
+[Resource.delete](/rest/api/resource#delete)
 provides such an endpoint.
 
 ## Create

--- a/docs/core/concepts/expiry-policy.md
+++ b/docs/core/concepts/expiry-policy.md
@@ -147,7 +147,7 @@ Long cache lifetime
 import {
   RestEndpoint,
   RestGenerics,
-  createResource,
+  resource,
 } from '@data-client/rest';
 
 // We can now use LongLivingEndpoint to create endpoints that will be cached for one hour
@@ -157,7 +157,7 @@ class LongLivingEndpoint<
   dataExpiryLength = 60 * 60 * 1000; // one hour
 }
 
-const LongLivingResource = createResource({
+const LongLivingResource = resource({
   path: '/:id',
   Endpoint: LongLivingEndpoint,
 });
@@ -169,7 +169,7 @@ Never retry on error
 import {
   RestEndpoint,
   RestGenerics,
-  createResource,
+  resource,
 } from '@data-client/rest';
 
 // We can now use NoRetryEndpoint to create endpoints that will be cached for one hour
@@ -179,7 +179,7 @@ class NoRetryEndpoint<
   errorExpiryLength = Infinity;
 }
 
-const NoRetryResource = createResource({
+const NoRetryResource = resource({
   path: '/:id',
   Endpoint: NoRetryEndpoint,
 });

--- a/docs/core/concepts/overview.md
+++ b/docs/core/concepts/overview.md
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 | :----------------------------------: | --------------------------------------------- |
 |    [Endpoint](/rest/api/Endpoint)    | Async methods                                 |
 |     [Schema](./normalization.md)     | Declarative Data model                        |
-| [Resource](/rest/api/createResource) | Collection of methods for a given data model. |
+| [Resource](/rest/api/resource) | Collection of methods for a given data model. |
 
 ### Endpoint Conditions
 

--- a/docs/core/getting-started/data-dependency.md
+++ b/docs/core/getting-started/data-dependency.md
@@ -26,7 +26,7 @@ which guarantees data like [await](https://developer.mozilla.org/en-US/docs/Web/
 <HooksPlayground defaultOpen="n" row fixtures={postFixtures}>
 
 ```ts title="Resources" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class User extends Entity {
   id = 0;
@@ -45,7 +45,7 @@ export class User extends Entity {
   }
   static key = 'User';
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,
@@ -66,7 +66,7 @@ export class Post extends Entity {
     author: User,
   };
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
   paginationField: 'page',
@@ -314,7 +314,7 @@ For these cases, or compatibility with some component libraries, [useDLE()](../a
 <HooksPlayground fixtures={listFixtures} row>
 
 ```typescript title="ProfileResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Profile extends Entity {
   id: number | undefined = undefined;
@@ -328,7 +328,7 @@ export class Profile extends Entity {
   static key = 'Profile';
 }
 
-export const ProfileResource = createResource({
+export const ProfileResource = resource({
   path: '/profiles/:id',
   schema: Profile,
 });

--- a/docs/core/getting-started/mutations.md
+++ b/docs/core/getting-started/mutations.md
@@ -28,7 +28,7 @@ Using our [Create, Update, and Delete](/docs/concepts/atomic-mutations) endpoint
 <HooksPlayground defaultOpen="n" row fixtures={todoFixtures}>
 
 ```ts title="TodoResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Todo extends Entity {
   id = 0;
@@ -40,7 +40,7 @@ export class Todo extends Entity {
   }
   static key = 'Todo';
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   searchParams: {} as { userId?: string | number } | undefined,

--- a/docs/core/getting-started/resource.md
+++ b/docs/core/getting-started/resource.md
@@ -18,7 +18,7 @@ import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 
 # Define Resources
 
-[Resources](/rest/api/createResource) are a collection of `methods` for a given `data model`.
+[Resources](/rest/api/resource) are a collection of `methods` for a given `data model`.
 
 [Entities](/rest/api/Entity) and [Schemas](/rest/api/schema) declaratively define the [_data model_](../concepts/normalization.md).
 [Endpoints](/rest/api/Endpoint) are the [_methods_](<https://en.wikipedia.org/wiki/Method_(computer_programming)>) on
@@ -36,12 +36,12 @@ values={[
 
   <PkgInstall pkgs="@data-client/rest" />
 
-[createResource()](/rest/api/createResource) constructs a namespace of [RestEndpoints](/rest/api/RestEndpoint)
+[resource()](/rest/api/resource) constructs a namespace of [RestEndpoints](/rest/api/RestEndpoint)
 
 <TypeScriptEditor row={false}>
 
 ```typescript title="TodoResource"
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Todo extends Entity {
   id = 0;
@@ -55,7 +55,7 @@ export class Todo extends Entity {
   static key = 'Todo';
 }
 
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,

--- a/docs/core/guides/img-media.md
+++ b/docs/core/guides/img-media.md
@@ -14,7 +14,7 @@ some media fetches as well to take advantage of suspense and [concurrent mode su
 
 ## Storing ArrayBuffer
 
-[Resource](/rest/api/createResource) and [Entity](/rest/api/Entity) should not be used in this case, since they both represent
+[Resource](/rest/api/resource) and [Entity](/rest/api/Entity) should not be used in this case, since they both represent
 string -> value map structures. Instead, we'll define our own simple [Endpoint](/rest/api/Endpoint).
 
 ```typescript

--- a/docs/core/guides/storybook.md
+++ b/docs/core/guides/storybook.md
@@ -17,7 +17,7 @@ testing, potentially speeding up development time greatly.
 
 [&lt;MockResolver /\>](../api/MockResolver.md) enables easy loading of [fixtures or interceptors](../api/Fixtures.md) to see what
 different network responses might look like. It can be layered, composed, and even used
-for [imperative fetches](../api/Controller.md#fetch) usually used with side-effect endpoints like [getList.push](/rest/api/createResource#push) and [update](/rest/api/createResource#update).
+for [imperative fetches](../api/Controller.md#fetch) usually used with side-effect endpoints like [getList.push](/rest/api/resource#push) and [update](/rest/api/resource#update).
 
 ## Setup
 
@@ -41,7 +41,7 @@ export class Article extends Entity {
   }
   static key = 'Article';
 }
-export const ArticleResource = createResource({
+export const ArticleResource = resource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
   schema: Article,

--- a/docs/core/shared/_VoteDemo.mdx
+++ b/docs/core/shared/_VoteDemo.mdx
@@ -32,13 +32,13 @@ export class Post extends Entity {
 }
 ```
 
-```ts title="PostResource" {15-22}
-import { createResource } from '@data-client/rest';
+```ts title="PostResource" {14-21}
+import { resource } from '@data-client/rest';
 import { Post } from './Post';
 
 export { Post };
 
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   searchParams: {} as { userId?: string | number } | undefined,
   schema: Post,

--- a/docs/core/shared/_pagination.mdx
+++ b/docs/core/shared/_pagination.mdx
@@ -26,7 +26,7 @@ export class User extends Entity {
 ```
 
 ```ts title="Post" {22,24} collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 import { User } from './User';
 
 export class Post extends Entity {
@@ -44,7 +44,7 @@ export class Post extends Entity {
     author: User,
   };
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
   paginationField: 'cursor',

--- a/docs/core/shared/_useCancelling.mdx
+++ b/docs/core/shared/_useCancelling.mdx
@@ -13,7 +13,7 @@ export class Todo extends Entity {
   }
   static key = 'Todo';
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,

--- a/docs/core/shared/_useLoading.mdx
+++ b/docs/core/shared/_useLoading.mdx
@@ -4,7 +4,7 @@ import { postFixtures,getInitialInterceptorData } from '@site/src/fixtures/posts
 <HooksPlayground fixtures={postFixtures} getInitialInterceptorData={getInitialInterceptorData} row>
 
 ```ts title="PostResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Post extends Entity {
   id = 0;
@@ -22,7 +22,7 @@ export class Post extends Entity {
     return `//loremflickr.com/96/72/kitten,cat?lock=${this.id % 16}`;
   }
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
 });

--- a/docs/core/shared/_useTransition.mdx
+++ b/docs/core/shared/_useTransition.mdx
@@ -7,7 +7,7 @@ import {
 <HooksPlayground fixtures={postFixtures} getInitialInterceptorData={getInitialInterceptorData} row>
 
 ```ts title="PostResource" collapsed
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Post extends Entity {
   id = 0;
@@ -25,7 +25,7 @@ export class Post extends Entity {
     return `//loremflickr.com/96/72/kitten,cat?lock=${this.id % 16}`;
   }
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
 });

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -22,7 +22,7 @@ When using TypeScript (optional), version 4.0 or above is required.
 
 ## Define the API
 
-[Resources](./api/createResource.md) are a collection of `methods` for a given `data model`. [Entities](./api/Entity.md) and [Schemas](./api/schema.md) are the declarative _data model_.
+[Resources](./api/resource.md) are a collection of `methods` for a given `data model`. [Entities](./api/Entity.md) and [Schemas](./api/schema.md) are the declarative _data model_.
 [RestEndpoint](./api/RestEndpoint.md) are the [_methods_](<https://en.wikipedia.org/wiki/Method_(computer_programming)>) on
 that data.
 
@@ -50,7 +50,7 @@ export class User extends Entity {
 ```
 
 ```typescript title="Article"
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 import { User } from './User';
 
 export class Article extends Entity {
@@ -73,7 +73,7 @@ export class Article extends Entity {
   static key = 'Article';
 }
 
-export const ArticleResource = createResource({
+export const ArticleResource = resource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
   searchParams: {} as { userId?: string } | undefined,
@@ -100,7 +100,7 @@ export class UserEntity extends schema.Entity(User) {}
 ```
 
 ```typescript title="Article"
-import { schema, createResource } from '@data-client/rest';
+import { schema, resource } from '@data-client/rest';
 import { UserEntity } from './User';
 
 export class Article {
@@ -120,7 +120,7 @@ export class ArticleEntity extends schema.Entity(Article, {
   key: 'Article',
 }) {}
 
-export const ArticleResource = createResource({
+export const ArticleResource = resource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
   searchParams: {} as { userId?: string } | undefined,
@@ -230,7 +230,7 @@ export default function NewArticleForm() {
 }
 ```
 
-[getList.push](api/createResource.md#push) then takes any `keyable` body to send as the payload and then returns a promise that
+[getList.push](api/resource.md#push) then takes any `keyable` body to send as the payload and then returns a promise that
 resolves to the new Resource created by the API. It will automatically be added in the cache for any consumers to display.
 
 </TabItem>
@@ -258,7 +258,7 @@ export default function UpdateArticleForm({ id }: { id: number }) {
 }
 ```
 
-[update](api/createResource.md#update) then takes any `keyable` body to send as the payload and then returns a promise that
+[update](api/resource.md#update) then takes any `keyable` body to send as the payload and then returns a promise that
 then takes any `keyable` body to send as the payload and then returns a promise that
 resolves to the new Resource created by the API. It will automatically be added in the cache for any consumers to display.
 

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -87,7 +87,7 @@ object.
 
 :::tip
 
-Entities are bound to Endpoints using [createResource.schema](./createResource.md#schema) or
+Entities are bound to Endpoints using [resource.schema](./resource.md#schema) or
 [RestEndpoint.schema](./RestEndpoint.md#schema)
 
 :::
@@ -581,7 +581,7 @@ export class User extends Entity {
   // highlight-next-line
   static indexes = ['username' as const];
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   path: '/user/:id',
   schema: User,
 });

--- a/docs/rest/api/Invalidate.md
+++ b/docs/rest/api/Invalidate.md
@@ -117,7 +117,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource" {9}
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/posts/:id',
 }).extend('deleteMany', {
@@ -164,7 +164,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource" {10-13}
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/posts/:id',
 }).extend('deleteMany', {

--- a/docs/rest/api/Query.md
+++ b/docs/rest/api/Query.md
@@ -61,7 +61,7 @@ export class User extends Entity {
     return this.id;
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   path: '/users/:id',
   schema: User,
 });
@@ -115,7 +115,7 @@ export class User extends Entity {
     return `${this.id}`;
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,
@@ -137,7 +137,7 @@ export class Todo extends Entity {
     userId: User,
   };
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,
@@ -192,7 +192,7 @@ export class User extends Entity {
     return `${this.id}`;
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,
@@ -214,7 +214,7 @@ export class Todo extends Entity {
     userId: User,
   };
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,

--- a/docs/rest/api/hookifyResource.md
+++ b/docs/rest/api/hookifyResource.md
@@ -13,7 +13,7 @@ import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 
 # hookfiyResource
 
-`hookifyResource()` Turns any [Resource](./createResource.md) (collection of [RestEndpoints](./RestEndpoint.md)) into a collection
+`hookifyResource()` Turns any [Resource](./resource.md) (collection of [RestEndpoints](./RestEndpoint.md)) into a collection
 of hooks that return [RestEndpoints](./RestEndpoint.md).
 
 :::info
@@ -26,7 +26,7 @@ TypeScript >=4.3 is required for generative types to work correctly.
 
 ```ts title="api/ArticleResource.ts"
 import React from 'react';
-import { createResource, hookifyResource, Entity } from '@data-client/rest';
+import { resource, hookifyResource, Entity } from '@data-client/rest';
 
 class Article extends Entity {
   id = '';
@@ -39,7 +39,7 @@ class Article extends Entity {
 }
 const AuthContext = React.createContext('');
 
-const ArticleResourceBase = createResource({
+const ArticleResourceBase = resource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
   schema: Article,
@@ -75,7 +75,7 @@ render(<ArticleDetail id="1" />);
 
 ## Members
 
-Assuming you use the unchanged result of [createResource()](./createResource.md), these will be your methods
+Assuming you use the unchanged result of [resource()](./resource.md), these will be your methods
 
 ### useGet()
 
@@ -86,7 +86,7 @@ Assuming you use the unchanged result of [createResource()](./createResource.md)
 ```typescript
 // GET //test.com/api/abc/xyz
 hookifyResource(
-  createResource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
+  resource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
 ).useGet()({
   group: 'abc',
   id: 'xyz',
@@ -101,9 +101,9 @@ Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidat
 - path: `shortenPath(path)`
   - Removes the last argument:
     ```ts
-    hookifyResource(createResource({ path: '/:first/:second' })).useGetList()
+    hookifyResource(resource({ path: '/:first/:second' })).useGetList()
       .path === '/:first';
-    hookifyResource(createResource({ path: '/:first' })).useGetList().path ===
+    hookifyResource(resource({ path: '/:first' })).useGetList().path ===
       '/';
     ```
 - schema: [\[schema\]](./Array.md)
@@ -111,7 +111,7 @@ Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidat
 ```typescript
 // GET //test.com/api/abc?isExtra=xyz
 hookifyResource(
-  createResource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
+  resource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
 ).useGetList()({
   group: 'abc',
   isExtra: 'xyz',
@@ -131,7 +131,7 @@ Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidat
 ```typescript
 // POST //test.com/api/abc
 // BODY { "title": "winning" }
-createResource({
+resource({
   urlPrefix: '//test.com',
   path: '/api/:group/:id',
 }).useGetList().push({ group: 'abc' }, { title: 'winning' });
@@ -150,7 +150,7 @@ Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 ```typescript
 // POST //test.com/api/abc
 // BODY { "title": "winning" }
-createResource({
+resource({
   urlPrefix: '//test.com',
   path: '/api/:group/:id',
 }).useGetList().push({ group: 'abc' }, { title: 'winning' });
@@ -168,7 +168,7 @@ Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 
 ```typescript
 // GET //test.com/api/abc?isExtra=xyz&page=2
-createResource({
+resource({
   urlPrefix: '//test.com',
   path: '/api/:group/:id',
   paginationField: 'page',
@@ -191,7 +191,7 @@ Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 // PUT //test.com/api/abc/xyz
 // BODY { "title": "winning" }
 hookifyResource(
-  createResource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
+  resource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
 ).useUpdate()({ group: 'abc', id: 'xyz' }, { title: 'winning' });
 ```
 
@@ -207,7 +207,7 @@ Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 // PATCH //test.com/api/abc/xyz
 // BODY { "title": "winning" }
 hookifyResource(
-  createResource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
+  resource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
 ).usePartialUpdate()({ group: 'abc', id: 'xyz' }, { title: 'winning' });
 ```
 
@@ -228,7 +228,7 @@ Commonly used with [Controller.fetch](/docs/api/Controller#fetch)
 ```typescript
 // DELETE //test.com/api/abc/xyz
 hookifyResource(
-  createResource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
+  resource({ urlPrefix: '//test.com', path: '/api/:group/:id' }),
 ).useDelete()({
   group: 'abc',
   id: 'xyz',

--- a/docs/rest/api/resource.md
+++ b/docs/rest/api/resource.md
@@ -1,7 +1,7 @@
 ---
-id: createResource
-title: createResource() - TypeScript definition for REST API resources
-sidebar_label: createResource
+id: resource
+title: resource() - TypeScript definition for REST API resources
+sidebar_label: resource
 description: Resources are a collection of RestEndpoints that operate on a common data by sharing a schema
 ---
 
@@ -15,7 +15,7 @@ import EndpointPlayground from '@site/src/components/HTTP/EndpointPlayground';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 import DeleteProcess from './\_DeleteProcess.mdx';
 
-# createResource
+# Resource
 
 `Resources` are a collection of [RestEndpoints](./RestEndpoint.md) that operate on a common
 data by sharing a [schema](./schema.md)
@@ -33,7 +33,7 @@ export class Todo extends Entity {
   static key = 'Todo';
 }
 
-const TodoResource = createResource({
+const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,
@@ -82,7 +82,7 @@ Passed to [RestEndpoint.path](./RestEndpoint.md#path) for single item [](#member
 Create ([getList.push](#push)/[getList.unshift](#unshift)) and [getList](#getlist) remove the last argument.
 
 ```ts
-const PostResource = createResource({
+const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
 });
@@ -139,7 +139,7 @@ export default class AuthdEndpoint<
     };
   }
 }
-const TodoResource = createResource({
+const TodoResource = resource({
   path: '/todos/:id',
   schema: Todo,
   // highlight-next-line
@@ -152,7 +152,7 @@ const TodoResource = createResource({
 [Collection Class](./Collection.md) used to construct [getList](#getlist) schema.
 
 ```ts
-import { schema, createResource } from '@data-client/rest';
+import { schema, resource } from '@data-client/rest';
 
 class MyCollection<
   S extends any[] | PolymorphicInterface = any,
@@ -164,7 +164,7 @@ class MyCollection<
     return key === 'orderBy';
   }
 }
-const TodoResource = createResource({
+const TodoResource = resource({
   path: '/todos/:id',
   searchParams: {} as { userId?: string; orderBy?: string } | undefined,
   schema: Todo,
@@ -182,7 +182,7 @@ These provide the standard [CRUD](https://en.wikipedia.org/wiki/Create,_read,_up
 new endpoints](#extend-new) based to match your API.
 
 ```ts
-const PostResource = createResource({
+const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -221,7 +221,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -266,7 +266,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -293,8 +293,8 @@ PostResource.getList({
 
 <!-- prettier-ignore-start -->
 ```ts
-createResource({ path: '/:first/:second' }).getList.path === '/:first';
-createResource({ path: '/:first' }).getList.path === '/';
+resource({ path: '/:first/:second' }).getList.path === '/:first';
+resource({ path: '/:first' }).getList.path === '/';
 ```
 <!-- prettier-ignore-end -->
 
@@ -321,7 +321,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -368,7 +368,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -417,7 +417,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -468,7 +468,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -514,7 +514,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -560,7 +560,7 @@ export default class Post extends Entity {
 
 ```typescript title="Resource"
 import Post from './Post';
-export const PostResource = createResource({
+export const PostResource = resource({
   schema: Post,
   path: '/:group/posts/:id',
   searchParams: {} as { author?: string },
@@ -600,14 +600,14 @@ This allows [schema.Invalidate](./Invalidate.md) to remove the entity from the [
 
 ### extend() {#extend}
 
-`createResource` builds a great starting point, but often endpoints need to be [further customized](./RestEndpoint.md#typing).
+`resource` builds a great starting point, but often endpoints need to be [further customized](./RestEndpoint.md#typing).
 
 `extend()` is polymorphic with three forms:
 
 #### Batch extension of known members {#extend-override}
 
 ```ts
-export const CommentResource = createResource({
+export const CommentResource = resource({
   path: '/repos/:owner/:repo/issues/comments/:id',
   schema: Comment,
 }).extend({
@@ -631,7 +631,7 @@ export const UserResource = createGithubResource({
 #### Function form (to get BaseResource/super) {#extend-function}
 
 ```ts
-export const IssueResource= createResource({
+export const IssueResource= resource({
   path: '/repos/:owner/:repo/issues/:number',
   schema: Issue,
   pollFrequency: 60000,
@@ -657,12 +657,12 @@ export const IssueResource= createResource({
 
 ## Function Inheritance Patterns
 
-To reuse code around `Resource` design, you can create your own function that calls createResource().
+To reuse code around `Resource` design, you can create your own function that calls resource().
 This has similar effects as class-based inheritance.
 
 ```typescript
 import {
-  createResource,
+  resource,
   RestEndpoint,
   type EndpointExtraOptions,
   type RestGenerics,
@@ -686,7 +686,7 @@ export function createMyResource<O extends ResourceGenerics = any>({
   Endpoint = AuthdEndpoint,
   ...extraOptions
 }: Readonly<O> & ResourceOptions) {
-  return createResource({
+  return resource({
     Endpoint,
     schema,
     ...extraOptions,

--- a/docs/rest/guides/auth.md
+++ b/docs/rest/guides/auth.md
@@ -32,7 +32,7 @@ export default class AuthdEndpoint<
 ```
 
 ```ts title="MyResource" collapsed
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 import AuthdEndpoint from './AuthdEndpoint';
 
 class MyEntity extends Entity {
@@ -43,7 +43,7 @@ class MyEntity extends Entity {
   }
 }
 
-export const MyResource = createResource({
+export const MyResource = resource({
   path: '/my/:id',
   schema: MyEntity,
   Endpoint: AuthdEndpoint,
@@ -114,7 +114,7 @@ export default function Auth() {
 ```
 
 ```ts title="MyResource" collapsed
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 import AuthdEndpoint from './AuthdEndpoint';
 
 class MyEntity extends Entity {
@@ -125,7 +125,7 @@ class MyEntity extends Entity {
   }
 }
 
-export const MyResource = createResource({
+export const MyResource = resource({
   path: '/my/:id',
   schema: MyEntity,
   Endpoint: AuthdEndpoint,
@@ -190,7 +190,7 @@ export default function Auth() {
 ```
 
 ```ts title="MyResource" collapsed
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 import AuthdEndpoint from './AuthdEndpoint';
 
 class MyEntity extends Entity {
@@ -201,7 +201,7 @@ class MyEntity extends Entity {
   }
 }
 
-export const MyResource = createResource({
+export const MyResource = resource({
   path: '/my/:id',
   schema: MyEntity,
   Endpoint: AuthdEndpoint,
@@ -265,7 +265,7 @@ export default function Auth() {
 ```
 
 ```ts title="MyResource" collapsed
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 import AuthdEndpoint from './AuthdEndpoint';
 
 class MyEntity extends Entity {
@@ -276,7 +276,7 @@ class MyEntity extends Entity {
   }
 }
 
-export const MyResource = createResource({
+export const MyResource = resource({
   path: '/my/:id',
   schema: MyEntity,
   Endpoint: AuthdEndpoint,
@@ -310,16 +310,16 @@ values={[
 ]}>
 <TabItem value="resource">
 
-We can transform any [Resource](../api/createResource.md) into one that uses hooks to create endpoints
+We can transform any [Resource](../api/resource.md) into one that uses hooks to create endpoints
 by using [hookifyResource](../api/hookifyResource.md)
 
 ```ts title="api/Post.ts"
-import { createResource, hookifyResource } from '@data-client/rest';
+import { resource, hookifyResource } from '@data-client/rest';
 
 // Post defined here
 
 export const PostResource = hookifyResource(
-  createResource({ path: '/posts/:id', schema: Post }),
+  resource({ path: '/posts/:id', schema: Post }),
   function useInit(): RequestInit {
     const accessToken = useAuthContext();
     return {

--- a/docs/rest/guides/computed-properties.md
+++ b/docs/rest/guides/computed-properties.md
@@ -106,7 +106,7 @@ export class User extends Entity {
     return this.id;
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   path: '/users/:id',
   schema: User,
 });

--- a/docs/rest/guides/django.md
+++ b/docs/rest/guides/django.md
@@ -60,7 +60,7 @@ export default class DjangoEndpoint<
 ```
 
 ```ts title="MyResource" collapsed {15}
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 import DjangoEndpoint from './DjangoEndpoint';
 
 class MyEntity extends Entity {
@@ -71,7 +71,7 @@ class MyEntity extends Entity {
   }
 }
 
-export const MyResource = createResource({
+export const MyResource = resource({
   path: '/my/:id',
   schema: MyEntity,
   Endpoint: DjangoEndpoint,

--- a/docs/rest/guides/mocking-unfinished.md
+++ b/docs/rest/guides/mocking-unfinished.md
@@ -12,7 +12,7 @@ you won't need to make major changes to your code.
 <HooksPlayground>
 
 ```typescript title="api/Rating"
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Rating extends Entity {
   id = '';
@@ -30,7 +30,7 @@ export class Rating extends Entity {
   };
 }
 
-export const RatingResource = createResource({
+export const RatingResource = resource({
   path: '/ratings/:id',
   schema: Rating,
 }).extend({

--- a/docs/rest/guides/optimistic-updates.md
+++ b/docs/rest/guides/optimistic-updates.md
@@ -22,12 +22,12 @@ handles these for you.
 
 ## Resources
 
-[createResource()](../api/createResource.md) can be configured by setting [optimistic: true](../api/createResource.md#optimistic).
+[resource()](../api/resource.md) can be configured by setting [optimistic: true](../api/resource.md#optimistic).
 
 <HooksPlayground defaultOpen="n" row fixtures={todoFixtures}>
 
 ```ts title="TodoResource" {18}
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Todo extends Entity {
   id = 0;
@@ -39,7 +39,7 @@ export class Todo extends Entity {
   }
   static key = 'Todo';
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   searchParams: {} as { userId?: string | number } | undefined,
@@ -194,7 +194,7 @@ function optimisticDelete(snap: SnapshotInterface, params: any) {
 
 In case you do not want all endpoints to be optimistic, or if you have unusual API designs,
 you can set [getOptimisticResponse()](../api/RestEndpoint.md#getoptimisticresponse) using
-[Resource.extend()](../api/createResource.md#extend)
+[Resource.extend()](../api/resource.md#extend)
 
 ## Optimistic Transforms
 

--- a/docs/rest/guides/pagination.md
+++ b/docs/rest/guides/pagination.md
@@ -16,15 +16,15 @@ import PaginationDemo from '../../core/shared/\_pagination.mdx';
 ## Expanding Lists
 
 In case you want to append results to your existing list, rather than move to another page
-[Resource.getList.getPage](../api/createResource.md#getpage) can be used as long as [paginationField](../api/createResource.md#paginationfield) was provided.
+[Resource.getList.getPage](../api/resource.md#getpage) can be used as long as [paginationField](../api/resource.md#paginationfield) was provided.
 
 <PaginationDemo />
 
-Don't forget to define our [Resource's](../api/createResource.md) [paginationField](../api/createResource.md#paginationfield) and
-correct [schema](../api/createResource.md#schema)!
+Don't forget to define our [Resource's](../api/resource.md) [paginationField](../api/resource.md#paginationfield) and
+correct [schema](../api/resource.md#schema)!
 
 ```ts title="Post"
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
   // highlight-next-line
@@ -46,7 +46,7 @@ Scroll to the bottom of the preview to click _"Load more"_ to append the next pa
 
 Here we explore a real world example using [cosmos validators list](https://rest.cosmos.directory/stargaze/cosmos/staking/v1beta1/validators).
 
-Since validators only have one Endpoint, we use [RestEndpoint](../api/RestEndpoint.md) instead of [createResource](../api/createResource.md). By using [Collections](../api/Collection.md) and [paginationField](../api/RestEndpoint.md#paginationfield), we can call [RestEndpoint.getPage](../api/RestEndpoint.md#getpage)
+Since validators only have one Endpoint, we use [RestEndpoint](../api/RestEndpoint.md) instead of [resource](../api/resource.md). By using [Collections](../api/Collection.md) and [paginationField](../api/RestEndpoint.md#paginationfield), we can call [RestEndpoint.getPage](../api/RestEndpoint.md#getpage)
 to append the next page of validators to our list.
 
 <HooksPlayground defaultOpen="n" row>
@@ -195,7 +195,7 @@ function NewsList() {
 
 In some cases the pagination tokens will be embeded in HTTP headers, rather than part of the payload. In this
 case you'll need to customize the [parseResponse()](api/RestEndpoint.md#parseResponse) function
-for [getList](api/createResource.md#getlist) so the pagination headers are included fetch object.
+for [getList](api/resource.md#getlist) so the pagination headers are included fetch object.
 
 We show the custom `getList` below. All other parts of the above example remain the same.
 
@@ -204,7 +204,7 @@ Pagination token is stored in the header `link` for this example.
 ```typescript
 import { Resource } from '@data-client/rest';
 
-export const ArticleResource = createResource({
+export const ArticleResource = resource({
   path: '/articles/:id',
   schema: Article,
 }).extend(Base => ({
@@ -255,11 +255,11 @@ export class PagingEndpoint<
 ```
 
 ```ts title="api/My.ts"
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 
 import { PagingEndpoint } from './PagingEndpoint';
 
-export const MyResource = createResource({
+export const MyResource = resource({
   path: '/stuff/:id',
   schema: MyEntity,
   Endpoint: PagingEndpoint,

--- a/docs/rest/guides/partial-entities.md
+++ b/docs/rest/guides/partial-entities.md
@@ -6,7 +6,7 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 import {RestEndpoint} from '@data-client/rest';
 import Grid from '@site/src/components/Grid';
 
-Sometimes you have a [list endpoint](../api/createResource.md#getlist) whose entities only include
+Sometimes you have a [list endpoint](../api/resource.md#getlist) whose entities only include
 a subset of fields needed to summarize.
 
 <Grid>
@@ -68,7 +68,7 @@ delay: 150,
 
 ```typescript title="api/Article" {12,24}
 import { validateRequired } from '@data-client/rest';
-import { Entity, createResource, schema } from '@data-client/rest';
+import { Entity, resource, schema } from '@data-client/rest';
 
 export class ArticleSummary extends Entity {
   id = '';
@@ -94,7 +94,7 @@ export class Article extends ArticleSummary {
   }
 }
 
-export const ArticleResource = createResource({
+export const ArticleResource = resource({
   path: '/article/:id',
   schema: Article,
 }).extend({
@@ -206,7 +206,7 @@ class ArticleMeta extends Entity {
   };
 }
 
-const ArticleResource = createResource({
+const ArticleResource = resource({
   path: '/article/:id',
   schema: Article,
 }).extend({

--- a/docs/rest/guides/relational-data.md
+++ b/docs/rest/guides/relational-data.md
@@ -136,7 +136,7 @@ export class Post extends Entity {
   };
 }
 
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
 });
@@ -196,7 +196,7 @@ export class User extends Entity {
     return `${this.id}`;
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,
@@ -218,7 +218,7 @@ export class Todo extends Entity {
     userId: User,
   };
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,
@@ -413,12 +413,12 @@ Comment.schema = {
   post: Post,
 };
 
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   schema: Post,
   dataExpiryLength: Infinity,
 });
-export const UserResource = createResource({
+export const UserResource = resource({
   path: '/users/:id',
   schema: User,
 });

--- a/docs/rest/guides/side-effects.md
+++ b/docs/rest/guides/side-effects.md
@@ -74,9 +74,9 @@ To handle this, we just need to update the `schema` to include the custom
 endpoint.
 
 ```typescript title="api/TradeResource.ts"
-import { createResource } from '@data-client/rest';
+import { resource } from '@data-client/rest';
 
-export const TradeResource = createResource({
+export const TradeResource = resource({
   path: '/trade/:id',
   schema: Trade,
 }).extend(Base => ({
@@ -89,7 +89,7 @@ export const TradeResource = createResource({
 }));
 ```
 
-Now if when we use the [getList.push](../api/createResource.md#push) Endpoint generator method,
+Now if when we use the [getList.push](../api/resource.md#push) Endpoint generator method,
 we will be happy knowing both the trade and account information will
 be updated in the cache after the `POST` request is complete.
 

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -11,7 +11,7 @@ export type {
   EndpointExtendOptions,
 } from './endpoint.js';
 export * as schema from './schema.js';
-// Without this we get 'cannot be named without a reference to' for createResource()....why is this?
+// Without this we get 'cannot be named without a reference to' for resource()....why is this?
 // Clue 1) It only happens with types mentioned in return types of other types
 export type { Array, Invalidate, Collection, DefaultArgs } from './schema.js';
 export { default as Entity } from './schemas/Entity.js';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -67,13 +67,13 @@ class Article extends Entity {
 ### Create [collection of API Endpoints](https://dataclient.io/docs/getting-started/resource)
 
 ```typescript
-const UserResource = createResource({
+const UserResource = resource({
   path: '/users/:id',
   schema: User,
   optimistic: true,
 });
 
-const ArticleResource = createResource({
+const ArticleResource = resource({
   path: '/articles/:id',
   schema: Article,
   searchParams: {} as { author?: string },

--- a/packages/react/src/__tests__/integration-collections.tsx
+++ b/packages/react/src/__tests__/integration-collections.tsx
@@ -1,7 +1,7 @@
 import { CacheProvider } from '@data-client/react';
 import { DataProvider as ExternalDataProvider } from '@data-client/react/redux';
 import { schema, RestEndpoint, PolymorphicInterface } from '@data-client/rest';
-import { createResource } from '@data-client/rest';
+import { resource } from '@data-client/rest';
 import {
   IDEntity,
   Article,
@@ -43,17 +43,17 @@ class User extends IDEntity {
   };
 }
 
-const UserResource = createResource({
+const UserResource = resource({
   path: '/users/:id',
   schema: User,
 });
-const TodoResource = createResource({
+const TodoResource = resource({
   path: '/todos/:id',
   searchParams: {} as { userId?: string } | undefined,
   schema: Todo,
 });
 // for nesting test
-const BaseArticleResource = createResource({
+const BaseArticleResource = resource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
   schema: Article,
@@ -73,7 +73,7 @@ const ArticleResource = {
   }),
 };
 // for pagination test
-const ArticlePaginatedResource = createResource({
+const ArticlePaginatedResource = resource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
   searchParams: {} as { userId?: number; extra?: undefined } | undefined,
@@ -86,23 +86,23 @@ const ArticlePaginatedResource = createResource({
   },
 });
 
-const UnionResource = createResource({
+const UnionResource = resource({
   path: '/union/:id',
   schema: UnionSchema,
 });
 
-const UserResourceLegacy = createResource({
+const UserResourceLegacy = resource({
   path: '/users/:id',
   schema: User,
   Endpoint: RestEndpoint as any,
 });
-const TodoResourceLegacy = createResource({
+const TodoResourceLegacy = resource({
   path: '/todos/:id',
   searchParams: {} as { userId?: string } | undefined,
   schema: Todo,
   Endpoint: RestEndpoint as any,
 });
-const BaseArticleResourceLegacy = createResource({
+const BaseArticleResourceLegacy = resource({
   urlPrefix: 'http://test.com',
   path: '/article/:id',
   schema: Article,
@@ -370,7 +370,7 @@ describe.each([
         return key === 'sorted';
       }
     }
-    const TodoResource = createResource({
+    const TodoResource = resource({
       path: '/todos/:id',
       searchParams: {} as { userId?: string; sorted?: boolean } | undefined,
       schema: Todo,

--- a/packages/react/src/__tests__/optional-members.tsx
+++ b/packages/react/src/__tests__/optional-members.tsx
@@ -1,4 +1,4 @@
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 
 import { useSuspense, useCache, CacheProvider } from '../';
 import { Fixture, FixtureEndpoint, makeRenderDataClient } from '../../../test';
@@ -23,7 +23,7 @@ export class Some extends Entity {
     things: [Nested],
   };
 }
-const SomeResource = createResource({ path: '/some/:id', schema: Some });
+const SomeResource = resource({ path: '/some/:id', schema: Some });
 
 const fixture: FixtureEndpoint = {
   endpoint: SomeResource.getList,

--- a/packages/react/src/hooks/__tests__/useQuery.tsx
+++ b/packages/react/src/hooks/__tests__/useQuery.tsx
@@ -1,6 +1,6 @@
 import { schema } from '@data-client/endpoint';
 import { CacheProvider } from '@data-client/react';
-import { createResource } from '@data-client/rest';
+import { resource } from '@data-client/rest';
 import {
   ArticleWithSlug,
   ArticleSlugResource,
@@ -186,7 +186,7 @@ describe('useQuery()', () => {
       }),
     });
 
-    const UserResource = createResource({ schema: User, path: '/users/:id' });
+    const UserResource = resource({ schema: User, path: '/users/:id' });
 
     const initialFixtures = [
       {
@@ -228,7 +228,7 @@ describe('useQuery()', () => {
   });
 
   it('should work with unions', async () => {
-    const UnionResource = createResource({
+    const UnionResource = resource({
       path: '/union/:id',
       schema: UnionSchema,
     });
@@ -271,7 +271,7 @@ describe('useQuery()', () => {
     const prevWarn = global.console.warn;
     global.console.warn = jest.fn();
 
-    const UnionResource = createResource({
+    const UnionResource = resource({
       path: '/union/:id',
       schema: UnionSchema,
     });

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -37,9 +37,9 @@ It automatically handles REST concepts like JSON serialization, consolidated err
 
 ## Resources
 
-Simplify related CRUD endpoints with [Resources](https://dataclient.io/rest/api/createResource)
+Simplify related CRUD endpoints with [Resources](https://dataclient.io/rest/api/resource)
 
-[Resources](https://dataclient.io/rest/api/createResource) are a collection of `methods` for a given `data model`.
+[Resources](https://dataclient.io/rest/api/resource) are a collection of `methods` for a given `data model`.
 
 [Entities](https://dataclient.io/rest/api/Entity) and [Schemas](https://dataclient.io/concepts/normalization) declaratively define the _data model_.
 [RestEndpoints](https://dataclient.io/rest/api/RestEndpoint) are the [_methods_](<https://en.wikipedia.org/wiki/Method_(computer_programming)>) on
@@ -55,7 +55,7 @@ class Todo extends Entity {
     return `${this.id}`;
   }
 }
-const TodoResource = createResource({
+const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   searchParams: {} as { userId?: string | number },
@@ -64,7 +64,7 @@ const TodoResource = createResource({
 });
 ```
 
-One Resource defines [seven endpoints](https://dataclient.io/rest/api/createResource#members):
+One Resource defines [seven endpoints](https://dataclient.io/rest/api/resource#members):
 
 ```typescript
 // GET https://jsonplaceholder.typicode.com/todos/5
@@ -145,7 +145,7 @@ supports inferring argument types from the path templates.
 
 - Networking definition
   - [Endpoints](https://dataclient.io/rest/api/Endpoint): [RestEndpoint](https://dataclient.io/rest/api/RestEndpoint)
-  - [Resources](https://dataclient.io/docs/getting-started/resource): [createResource()](https://dataclient.io/rest/api/createResource), [hookifyResource()](https://dataclient.io/rest/api/hookifyResource)
+  - [Resources](https://dataclient.io/docs/getting-started/resource): [resource()](https://dataclient.io/rest/api/resource), [hookifyResource()](https://dataclient.io/rest/api/hookifyResource)
 - [Data model](https://dataclient.io/docs/concepts/normalization)
   - [Entity](https://dataclient.io/rest/api/Entity), [schema.Entity](https://dataclient.io/rest/api/schema.Entity) mixin
   - [Object](https://dataclient.io/rest/api/Object)

--- a/packages/rest/src/__tests__/Resource.test.ts
+++ b/packages/rest/src/__tests__/Resource.test.ts
@@ -5,7 +5,7 @@ import { CacheProvider } from '@data-client/react';
 import nock from 'nock';
 
 import { makeRenderDataClient } from '../../../test';
-import createResource from '../createResource';
+import resource from '../resource';
 import { ResourcePath } from '../pathTypes';
 import RestEndpoint from '../RestEndpoint';
 import {
@@ -30,7 +30,7 @@ export class User extends Entity {
     return this.id?.toString();
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   path: 'http\\://test.com/user/:id',
   schema: User,
 });
@@ -58,7 +58,7 @@ function createPaginatableResource<U extends ResourcePath, S extends Schema>({
   readonly schema: S;
   readonly Endpoint?: typeof RestEndpoint;
 }) {
-  const baseResource = createResource({ path, schema, Endpoint });
+  const baseResource = resource({ path, schema, Endpoint });
   const getList = baseResource.getList.extend({
     path: 'http\\://test.com/article-paginated',
     schema: {
@@ -82,7 +82,7 @@ export class UrlArticle extends PaginatedArticle {
   readonly url: string = 'happy.com';
 }
 
-describe('createResource()', () => {
+describe('resource()', () => {
   const renderDataClient: ReturnType<typeof makeRenderDataClient> =
     makeRenderDataClient(CacheProvider);
   let mynock: nock.Scope;
@@ -142,7 +142,7 @@ describe('createResource()', () => {
   });
 
   it('should handle multiarg urls', () => {
-    const MyUserResource = createResource({
+    const MyUserResource = resource({
       path: 'http\\://test.com/groups/:group/users/:id',
       schema: User,
     });
@@ -261,7 +261,7 @@ describe('createResource()', () => {
         return this.id;
       }
     }
-    const ComplexResource = createResource({
+    const ComplexResource = resource({
       path: '/complex-thing/:id',
       schema: ComplexEntity,
     });

--- a/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
+++ b/packages/rest/src/__tests__/__snapshots__/createResource.test.ts.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createResource() UserResource.delete should work with  1`] = `"not found"`;
+exports[`resource() UserResource.delete should work with  1`] = `"not found"`;
 
-exports[`createResource() UserResource.delete should work with {"id": 5} 1`] = `"not found"`;
+exports[`resource() UserResource.delete should work with {"id": 5} 1`] = `"not found"`;
 
-exports[`createResource() should not allow paths without at least one argument 1`] = `"Resource path requires at least one :parameter"`;
+exports[`resource() should not allow paths without at least one argument 1`] = `"Resource path requires at least one :parameter"`;
 
-exports[`createResource() warnings should warn when mis-capitalizing options 1`] = `
+exports[`resource() warnings should warn when mis-capitalizing options 1`] = `
 [
   [
     "You passed 'endpoint' option; did you mean to use Endpoint?
-https://dataclient.io/rest/api/createResource#endpoint
+https://dataclient.io/rest/api/resource#endpoint
 This parameter must be capitalized.
 
 This warning will not show in production.",
@@ -18,11 +18,11 @@ This warning will not show in production.",
 ]
 `;
 
-exports[`createResource() warnings should warn when mis-capitalizing options 2`] = `
+exports[`resource() warnings should warn when mis-capitalizing options 2`] = `
 [
   [
     "You passed 'collection' option; did you mean to use Collection?
-https://dataclient.io/rest/api/createResource#collection
+https://dataclient.io/rest/api/resource#collection
 This parameter must be capitalized.
 
 This warning will not show in production.",

--- a/packages/rest/src/__tests__/createResource.test.ts
+++ b/packages/rest/src/__tests__/createResource.test.ts
@@ -11,10 +11,10 @@ import {
 import { makeRenderDataClient, act } from '@data-client/test';
 import nock, { ReplyHeaders } from 'nock';
 
-import createResource from '../createResource';
+import resource from '../resource';
 import RestEndpoint, { RestGenerics } from '../RestEndpoint';
 
-describe('createResource()', () => {
+describe('resource()', () => {
   const renderDataClient: ReturnType<typeof makeRenderDataClient> =
     makeRenderDataClient(CacheProvider);
   let mynock: nock.Scope;
@@ -44,7 +44,7 @@ describe('createResource()', () => {
     additional = 5;
   }
 
-  const UserResource = createResource({
+  const UserResource = resource({
     path: 'http\\://test.com/groups/:group/users/:id',
     schema: User,
     Endpoint: MyEndpoint,
@@ -81,7 +81,7 @@ describe('createResource()', () => {
   });
 
   it('can override endpoint options', async () => {
-    const UserResourceBase = createResource({
+    const UserResourceBase = resource({
       path: 'http\\://test.com/groups/:group/users/:id',
       schema: User,
     });
@@ -212,7 +212,7 @@ describe('createResource()', () => {
   });
 
   it('can override endpoint options', async () => {
-    const UserResourceBase = createResource({
+    const UserResourceBase = resource({
       path: 'http\\://test.com/groups/:group/users/:id',
       schema: User,
       paginationField: 'cursor',
@@ -360,7 +360,7 @@ describe('createResource()', () => {
   });
 
   it('can override with no generics', async () => {
-    const UserResource = createResource({
+    const UserResource = resource({
       path: 'http\\://test.com/groups/:group/users/:id',
       schema: User,
       paginationField: 'cursor',
@@ -377,7 +377,7 @@ describe('createResource()', () => {
   });
 
   it('can override resource endpoints (function form)', async () => {
-    const UserResource = createResource({
+    const UserResource = resource({
       path: 'http\\://test.com/groups/:group/users/:id',
       schema: User,
       paginationField: 'cursor',
@@ -538,7 +538,7 @@ describe('createResource()', () => {
     }
 
     expect(() =>
-      createResource({
+      resource({
         // TODO(see path types): @ts-expect-error
         path: '/todos/',
         schema: Todo,
@@ -843,7 +843,7 @@ describe('createResource()', () => {
       { post: FeedPost, link: FeedLink },
       'type',
     );
-    const FeedResource = createResource({
+    const FeedResource = resource({
       path: 'http\\://test.com/feed/:id',
       schema: FeedUnion,
       Endpoint: MyEndpoint,
@@ -1019,7 +1019,7 @@ describe('createResource()', () => {
   });
 
   it('UserResource.getList.push.extends() should work with zero urlParams', async () => {
-    const UserResource = createResource({
+    const UserResource = resource({
       path: 'http\\://test.com/users/:id',
       schema: User,
       Endpoint: MyEndpoint,
@@ -1072,7 +1072,7 @@ describe('createResource()', () => {
       ...body,
       id: 5,
     }));
-    const UserResource = createResource({
+    const UserResource = resource({
       path: '/users/:id',
       schema: User,
       optimistic: true,
@@ -1127,7 +1127,7 @@ describe('createResource()', () => {
       }
     }
 
-    const TodoResource = createResource({
+    const TodoResource = resource({
       path: '/todos/:id',
       schema: Todo,
       optimistic: true,
@@ -1159,7 +1159,7 @@ describe('createResource()', () => {
     });
 
     it('should warn when mis-capitalizing options', () => {
-      createResource({
+      resource({
         path: 'http\\://test.com/users/:id',
         schema: User,
         endpoint: MyEndpoint,
@@ -1179,7 +1179,7 @@ describe('createResource()', () => {
           return key === 'orderBy';
         }
       }
-      createResource({
+      resource({
         path: 'http\\://test.com/users/:id',
         schema: User,
         collection: MyCollection,

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -22,7 +22,8 @@ export type {
 } from './RestEndpoint.js';
 export type { RestEndpoint as IRestEndpoint } from './RestEndpointTypes.js';
 export { getUrlBase, getUrlTokens } from './RestHelpers.js';
-export { default as createResource } from './createResource.js';
+export { default as resource } from './resource.js';
+export { default as createResource } from './resource.js';
 export type { Resource } from './resourceTypes.js';
 export type { ResourceOptions, ResourceGenerics } from './resourceTypes.js';
 export type {

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -19,9 +19,9 @@ const { Invalidate, Collection: BaseCollection } = schema;
 
 /** Creates collection of Endpoints for common operations on a given data/schema.
  *
- * @see https://dataclient.io/rest/api/createResource
+ * @see https://dataclient.io/rest/api/resource
  */
-export default function createResource<O extends ResourceGenerics>({
+export default function resource<O extends ResourceGenerics>({
   path,
   schema,
   Endpoint = RestEndpoint,
@@ -44,7 +44,7 @@ export default function createResource<O extends ResourceGenerics>({
     ) {
       console.warn(
         `You passed 'endpoint' option; did you mean to use Endpoint?
-https://dataclient.io/rest/api/createResource#endpoint
+https://dataclient.io/rest/api/resource#endpoint
 This parameter must be capitalized.
 
 This warning will not show in production.`,
@@ -63,7 +63,7 @@ This warning will not show in production.`,
     ) {
       console.warn(
         `You passed 'collection' option; did you mean to use Collection?
-https://dataclient.io/rest/api/createResource#collection
+https://dataclient.io/rest/api/resource#collection
 This parameter must be capitalized.
 
 This warning will not show in production.`,

--- a/packages/rest/src/resourceExtendable.ts
+++ b/packages/rest/src/resourceExtendable.ts
@@ -27,7 +27,7 @@ export interface Extendable<
 > {
   /** Allows customizing individual endpoints
    *
-   * @see https://dataclient.io/rest/api/createResource#extend
+   * @see https://dataclient.io/rest/api/resource#extend
    */
   extend<
     R extends {

--- a/packages/rest/src/resourceTypes.ts
+++ b/packages/rest/src/resourceTypes.ts
@@ -19,31 +19,31 @@ import RestEndpoint, {
 
 /** The typed (generic) options for a Resource
  *
- * @see https://dataclient.io/rest/api/createResource#function-inheritance-patterns
+ * @see https://dataclient.io/rest/api/resource#function-inheritance-patterns
  */
 export interface ResourceGenerics {
-  /** @see https://dataclient.io/rest/api/createResource#path */
+  /** @see https://dataclient.io/rest/api/resource#path */
   readonly path: ResourcePath;
-  /** @see https://dataclient.io/rest/api/createResource#schema */
+  /** @see https://dataclient.io/rest/api/resource#schema */
   readonly schema: Schema;
   /** Only used for types */
-  /** @see https://dataclient.io/rest/api/createResource#body */
+  /** @see https://dataclient.io/rest/api/resource#body */
   readonly body?: any;
   /** Only used for types */
-  /** @see https://dataclient.io/rest/api/createResource#searchParams */
+  /** @see https://dataclient.io/rest/api/resource#searchParams */
   readonly searchParams?: any;
-  /** @see https://dataclient.io/rest/api/createResource#paginationfield */
+  /** @see https://dataclient.io/rest/api/resource#paginationfield */
   readonly paginationField?: string;
 }
-/** The untyped options for createResource() */
+/** The untyped options for resource() */
 export interface ResourceOptions {
-  /** @see https://dataclient.io/rest/api/createResource#endpoint */
+  /** @see https://dataclient.io/rest/api/resource#endpoint */
   Endpoint?: typeof RestEndpoint;
-  /** @see https://dataclient.io/rest/api/createResource#collection */
+  /** @see https://dataclient.io/rest/api/resource#collection */
   Collection?: typeof Collection;
-  /** @see https://dataclient.io/rest/api/createResource#optimistic */
+  /** @see https://dataclient.io/rest/api/resource#optimistic */
   optimistic?: boolean;
-  /** @see https://dataclient.io/rest/api/createResource#urlprefix */
+  /** @see https://dataclient.io/rest/api/resource#urlprefix */
   urlPrefix?: string;
   requestInit?: RequestInit;
   getHeaders?(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
@@ -63,19 +63,19 @@ export interface ResourceOptions {
 }
 
 /** Resources are a collection of methods for a given data model.
- * @see https://dataclient.io/rest/api/createResource
+ * @see https://dataclient.io/rest/api/resource
  */
 export interface Resource<
   O extends ResourceGenerics = { path: ResourcePath; schema: any },
 > extends Extendable<O> {
   /** Get one item (GET)
    *
-   * @see https://dataclient.io/rest/api/createResource#get
+   * @see https://dataclient.io/rest/api/resource#get
    */
   get: GetEndpoint<{ path: O['path']; schema: O['schema'] }>;
   /** Get an Array of items (GET)
    *
-   * @see https://dataclient.io/rest/api/createResource#getlist
+   * @see https://dataclient.io/rest/api/resource#getlist
    */
   getList: 'searchParams' extends keyof O ?
     GetEndpoint<
@@ -129,7 +129,7 @@ export interface Resource<
     }>;
   /** Update an item (PUT)
    *
-   * @see https://dataclient.io/rest/api/createResource#update
+   * @see https://dataclient.io/rest/api/resource#update
    */
   update: 'body' extends keyof O ?
     MutateEndpoint<{
@@ -144,7 +144,7 @@ export interface Resource<
     }>;
   /** Update an item (PATCH)
    *
-   * @see https://dataclient.io/rest/api/createResource#partialupdate
+   * @see https://dataclient.io/rest/api/resource#partialupdate
    */
   partialUpdate: 'body' extends keyof O ?
     MutateEndpoint<{
@@ -159,7 +159,7 @@ export interface Resource<
     }>;
   /** Delete an item (DELETE)
    *
-   * @see https://dataclient.io/rest/api/createResource#delete
+   * @see https://dataclient.io/rest/api/resource#delete
    */
   delete: RestTypeNoBody<
     PathArgs<O['path']>,

--- a/packages/rest/typescript-tests/types.test.ts
+++ b/packages/rest/typescript-tests/types.test.ts
@@ -3,7 +3,7 @@ import { Entity, schema } from '@data-client/endpoint';
 import { useController, useSuspense } from '@data-client/react';
 import { User } from '__tests__/new';
 
-import createResource from '../src/createResource';
+import resource from '../src/resource';
 import RestEndpoint, { GetEndpoint, MutateEndpoint } from '../src/RestEndpoint';
 
 it('RestEndpoint construct and extend with typed options', () => {
@@ -87,7 +87,7 @@ it('should customize resources', () => {
     }
   }
 
-  const TodoResource = createResource({
+  const TodoResource = resource({
     path: '/todos/:id',
     schema: Todo,
   });

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -20,7 +20,7 @@
 <summary><b>Resource</b></summary>
 
 ```typescript
-import { createResource, Entity } from '@data-client/rest';
+import { resource, Entity } from '@data-client/rest';
 
 export default class Article extends Entity {
   id = '';
@@ -32,7 +32,7 @@ export default class Article extends Entity {
     return this.id?.toString();
   }
 }
-export const ArticleResource = createResource({
+export const ArticleResource = resource({
   urlRoot: 'http://test.com',
   path: '/article/:id',
   schema: Article,

--- a/website/blog/2023-07-04-v0.2-release-announcement.md
+++ b/website/blog/2023-07-04-v0.2-release-announcement.md
@@ -12,7 +12,7 @@ import { todoFixtures } from '@site/src/fixtures/todos';
 extended by [pushing](/rest/api/Collection#push) or [unshifting](/rest/api/Collection#unshift) new
 members. The namesake comes from [Backbone Collections](https://backbonejs.org/#Collection).
 
-[Collections](/rest/api/Collection) are now the default schema for [Resource.getList](/rest/api/createResource#getlist).
+[Collections](/rest/api/Collection) are now the default schema for [Resource.getList](/rest/api/resource#getlist).
 
 <HooksPlayground defaultOpen="n" row fixtures={todoFixtures}>
 

--- a/website/blog/2024-04-08-v0.11-queries-querable-usequery.md
+++ b/website/blog/2024-04-08-v0.11-queries-querable-usequery.md
@@ -59,7 +59,7 @@ for most operations and [Queries](/rest/api/Query) being 16x faster.
 
 [**Other Highlights:**](/blog/2024/04/08/v0.11-queries-querable-usequery#other-improvements)
 
-- useCache() accepts Endpoints with sideEffects (like [Resource.update](/rest/api/createResource#update))
+- useCache() accepts Endpoints with sideEffects (like [Resource.update](/rest/api/resource#update))
 - Allow Entity.pk() to return numbers.
 - 2-16x [performance improvements](/blog/2024/04/08/v0.11-queries-querable-usequery#performance)
 
@@ -154,8 +154,8 @@ getOptimisticResponse(snapshot, { id }) {
 ```
 </DiffEditor>
 
-Since we no longer need to access other [Resource members](/rest/api/createResource#members) to get `Post`, we
-can use the much simpler [Resource.extend()](/rest/api/createResource#extend-new) overload.
+Since we no longer need to access other [Resource members](/rest/api/resource#members) to get `Post`, we
+can use the much simpler [Resource.extend()](/rest/api/resource#extend-new) overload.
 
 <DiffEditor>
 
@@ -273,7 +273,7 @@ xychart-beta
 
 ## Other improvements
 
-- useCache() accepts Endpoints with sideEffects (like [Resource.update](/rest/api/createResource#update)) [#2963](https://github.com/reactive/data-client/pull/2963)
+- useCache() accepts Endpoints with sideEffects (like [Resource.update](/rest/api/resource#update)) [#2963](https://github.com/reactive/data-client/pull/2963)
   ```ts
   const lastCreated = useCache(MyResource.getList.push);
   ```

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -304,6 +304,10 @@ const config: Config = {
             from: ['/docs/api/NetworkErrorBoundary'],
           },
           {
+            to: '/rest/api/resource',
+            from: ['/rest/api/createResource', '/rest/api/Resource'],
+          },
+          {
             to: '/docs/api/makeRenderDataClient',
             from: [
               '/docs/api/makeExternalCacheProvider',

--- a/website/sidebars-rest.js
+++ b/website/sidebars-rest.js
@@ -81,7 +81,7 @@ module.exports = {
         },
         {
           type: 'doc',
-          id: 'api/createResource',
+          id: 'api/resource',
         },
         {
           type: 'doc',

--- a/website/src/components/Demo/code/posts-app/rest/resources.ts
+++ b/website/src/components/Demo/code/posts-app/rest/resources.ts
@@ -1,5 +1,5 @@
 import { Entity } from '@data-client/rest';
-import { createResource } from '@data-client/rest';
+import { resource } from '@data-client/rest';
 
 export class Post extends Entity {
   id = 0;
@@ -10,7 +10,7 @@ export class Post extends Entity {
     return `${this.id}`;
   }
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/posts/:id',
   schema: Post,
@@ -34,7 +34,7 @@ export class User extends Entity {
     return `${this.id}`;
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,

--- a/website/src/components/Demo/code/profile-edit/rest/resources.ts
+++ b/website/src/components/Demo/code/profile-edit/rest/resources.ts
@@ -1,4 +1,4 @@
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 
 export class Post extends Entity {
   id = 0;
@@ -9,7 +9,7 @@ export class Post extends Entity {
     return `${this.id}`;
   }
 }
-export const PostResource = createResource({
+export const PostResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/posts/:id',
   schema: Post,
@@ -33,7 +33,7 @@ export class User extends Entity {
     return `${this.id}`;
   }
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,

--- a/website/src/components/Demo/code/simple/rest/api.ts
+++ b/website/src/components/Demo/code/simple/rest/api.ts
@@ -7,7 +7,7 @@ export class Todo extends Entity {
     return `${this.id}`;
   }
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   schema: Todo,

--- a/website/src/components/Demo/code/todo-app/rest/resources.ts
+++ b/website/src/components/Demo/code/todo-app/rest/resources.ts
@@ -1,4 +1,4 @@
-import { Entity, schema, createResource } from '@data-client/rest';
+import { Entity, schema, resource } from '@data-client/rest';
 
 export class Todo extends Entity {
   id = 0;
@@ -9,7 +9,7 @@ export class Todo extends Entity {
     return `${this.id}`;
   }
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   searchParams: {} as { userId?: string | number } | undefined,
@@ -41,7 +41,7 @@ export class User extends Entity {
     }),
   };
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -1563,7 +1563,7 @@ interface Extendable<O extends ResourceGenerics = {
 }> {
     /** Allows customizing individual endpoints
      *
-     * @see https://dataclient.io/rest/api/createResource#extend
+     * @see https://dataclient.io/rest/api/resource#extend
      */
     extend<R extends {
         [K in ExtendKey]: RestInstanceBase;
@@ -1579,31 +1579,31 @@ interface Extendable<O extends ResourceGenerics = {
 
 /** The typed (generic) options for a Resource
  *
- * @see https://dataclient.io/rest/api/createResource#function-inheritance-patterns
+ * @see https://dataclient.io/rest/api/resource#function-inheritance-patterns
  */
 interface ResourceGenerics {
-    /** @see https://dataclient.io/rest/api/createResource#path */
+    /** @see https://dataclient.io/rest/api/resource#path */
     readonly path: ResourcePath;
-    /** @see https://dataclient.io/rest/api/createResource#schema */
+    /** @see https://dataclient.io/rest/api/resource#schema */
     readonly schema: Schema;
     /** Only used for types */
-    /** @see https://dataclient.io/rest/api/createResource#body */
+    /** @see https://dataclient.io/rest/api/resource#body */
     readonly body?: any;
     /** Only used for types */
-    /** @see https://dataclient.io/rest/api/createResource#searchParams */
+    /** @see https://dataclient.io/rest/api/resource#searchParams */
     readonly searchParams?: any;
-    /** @see https://dataclient.io/rest/api/createResource#paginationfield */
+    /** @see https://dataclient.io/rest/api/resource#paginationfield */
     readonly paginationField?: string;
 }
-/** The untyped options for createResource() */
+/** The untyped options for resource() */
 interface ResourceOptions {
-    /** @see https://dataclient.io/rest/api/createResource#endpoint */
+    /** @see https://dataclient.io/rest/api/resource#endpoint */
     Endpoint?: typeof RestEndpoint;
-    /** @see https://dataclient.io/rest/api/createResource#collection */
+    /** @see https://dataclient.io/rest/api/resource#collection */
     Collection?: typeof Collection;
-    /** @see https://dataclient.io/rest/api/createResource#optimistic */
+    /** @see https://dataclient.io/rest/api/resource#optimistic */
     optimistic?: boolean;
-    /** @see https://dataclient.io/rest/api/createResource#urlprefix */
+    /** @see https://dataclient.io/rest/api/resource#urlprefix */
     urlPrefix?: string;
     requestInit?: RequestInit;
     getHeaders?(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
@@ -1622,7 +1622,7 @@ interface ResourceOptions {
     errorPolicy?(error: any): 'hard' | 'soft' | undefined;
 }
 /** Resources are a collection of methods for a given data model.
- * @see https://dataclient.io/rest/api/createResource
+ * @see https://dataclient.io/rest/api/resource
  */
 interface Resource<O extends ResourceGenerics = {
     path: ResourcePath;
@@ -1630,7 +1630,7 @@ interface Resource<O extends ResourceGenerics = {
 }> extends Extendable<O> {
     /** Get one item (GET)
      *
-     * @see https://dataclient.io/rest/api/createResource#get
+     * @see https://dataclient.io/rest/api/resource#get
      */
     get: GetEndpoint<{
         path: O['path'];
@@ -1638,7 +1638,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Get an Array of items (GET)
      *
-     * @see https://dataclient.io/rest/api/createResource#getlist
+     * @see https://dataclient.io/rest/api/resource#getlist
      */
     getList: 'searchParams' extends keyof O ? GetEndpoint<{
         path: ShortenPath<O['path']>;
@@ -1671,7 +1671,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Update an item (PUT)
      *
-     * @see https://dataclient.io/rest/api/createResource#update
+     * @see https://dataclient.io/rest/api/resource#update
      */
     update: 'body' extends keyof O ? MutateEndpoint<{
         path: O['path'];
@@ -1684,7 +1684,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Update an item (PATCH)
      *
-     * @see https://dataclient.io/rest/api/createResource#partialupdate
+     * @see https://dataclient.io/rest/api/resource#partialupdate
      */
     partialUpdate: 'body' extends keyof O ? MutateEndpoint<{
         path: O['path'];
@@ -1697,7 +1697,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Delete an item (DELETE)
      *
-     * @see https://dataclient.io/rest/api/createResource#delete
+     * @see https://dataclient.io/rest/api/resource#delete
      */
     delete: RestTypeNoBody<PathArgs<O['path']>, O['schema'] extends EntityInterface & {
         process: any;
@@ -1715,9 +1715,9 @@ interface ResourceInterface {
 
 /** Creates collection of Endpoints for common operations on a given data/schema.
  *
- * @see https://dataclient.io/rest/api/createResource
+ * @see https://dataclient.io/rest/api/resource
  */
-declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, Collection, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
+declare function resource<O extends ResourceGenerics>({ path, schema, Endpoint, Collection, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 
 interface HookableEndpointInterface extends EndpointInterface {
     extend(...args: any): HookableEndpointInterface;
@@ -1743,4 +1743,4 @@ declare class NetworkError extends Error {
     constructor(response: Response);
 }
 
-export { AbstractInstanceType, AddEndpoint, Array$1 as Array, Collection, CustomResource, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, createResource, getUrlBase, getUrlTokens, hookifyResource, schema_d as schema, validateRequired };
+export { AbstractInstanceType, AddEndpoint, Array$1 as Array, Collection, CustomResource, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -1567,7 +1567,7 @@ interface Extendable<O extends ResourceGenerics = {
 }> {
     /** Allows customizing individual endpoints
      *
-     * @see https://dataclient.io/rest/api/createResource#extend
+     * @see https://dataclient.io/rest/api/resource#extend
      */
     extend<R extends {
         [K in ExtendKey]: RestInstanceBase;
@@ -1583,31 +1583,31 @@ interface Extendable<O extends ResourceGenerics = {
 
 /** The typed (generic) options for a Resource
  *
- * @see https://dataclient.io/rest/api/createResource#function-inheritance-patterns
+ * @see https://dataclient.io/rest/api/resource#function-inheritance-patterns
  */
 interface ResourceGenerics {
-    /** @see https://dataclient.io/rest/api/createResource#path */
+    /** @see https://dataclient.io/rest/api/resource#path */
     readonly path: ResourcePath;
-    /** @see https://dataclient.io/rest/api/createResource#schema */
+    /** @see https://dataclient.io/rest/api/resource#schema */
     readonly schema: Schema;
     /** Only used for types */
-    /** @see https://dataclient.io/rest/api/createResource#body */
+    /** @see https://dataclient.io/rest/api/resource#body */
     readonly body?: any;
     /** Only used for types */
-    /** @see https://dataclient.io/rest/api/createResource#searchParams */
+    /** @see https://dataclient.io/rest/api/resource#searchParams */
     readonly searchParams?: any;
-    /** @see https://dataclient.io/rest/api/createResource#paginationfield */
+    /** @see https://dataclient.io/rest/api/resource#paginationfield */
     readonly paginationField?: string;
 }
-/** The untyped options for createResource() */
+/** The untyped options for resource() */
 interface ResourceOptions {
-    /** @see https://dataclient.io/rest/api/createResource#endpoint */
+    /** @see https://dataclient.io/rest/api/resource#endpoint */
     Endpoint?: typeof RestEndpoint;
-    /** @see https://dataclient.io/rest/api/createResource#collection */
+    /** @see https://dataclient.io/rest/api/resource#collection */
     Collection?: typeof Collection;
-    /** @see https://dataclient.io/rest/api/createResource#optimistic */
+    /** @see https://dataclient.io/rest/api/resource#optimistic */
     optimistic?: boolean;
-    /** @see https://dataclient.io/rest/api/createResource#urlprefix */
+    /** @see https://dataclient.io/rest/api/resource#urlprefix */
     urlPrefix?: string;
     requestInit?: RequestInit;
     getHeaders?(headers: HeadersInit): Promise<HeadersInit> | HeadersInit;
@@ -1626,7 +1626,7 @@ interface ResourceOptions {
     errorPolicy?(error: any): 'hard' | 'soft' | undefined;
 }
 /** Resources are a collection of methods for a given data model.
- * @see https://dataclient.io/rest/api/createResource
+ * @see https://dataclient.io/rest/api/resource
  */
 interface Resource<O extends ResourceGenerics = {
     path: ResourcePath;
@@ -1634,7 +1634,7 @@ interface Resource<O extends ResourceGenerics = {
 }> extends Extendable<O> {
     /** Get one item (GET)
      *
-     * @see https://dataclient.io/rest/api/createResource#get
+     * @see https://dataclient.io/rest/api/resource#get
      */
     get: GetEndpoint<{
         path: O['path'];
@@ -1642,7 +1642,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Get an Array of items (GET)
      *
-     * @see https://dataclient.io/rest/api/createResource#getlist
+     * @see https://dataclient.io/rest/api/resource#getlist
      */
     getList: 'searchParams' extends keyof O ? GetEndpoint<{
         path: ShortenPath<O['path']>;
@@ -1675,7 +1675,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Update an item (PUT)
      *
-     * @see https://dataclient.io/rest/api/createResource#update
+     * @see https://dataclient.io/rest/api/resource#update
      */
     update: 'body' extends keyof O ? MutateEndpoint<{
         path: O['path'];
@@ -1688,7 +1688,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Update an item (PATCH)
      *
-     * @see https://dataclient.io/rest/api/createResource#partialupdate
+     * @see https://dataclient.io/rest/api/resource#partialupdate
      */
     partialUpdate: 'body' extends keyof O ? MutateEndpoint<{
         path: O['path'];
@@ -1701,7 +1701,7 @@ interface Resource<O extends ResourceGenerics = {
     }>;
     /** Delete an item (DELETE)
      *
-     * @see https://dataclient.io/rest/api/createResource#delete
+     * @see https://dataclient.io/rest/api/resource#delete
      */
     delete: RestTypeNoBody<PathArgs<O['path']>, O['schema'] extends EntityInterface & {
         process: any;
@@ -1719,9 +1719,9 @@ interface ResourceInterface {
 
 /** Creates collection of Endpoints for common operations on a given data/schema.
  *
- * @see https://dataclient.io/rest/api/createResource
+ * @see https://dataclient.io/rest/api/resource
  */
-declare function createResource<O extends ResourceGenerics>({ path, schema, Endpoint, Collection, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
+declare function resource<O extends ResourceGenerics>({ path, schema, Endpoint, Collection, optimistic, paginationField, ...extraOptions }: Readonly<O> & ResourceOptions): Resource<O>;
 
 interface HookableEndpointInterface extends EndpointInterface {
     extend(...args: any): HookableEndpointInterface;
@@ -1922,4 +1922,4 @@ declare function useController(): Controller;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
 
-export { AbstractInstanceType, AddEndpoint, Array$1 as Array, _default as AsyncBoundary, Collection, CustomResource, DataProvider, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes$1 as ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, createResource, getUrlBase, getUrlTokens, hookifyResource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };
+export { AbstractInstanceType, AddEndpoint, Array$1 as Array, _default as AsyncBoundary, Collection, CustomResource, DataProvider, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes$1 as ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };

--- a/website/src/components/Playground/resources/PlaceholderBaseResource.ts
+++ b/website/src/components/Playground/resources/PlaceholderBaseResource.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  createResource,
+  resource,
   RestEndpoint,
   Schema,
 } from '@data-client/rest';
@@ -24,7 +24,7 @@ export function createPlaceholderResource<U extends string, S extends Schema>({
   readonly schema: S;
   readonly Endpoint?: typeof RestEndpoint;
 }) {
-  const base = createResource({ path, schema, Endpoint });
+  const base = resource({ path, schema, Endpoint });
   const partialUpdate = base.partialUpdate.extend({
     fetch: async function (...args: any) {
       // body only contains what we're changing, but we can find the id in params

--- a/website/src/fixtures/posts.ts
+++ b/website/src/fixtures/posts.ts
@@ -1,4 +1,4 @@
-import { Entity, createResource } from '@data-client/rest';
+import { Entity, resource } from '@data-client/rest';
 import { v4 as uuid } from 'uuid';
 
 export class User extends Entity {
@@ -19,7 +19,7 @@ export class User extends Entity {
 
   static key = 'User';
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,
@@ -47,7 +47,7 @@ export class Post extends Entity {
   }
 }
 
-export const PostResource = createResource({
+export const PostResource = resource({
   path: '/posts/:id',
   searchParams: {} as { userId?: string | number } | undefined,
   schema: Post,

--- a/website/src/fixtures/profiles.ts
+++ b/website/src/fixtures/profiles.ts
@@ -1,4 +1,4 @@
-import { Entity, createResource, RestEndpoint } from '@data-client/rest';
+import { Entity, resource, RestEndpoint } from '@data-client/rest';
 
 export class Profile extends Entity {
   id: number | undefined = undefined;
@@ -13,7 +13,7 @@ export class Profile extends Entity {
   static key = 'Profile';
 }
 
-export const ProfileResource = createResource({
+export const ProfileResource = resource({
   path: '/profiles/:id',
   schema: Profile,
 });

--- a/website/src/fixtures/todos.ts
+++ b/website/src/fixtures/todos.ts
@@ -1,4 +1,4 @@
-import { Entity, schema, createResource } from '@data-client/rest';
+import { Entity, schema, resource } from '@data-client/rest';
 import { v4 as uuid } from 'uuid';
 
 export class Todo extends Entity {
@@ -12,7 +12,7 @@ export class Todo extends Entity {
 
   static key = 'Todo';
 }
-export const TodoResource = createResource({
+export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/todos/:id',
   searchParams: {} as { userId?: string | number } | undefined,
@@ -46,7 +46,7 @@ export class User extends Entity {
     }),
   };
 }
-export const UserResource = createResource({
+export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
   path: '/users/:id',
   schema: User,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Reduced verbosity.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- createResource() -> resource()

```ts
import { resource } from '@data-client/rest';

export const TodoResource = resource({
  urlPrefix: 'https://jsonplaceholder.typicode.com',
  path: '/todos/:id',
  searchParams: {} as { userId?: string | number } | undefined,
  schema: Todo,
  optimistic: true,
});
```

### Open questions

#### Why not `new Resource()`?

Class works for [RestEndpoint](https://dataclient.io/rest/api/RestEndpoint), because the 'project-wide' code sharing are all non-type specific - things that do not affect the type of RestEndpoint. RestEndpoint's typing comes from it's schema, and function signature which are expected to be different in each instance, with some small similarities being doable with .extend().

However, for [resources](https://dataclient.io/rest/api/createResource), while there are a few non-typed overrides like optimisticPartial, getName, Endpoint, Collection, many cases we want to establish common method shapes. This means affecting the type of the `resource`. (Like paginationField default, or getList shape to handle pagination). Because of this, classes fundamentally do not work from a TypeScript perspective. TypeScript simply does not allow changes in types of descendants in any way but specialization (aka extends). This means it is impractical for many common cases of 'Base class' to use class inheritance, which means we would need to fallback to a function anyway. Having two dominant ways of doing things seems confusing, so we will go with 'lowest common denominator'.

#### Is `resource()` lower case with no action confusing?

Convention is to have instances use PascalCase, so having a variable named `resource` would be against convention. Since `resource` is camelCase, it is clear it should not be called with `new`