### PR TITLE
feat: Add configuration to getDefaultManagers()

### DIFF
--- a/.changeset/pink-dodos-protect.md
+++ b/.changeset/pink-dodos-protect.md
@@ -1,0 +1,6 @@
+---
+'@data-client/react': patch
+'@data-client/core': patch
+---
+
+Add jsdocs to IdlingNetworkManager

--- a/.changeset/witty-papayas-battle.md
+++ b/.changeset/witty-papayas-battle.md
@@ -1,0 +1,30 @@
+---
+'@data-client/react': patch
+---
+
+Add configuration to [getDefaultManagers()](https://dataclient.io/docs/api/getDefaultManagers)
+
+```ts
+// completely remove DevToolsManager
+const managers = getDefaultManagers({ devToolsManager: null });
+```
+
+```ts
+// easier configuration
+const managers = getDefaultManagers({
+	devToolsManager: {
+	  // double latency to help with high frequency updates
+	  latency: 1000,
+	  // skip websocket updates as these are too spammy
+	  predicate: (state, action) =>
+	    action.type !== actionTypes.SET_TYPE || action.schema !== Ticker,
+	}
+});
+```
+
+```ts
+// passing instance allows us to use custom classes as well
+const managers = getDefaultManagers({
+	networkManager: new CustomNetworkManager(),
+});
+```

--- a/docs/core/api/DataProvider.md
+++ b/docs/core/api/DataProvider.md
@@ -73,9 +73,9 @@ be useful for testing, or rehydrating the cache state when using server side ren
 
 ### managers?: Manager[] {#managers}
 
-List of [Manager](./Manager.md#provided-managers)s use. This is the main extensibility point of the provider.
+List of [Manager](./Manager.md)s use. This is the main extensibility point of the provider.
 
-`getDefaultManagers()` can be used to extend the default managers.
+[getDefaultManagers()](./getDefaultManagers.md) can be used to extend the default managers.
 
 Default Production:
 

--- a/docs/core/api/DevToolsManager.md
+++ b/docs/core/api/DevToolsManager.md
@@ -27,7 +27,7 @@ browser to get started.
 [Arguments](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md)
 to send to redux devtools.
 
-For example, we can enable the `trace` option to help track down where actions are dispatched from.
+For example, we can enable the [trace](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#trace) option to help track down where actions are dispatched from.
 
 ```tsx title="index.tsx"
 import {
@@ -37,19 +37,10 @@ import {
 } from '@data-client/react';
 import ReactDOM from 'react-dom';
 
-const managers =
-  process.env.NODE_ENV !== 'production'
-    ? [
-        // highlight-start
-        new DevToolsManager({
-          trace: true,
-        }),
-        // highlight-end
-        ...getDefaultManagers().filter(
-          manager => manager.constructor.name !== 'DevToolsManager',
-        ),
-      ]
-    : getDefaultManagers();
+const managers = getDefaultManagers({
+  // highlight-next-line
+  devToolsManager: { trace: true },
+});
 
 ReactDOM.createRoot(document.body).render(
   <DataProvider managers={managers}>

--- a/docs/core/api/Manager.md
+++ b/docs/core/api/Manager.md
@@ -14,14 +14,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Manager
 
-Managers are singletons that orchestrate the complex asynchronous behavior of `Reactive Data Client`.
-Several managers are provided by `Reactive Data Client` and used by default; however there is nothing
+`Managers` are singletons that orchestrate the complex asynchronous behavior of <abbr title="Reactive Data Client">Data Client</abbr>.
+Several managers are provided by <abbr title="Reactive Data Client">Data Client</abbr> and used by default; however there is nothing
 stopping other compatible managers to be built that expand the functionality. We encourage
 PRs or complimentary libraries!
 
 While managers often have complex internal state and methods - the exposed interface is quite simple.
 Because of this, it is encouraged to keep any supporting state or methods marked at protected by
-typescript. Managers have three exposed pieces - the constructor to build initial state and
+typescript. `Managers` have three exposed pieces - the constructor to build initial state and
 take any parameters; a simple cleanup() method to tear down any dangling pieces like setIntervals()
 or unresolved Promises; and finally getMiddleware() - providing the mechanism to hook into
 the flux data flow.

--- a/docs/core/api/NetworkManager.md
+++ b/docs/core/api/NetworkManager.md
@@ -16,7 +16,7 @@ it is able to dedupe identical requests if they are made using the throttle flag
 
 ## Members
 
-### constructor(dataExpiryLength = 60000, errorExpiryLength = 1000) {#constructor}
+### constructor(\{ dataExpiryLength = 60000, errorExpiryLength = 1000 }) {#constructor}
 
 Arguments represent the default time (in miliseconds) before a resource is considered 'stale'.
 

--- a/docs/core/api/getDefaultManagers.md
+++ b/docs/core/api/getDefaultManagers.md
@@ -1,0 +1,128 @@
+---
+title: getDefaultManagers() - Configuring managers for DataProvider
+sidebar_label: getDefaultManagers
+---
+
+import StackBlitz from '@site/src/components/StackBlitz';
+
+# getDefaultManagers()
+
+`getDefaultManagers` returns an Array of [Managers](./Manager.md) to be sent to [&lt;DataProvider />](./DataProvider.md).
+
+This makes it simple to configure and add custom [Managers](./Manager.md), while remaining robust against
+any potential changes to the default managers.
+
+Currently returns \[[DevToolsManager](./DevToolsManager.md)\*, [NetworkManager](./NetworkManager.md), [SubscriptionManager](./SubscriptionManager.md)\].
+
+\*(`DevToolsManager` is excluded in production builds.)
+
+## Usage
+
+```tsx
+import {
+  DevToolsManager,
+  DataProvider,
+  getDefaultManagers,
+} from '@data-client/react';
+import ReactDOM from 'react-dom';
+
+// highlight-start
+const managers = getDefaultManagers({
+  // set fallback expiry time to an hour
+  networkManager: { dataExpiryLength: 1000 * 60 * 60 },
+});
+// highlight-end
+
+ReactDOM.createRoot(document.body).render(
+  <DataProvider managers={managers}>
+    <App />
+  </DataProvider>,
+);
+```
+
+See [DataProvider](./DataProvider.md) for details on usage in different environments.
+
+## Arguments
+
+Each argument represents a configuration of the manager. It can be of three possible types:
+
+- Any plain object is used as options to be sent to the manager's constructor.
+- An instance of the manager to be used directly.
+- `null`. When sent will exclude the manager.
+
+```ts
+getDefaultManagers({
+  devToolsManager: { trace: true },
+  networkManager: new NetworkManager({ errorExpiryLength: 1 }),
+  subscriptionManager: null,
+});
+```
+
+### networkManager
+
+:::note
+
+`null` is not allowed here since NetworkManager is required
+
+:::
+
+`dataExpiryLength` is used as a fallback when an Endpoint does not have [dataExpiryLength](https://dataclient.io/docs/concepts/expiry-policy#endpointdataexpirylength) defined.
+
+`errorExpiryLength` is used as a fallback when an Endpoint does not have [errorExpiryLength](https://dataclient.io/docs/concepts/expiry-policy#endpointerrorexpirylength) defined.
+
+### devToolsManager
+
+[Arguments](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md)
+to send to redux devtools.
+
+### subscriptionManager
+
+A class that implements `SubscriptionConstructable` like [PollingSubscription](./PollingSubscription.md)
+
+## Examples
+
+### Tracing actions
+
+For example, we can enable the [trace](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md#trace) option to help track down where actions are dispatched from. This has a large performance impact, so it is normally disabled.
+
+```ts
+const managers = getDefaultManagers({
+  // highlight-next-line
+  devToolsManager: { trace: true },
+});
+```
+
+### Manager inheritance
+
+Sending manager instances allows us to customize managers using inheritance.
+
+```ts
+import { IdlingNetworkManager } from '@data-client/react';
+
+const managers = getDefaultManagers({
+  networkManager: new IdlingNetworkManager(),
+});
+```
+
+`IdlingNetworkManager` can prevent stuttering by delaying [sideEffect](/rest/api/Endpoint#sideeffect)-free (read-only/GET) fetches
+until animations are complete. This works in web using [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback), and react native using InteractionManager.runAfterInteractions.
+
+### Disabling
+
+Using `null` will remove managers completely. [NetworkManager](./NetworkManager.md) cannot be removed this way.
+
+```ts
+const managers = getDefaultManagers({
+  devToolsManager: null,
+  subscriptionManager: null,
+});
+```
+
+Here we disable every manager except [NetworkManager](./NetworkManager.md).
+
+### Coin App
+
+New prices are streamed in many times a second; to reduce devtool spam, we set it
+to ignore [SET](./Controller.md#set) actions for `Ticker`.
+
+<StackBlitz app="coin-app" file="src/index.tsx,src/resources/StreamManager.ts,src/getManagers.ts" height="600" />

--- a/docs/core/concepts/managers.md
+++ b/docs/core/concepts/managers.md
@@ -126,4 +126,4 @@ with `event.data`.
 
 ### Coin App
 
-<StackBlitz app="coin-app" file="src/index.tsx,src/resources/Ticker.ts,src/pages/AssetDetail/AssetPrice.tsx,src/resources/StreamManager.ts" height="600" />
+<StackBlitz app="coin-app" file="src/getManagers.tsx,src/resources/Ticker.ts,src/pages/AssetDetail/AssetPrice.tsx,src/resources/StreamManager.ts" height="600" />

--- a/docs/core/getting-started/debugging.md
+++ b/docs/core/getting-started/debugging.md
@@ -97,19 +97,10 @@ import {
 } from '@data-client/react';
 import ReactDOM from 'react-dom';
 
-const managers =
-  process.env.NODE_ENV !== 'production'
-    ? [
-        // highlight-start
-        new DevToolsManager({
-          trace: true,
-        }),
-        // highlight-end
-        ...getDefaultManagers().filter(
-          manager => manager.constructor.name !== 'DevToolsManager',
-        ),
-      ]
-    : getDefaultManagers();
+const managers = getDefaultManagers({
+  // highlight-next-line
+  devToolsManager: { trace: true },
+});
 
 ReactDOM.createRoot(document.body).render(
   <DataProvider managers={managers}>

--- a/examples/coin-app/src/getManagers.ts
+++ b/examples/coin-app/src/getManagers.ts
@@ -1,0 +1,21 @@
+import { getDefaultManagers, actionTypes } from '@data-client/react';
+import StreamManager from 'resources/StreamManager';
+import { Ticker } from 'resources/Ticker';
+
+export default function getManagers() {
+  return [
+    new StreamManager(
+      () => new WebSocket('wss://ws-feed.exchange.coinbase.com'),
+      { ticker: Ticker },
+    ),
+    ...getDefaultManagers({
+      devToolsManager: {
+        // double latency to help with high frequency updates
+        latency: 1000,
+        // skip websocket updates as these are too spammy
+        predicate: (state, action) =>
+          action.type !== actionTypes.SET_TYPE || action.schema !== Ticker,
+      },
+    }),
+  ];
+}

--- a/examples/coin-app/src/index.tsx
+++ b/examples/coin-app/src/index.tsx
@@ -6,16 +6,8 @@ import {
   JSONSpout,
   appSpout,
 } from '@anansi/core';
-import {
-  useController,
-  AsyncBoundary,
-  getDefaultManagers,
-  DevToolsManager,
-  NetworkManager,
-  actionTypes,
-} from '@data-client/react';
-import StreamManager from 'resources/StreamManager';
-import { Ticker } from 'resources/Ticker';
+import { useController, AsyncBoundary } from '@data-client/react';
+import getManagers from 'getManagers';
 
 import App from './App';
 import { createRouter } from './routing';
@@ -28,17 +20,7 @@ const app = (
 
 const spouts = JSONSpout()(
   documentSpout({ title: 'Coin App' })(
-    dataClientSpout({
-      getManagers: () => {
-        return [
-          new StreamManager(
-            () => new WebSocket('wss://ws-feed.exchange.coinbase.com'),
-            { ticker: Ticker },
-          ),
-          ...getManagers(),
-        ];
-      },
-    })(
+    dataClientSpout({ getManagers })(
       routerSpout({
         useResolveWith: useController,
         createRouter,
@@ -46,29 +28,5 @@ const spouts = JSONSpout()(
     ),
   ),
 );
-
-function getManagers() {
-  const managers = getDefaultManagers().filter(
-    manager => manager.constructor.name !== 'DevToolsManager',
-  );
-  if (process.env.NODE_ENV !== 'production') {
-    const networkManager: NetworkManager | undefined = managers.find(
-      manager => manager instanceof NetworkManager,
-    ) as any;
-    managers.unshift(
-      new DevToolsManager(
-        {
-          // double latency to help with high frequency updates
-          latency: 1000,
-          // skip websocket updates as these are too spammy
-          predicate: (state, action) =>
-            action.type !== actionTypes.SET_TYPE || action.schema !== Ticker,
-        },
-        networkManager && (action => networkManager.skipLogging(action)),
-      ),
-    );
-  }
-  return managers;
-}
 
 export default floodSpouts(spouts);

--- a/packages/core/src/manager/SubscriptionManager.ts
+++ b/packages/core/src/manager/SubscriptionManager.ts
@@ -32,8 +32,9 @@ export interface SubscriptionConstructable {
  *
  * @see https://dataclient.io/docs/api/SubscriptionManager
  */
-export default class SubscriptionManager<S extends SubscriptionConstructable>
-  implements Manager<Actions>
+export default class SubscriptionManager<
+  S extends SubscriptionConstructable = SubscriptionConstructable,
+> implements Manager<Actions>
 {
   protected subscriptions: {
     [key: string]: InstanceType<S>;

--- a/packages/react/src/components/DataProvider.tsx
+++ b/packages/react/src/components/DataProvider.tsx
@@ -3,9 +3,6 @@ import {
   initialState as defaultState,
   Controller as DataController,
   applyManager,
-  SubscriptionManager,
-  PollingSubscription,
-  DevToolsManager,
 } from '@data-client/core';
 import type { State, Manager } from '@data-client/core';
 import React, { useMemo, useRef } from 'react';
@@ -13,10 +10,11 @@ import type { JSX } from 'react';
 
 import DataStore from './DataStore.js';
 import type { DevToolsPosition } from './DevToolsButton.js';
+import { getDefaultManagers } from './getDefaultManagers.js';
 import { SSR } from './LegacyReact.js';
 import { renderDevButton } from './renderDevButton.js';
 import { ControllerContext } from '../context.js';
-import { NetworkManager } from '../managers/index.js';
+import { DevToolsManager } from '../managers/index.js';
 
 export interface ProviderProps {
   children: React.ReactNode;
@@ -89,26 +87,3 @@ See https://dataclient.io/docs/guides/ssr.`,
     </ControllerContext.Provider>
   );
 }
-
-/* istanbul ignore next */
-let getDefaultManagers = () =>
-  [
-    new NetworkManager(),
-    new SubscriptionManager(PollingSubscription),
-  ] as Manager[];
-
-/* istanbul ignore else */
-if (process.env.NODE_ENV !== 'production') {
-  getDefaultManagers = () => {
-    const networkManager = new NetworkManager();
-    return [
-      new DevToolsManager(
-        undefined,
-        networkManager.skipLogging.bind(networkManager),
-      ),
-      networkManager,
-      new SubscriptionManager(PollingSubscription),
-    ] as Manager[];
-  };
-}
-export { getDefaultManagers };

--- a/packages/react/src/components/__tests__/__snapshots__/getDefaultManagers.tsx.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/getDefaultManagers.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getDefaultManagers() networkManager should not be removable 1`] = `
+[
+  [
+    "Disabling NetworkManager is not allowed.",
+  ],
+]
+`;

--- a/packages/react/src/components/__tests__/getDefaultManagers.tsx
+++ b/packages/react/src/components/__tests__/getDefaultManagers.tsx
@@ -1,0 +1,106 @@
+// eslint-env jest
+import {
+  NetworkManager,
+  SubscriptionManager,
+  DevToolsManager,
+} from '@data-client/core';
+
+import { getDefaultManagers } from '../getDefaultManagers';
+
+describe('getDefaultManagers()', () => {
+  let warnspy: jest.SpyInstance;
+  let debugspy: jest.SpyInstance;
+  beforeEach(() => {
+    warnspy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+    debugspy = jest.spyOn(global.console, 'info').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnspy.mockRestore();
+    debugspy.mockRestore();
+  });
+
+  let errorSpy: jest.SpyInstance;
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+  beforeEach(
+    () => (errorSpy = jest.spyOn(console, 'error').mockImplementation()),
+  );
+  it('should have SubscriptionManager in default managers', () => {
+    const subManagers = getDefaultManagers().find(
+      manager => manager instanceof SubscriptionManager,
+    );
+    expect(subManagers).toBeDefined();
+  });
+  it('should have NetworkManager in default managers', () => {
+    const networkManager = getDefaultManagers().find(
+      manager => manager instanceof NetworkManager,
+    );
+    expect(networkManager).toBeDefined();
+  });
+  it('should have DevToolsManager in default managers', () => {
+    const devtoolsMgr = getDefaultManagers().find(
+      manager => manager instanceof DevToolsManager,
+    );
+    expect(devtoolsMgr).toBeDefined();
+  });
+  it('null option should disable a manager', () => {
+    expect(
+      getDefaultManagers({ devToolsManager: null }).find(
+        manager => manager instanceof DevToolsManager,
+      ),
+    ).toBeUndefined();
+    expect(
+      getDefaultManagers({ subscriptionManager: null }).find(
+        manager => manager instanceof SubscriptionManager,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('networkManager should not be removable', () => {
+    expect(
+      // @ts-expect-error
+      getDefaultManagers({ networkManager: null }).find(
+        manager => manager instanceof NetworkManager,
+      ),
+    ).toBeDefined();
+    expect(errorSpy.mock.calls).toMatchSnapshot();
+  });
+
+  it('manager constructor options should work', () => {
+    const managers = getDefaultManagers({
+      networkManager: { dataExpiryLength: 1 },
+      devToolsManager: {
+        maxAge: 1000,
+      },
+    });
+    expect(
+      managers.find(manager => manager instanceof NetworkManager)
+        ?.dataExpiryLength,
+    ).toBe(1);
+    // check that the value set is not default
+    expect(
+      managers.find(manager => manager instanceof DevToolsManager)
+        ?.maxBufferLength,
+    ).not.toBe(DevToolsManager.prototype.maxBufferLength);
+  });
+
+  it('manager instance should work', () => {
+    class MyDevTool extends DevToolsManager {
+      maxBufferLength = 500;
+    }
+    const managers = getDefaultManagers({
+      networkManager: new NetworkManager({ dataExpiryLength: 1 }),
+      devToolsManager: new MyDevTool(),
+    });
+    expect(
+      managers.find(manager => manager instanceof NetworkManager)
+        ?.dataExpiryLength,
+    ).toBe(1);
+    // check that the value set is not default
+    expect(
+      managers.find(manager => manager instanceof DevToolsManager)
+        ?.maxBufferLength,
+    ).not.toBe(DevToolsManager.prototype.maxBufferLength);
+  });
+});

--- a/packages/react/src/components/__tests__/provider.native.tsx
+++ b/packages/react/src/components/__tests__/provider.native.tsx
@@ -2,7 +2,6 @@
 import {
   NetworkManager,
   actionTypes,
-  SubscriptionManager,
   Controller,
   SetResponseAction,
 } from '@data-client/core';
@@ -15,7 +14,7 @@ import { Text } from 'react-native';
 import { ControllerContext, StateContext } from '../../context';
 import { useController, useSuspense } from '../../hooks';
 import { payload } from '../../test-fixtures';
-import DataProvider, { getDefaultManagers } from '../DataProvider';
+import DataProvider from '../DataProvider';
 
 const { SET_RESPONSE_TYPE } = actionTypes;
 
@@ -155,12 +154,5 @@ describe('<DataProvider />', () => {
     });
     expect(count).toBe(2);
     expect(state).toMatchSnapshot();
-  });
-
-  it('should have SubscriptionManager in default managers', () => {
-    const subManagers = getDefaultManagers().filter(
-      manager => manager instanceof SubscriptionManager,
-    );
-    expect(subManagers.length).toBe(1);
   });
 });

--- a/packages/react/src/components/__tests__/provider.tsx
+++ b/packages/react/src/components/__tests__/provider.tsx
@@ -2,7 +2,6 @@
 import {
   NetworkManager,
   actionTypes,
-  SubscriptionManager,
   Manager,
   Middleware,
   Controller,
@@ -16,7 +15,8 @@ import React, { useContext, Suspense, StrictMode } from 'react';
 import { ControllerContext, StateContext } from '../../context';
 import { useController, useSuspense } from '../../hooks';
 import { payload } from '../../test-fixtures';
-import DataProvider, { getDefaultManagers } from '../DataProvider';
+import DataProvider from '../DataProvider';
+import { getDefaultManagers } from '../getDefaultManagers';
 
 const { SET_RESPONSE_TYPE } = actionTypes;
 
@@ -154,13 +154,6 @@ describe('<DataProvider />', () => {
     });
     expect(count).toBe(2);
     expect(state).toMatchSnapshot();
-  });
-
-  it('should have SubscriptionManager in default managers', () => {
-    const subManagers = getDefaultManagers().filter(
-      manager => manager instanceof SubscriptionManager,
-    );
-    expect(subManagers.length).toBe(1);
   });
 
   it('should ignore dispatches after unmount', async () => {

--- a/packages/react/src/components/getDefaultManagers.tsx
+++ b/packages/react/src/components/getDefaultManagers.tsx
@@ -1,0 +1,76 @@
+import type { DevToolsConfig, Manager } from '@data-client/core';
+
+import {
+  NetworkManager,
+  SubscriptionManager,
+  PollingSubscription,
+  DevToolsManager,
+} from '../managers/index.js';
+
+/* istanbul ignore next */
+/** Returns the default Managers used by DataProvider.
+ *
+ * @see https://dataclient.io/docs/api/getDefaultManagers
+ */
+let getDefaultManagers: ({
+  devToolsManager,
+  networkManager,
+  subscriptionManager,
+}?: GetManagersOptions) => Manager[] = ({
+  networkManager,
+  subscriptionManager = PollingSubscription,
+} = {}) =>
+  subscriptionManager === null ?
+    [constructManager(NetworkManager, networkManager)]
+  : [
+      constructManager(NetworkManager, networkManager),
+      constructManager(SubscriptionManager, subscriptionManager),
+    ];
+/* istanbul ignore else */
+if (process.env.NODE_ENV !== 'production') {
+  getDefaultManagers = ({
+    devToolsManager,
+    networkManager,
+    subscriptionManager = PollingSubscription,
+  }: GetManagersOptions = {}): Manager[] => {
+    if (networkManager === null) {
+      console.error('Disabling NetworkManager is not allowed.');
+      networkManager = {};
+    }
+    const nm = constructManager(NetworkManager, networkManager);
+    const managers: Manager[] = [nm];
+    if (subscriptionManager !== null) {
+      managers.push(constructManager(SubscriptionManager, subscriptionManager));
+    }
+    if (devToolsManager !== null) {
+      managers.unshift(
+        devToolsManager instanceof DevToolsManager ? devToolsManager : (
+          new DevToolsManager(devToolsManager, nm.skipLogging.bind(nm))
+        ),
+      );
+    }
+    return managers;
+  };
+}
+export { getDefaultManagers };
+
+function constructManager<
+  M extends { new (...args: any): Manager },
+  O extends InstanceType<M> | ConstructorArgs<M>,
+>(Mgr: M, optionOrInstance: O): InstanceType<M> {
+  return optionOrInstance instanceof Mgr ? optionOrInstance : (
+      (new Mgr(optionOrInstance) as any)
+    );
+}
+
+export type GetManagersOptions = {
+  devToolsManager?: DevToolsManager | DevToolsConfig | null;
+  networkManager?: NetworkManager | ConstructorArgs<typeof NetworkManager>;
+  subscriptionManager?:
+    | SubscriptionManager
+    | ConstructorArgs<typeof SubscriptionManager>
+    | null;
+};
+
+export type ConstructorArgs<T extends { new (...args: any): any }> =
+  T extends { new (options: infer O): any } ? O : never;

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,5 +1,6 @@
 import BackupLoading from './BackupLoading.js';
-import DataProvider, { getDefaultManagers } from './DataProvider.js';
+import DataProvider from './DataProvider.js';
+import { getDefaultManagers } from './getDefaultManagers.js';
 import UniversalSuspense from './UniversalSuspense.js';
 export type { ProviderProps } from './DataProvider.js';
 export type { DevToolsPosition } from './DevToolsButton.js';

--- a/packages/react/src/managers/IdlingNetworkManager.native.ts
+++ b/packages/react/src/managers/IdlingNetworkManager.native.ts
@@ -1,6 +1,7 @@
 import { NetworkManager } from '@data-client/core';
 import { InteractionManager } from 'react-native';
 
+/** Can help prevent stuttering by waiting for idle for sideEffect free fetches */
 export default class NativeIdlingNetworkManager extends NetworkManager {
   /** Calls the callback when client is not 'busy' with high priority interaction tasks
    *

--- a/packages/react/src/managers/IdlingNetworkManager.ts
+++ b/packages/react/src/managers/IdlingNetworkManager.ts
@@ -1,5 +1,6 @@
 import { NetworkManager } from '@data-client/core';
 
+/** Can help prevent stuttering by waiting for idle for sideEffect free fetches */
 export default class WebIdlingNetworkManager extends NetworkManager {
   static {
     if (typeof requestIdleCallback === 'function') {

--- a/packages/react/src/managers/__tests__/RIC.native.ts
+++ b/packages/react/src/managers/__tests__/RIC.native.ts
@@ -1,10 +1,19 @@
-import { NetworkManager } from '..';
+import { IdlingNetworkManager } from '..';
 describe('RequestIdleCallback', () => {
   it('should run using InteractionManager', async () => {
     const fn = jest.fn();
     jest.useFakeTimers();
     // @ts-expect-error this is protected member
-    new NetworkManager().idleCallback(fn, {});
+    new IdlingNetworkManager().idleCallback(fn, {});
+    jest.runAllTimers();
+    expect(fn).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+  it('should run with timeout using InteractionManager', async () => {
+    const fn = jest.fn();
+    jest.useFakeTimers();
+    // @ts-expect-error this is protected member
+    new IdlingNetworkManager().idleCallback(fn, { timeout: 500 });
     jest.runAllTimers();
     expect(fn).toHaveBeenCalled();
     jest.useRealTimers();

--- a/packages/react/src/managers/__tests__/RIC.web.ts
+++ b/packages/react/src/managers/__tests__/RIC.web.ts
@@ -4,11 +4,11 @@ describe('RequestIdleCallback', () => {
     (global as any).requestIdleCallback = undefined;
     jest.resetModules();
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { NetworkManager } = await import('..');
+    const { IdlingNetworkManager } = await import('..');
     const fn = jest.fn();
     jest.useFakeTimers();
     // @ts-expect-error
-    new NetworkManager().idleCallback(fn, {});
+    new IdlingNetworkManager().idleCallback(fn, {});
     jest.runAllTimers();
     expect(fn).toHaveBeenCalled();
     (global as any).requestIdleCallback = requestIdle;
@@ -18,11 +18,11 @@ describe('RequestIdleCallback', () => {
   it('should run through requestIdleCallback', async () => {
     jest.resetModules();
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { NetworkManager } = await import('..');
+    const { IdlingNetworkManager } = await import('..');
     const fn = jest.fn();
     jest.useFakeTimers();
     // @ts-expect-error
-    new NetworkManager().idleCallback(fn, {});
+    new IdlingNetworkManager().idleCallback(fn, {});
     jest.runAllTimers();
     expect(fn).toHaveBeenCalled();
     jest.useRealTimers();

--- a/packages/react/src/managers/index.ts
+++ b/packages/react/src/managers/index.ts
@@ -6,4 +6,4 @@ export {
   LogoutManager,
   NetworkManager,
 } from '@data-client/core';
-export { default as IdlingNetworkManager } from './NetworkManager.js';
+export { default as IdlingNetworkManager } from './IdlingNetworkManager.js';

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -237,6 +237,10 @@
             },
             {
               "type": "doc",
+              "id": "api/getDefaultManagers"
+            },
+            {
+              "type": "doc",
               "id": "api/NetworkManager"
             },
             {

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -633,7 +633,10 @@ declare class NetworkManager implements Manager {
     protected middleware: Middleware$2;
     protected controller: Controller;
     cleanupDate?: number;
-    constructor(dataExpiryLength?: number, errorExpiryLength?: number);
+    constructor({ dataExpiryLength, errorExpiryLength }?: {
+        dataExpiryLength?: number | undefined;
+        errorExpiryLength?: number | undefined;
+    });
     /** Used by DevtoolsManager to determine whether to log an action */
     skipLogging(action: ActionTypes): boolean;
     /** On mount */
@@ -807,7 +810,7 @@ interface SubscriptionConstructable {
  *
  * @see https://dataclient.io/docs/api/SubscriptionManager
  */
-declare class SubscriptionManager<S extends SubscriptionConstructable> implements Manager<Actions> {
+declare class SubscriptionManager<S extends SubscriptionConstructable = SubscriptionConstructable> implements Manager<Actions> {
     protected subscriptions: {
         [key: string]: InstanceType<S>;
     };

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -1,9 +1,10 @@
 import * as _data_client_core from '@data-client/core';
-import { NetworkManager, Manager, State, Controller, EndpointInterface as EndpointInterface$1, FetchFunction as FetchFunction$1, Schema as Schema$1, ResolveType as ResolveType$1, Denormalize as Denormalize$1, DenormalizeNullable as DenormalizeNullable$1, Queryable as Queryable$1, NI, SchemaArgs, NetworkError as NetworkError$1, UnknownError as UnknownError$1, ErrorTypes as ErrorTypes$2, __INTERNAL__, createReducer, applyManager, actions } from '@data-client/core';
+import { NetworkManager, Manager, State, Controller, DevToolsManager, DevToolsConfig, SubscriptionManager, EndpointInterface as EndpointInterface$1, FetchFunction as FetchFunction$1, Schema as Schema$1, ResolveType as ResolveType$1, Denormalize as Denormalize$1, DenormalizeNullable as DenormalizeNullable$1, Queryable as Queryable$1, NI, SchemaArgs, NetworkError as NetworkError$1, UnknownError as UnknownError$1, ErrorTypes as ErrorTypes$2, __INTERNAL__, createReducer, applyManager, actions } from '@data-client/core';
 export { AbstractInstanceType, ActionTypes, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, ResetAction, ResolveType, Schema, SetAction, SetResponseAction, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@data-client/core';
 import * as react_jsx_runtime from 'react/jsx-runtime';
 import React, { JSX, Context } from 'react';
 
+/** Can help prevent stuttering by waiting for idle for sideEffect free fetches */
 declare class WebIdlingNetworkManager extends NetworkManager {
 }
 
@@ -30,7 +31,23 @@ interface Props$1 {
  * @see https://dataclient.io/docs/api/DataProvider
  */
 declare function DataProvider({ children, managers, initialState, Controller, devButton, }: Props$1): JSX.Element;
-declare let getDefaultManagers: () => Manager[];
+
+/** Returns the default Managers used by DataProvider.
+ *
+ * @see https://dataclient.io/docs/api/getDefaultManagers
+ */
+declare let getDefaultManagers: ({ devToolsManager, networkManager, subscriptionManager, }?: GetManagersOptions) => Manager[];
+
+type GetManagersOptions = {
+    devToolsManager?: DevToolsManager | DevToolsConfig | null;
+    networkManager?: NetworkManager | ConstructorArgs<typeof NetworkManager>;
+    subscriptionManager?: SubscriptionManager | ConstructorArgs<typeof SubscriptionManager> | null;
+};
+type ConstructorArgs<T extends {
+    new (...args: any): any;
+}> = T extends {
+    new (options: infer O): any;
+} ? O : never;
 
 /** Suspense but compatible with 18 SSR, 17, 16 and native */
 declare const UniversalSuspense: React.FunctionComponent<{


### PR DESCRIPTION
## Motivation

Currently, customizing managers found in the default managers required awkward filtering them out, and then replacing them in the correct position.

```tsx
const getManagers =
  process.env.NODE_ENV === 'development' ?
    () => [
      ...getDefaultManagers().filter(
        mgr => mgr.constructor.name !== 'DevToolsManager',
      ),
    ]
  : getDefaultManagers;
```

```tsx
function getManagers() {
  const managers = getDefaultManagers().filter(
    manager => manager.constructor.name !== 'DevToolsManager',
  );
  if (process.env.NODE_ENV !== 'production') {
    const networkManager: NetworkManager | undefined = managers.find(
      manager => manager instanceof NetworkManager,
    ) as any;
    managers.unshift(
      new DevToolsManager(
        {
          // double latency to help with high frequency updates
          latency: 1000,
          // skip websocket updates as these are too spammy
          predicate: (state, action) =>
            action.type !== actionTypes.SET_TYPE || action.schema !== Ticker,
        },
        networkManager && (action => networkManager.skipLogging(action)),
      ),
    );
  }
  return managers;
}
```

This is very cumbersome to write, and makes simple customizations non-delightful

## Solution

Use [getDefaultManagers' arguments](https://dataclient.io/docs/api/getDefaultManagers#arguments) to configure the provided managers. The argument will be a key of manager name to possible values:

- An instance of the manager itself - enabling complete control
- Arguments to be sent to constructor
- `null` meaning disable. This will not work on NetworkManager.

```tsx
// completely remove DevToolsManager
const managers = getDefaultManagers({ devToolsManager: null });
```

```tsx
// easier configuration
const managers = getDefaultManagers({
  devToolsManager: {
    // double latency to help with high frequency updates
    latency: 1000,
    // skip websocket updates as these are too spammy
    predicate: (state, action) =>
      action.type !== actionTypes.SET_TYPE || action.schema !== Ticker,
  }
});
```

```tsx
// passing instance allows us to use custom classes as well
const managers = getDefaultManagers({
	networkManager: new CustomNetworkManager(),
});
```