### PR TITLE
enhance: Manager.getMiddleware() -> Manager.middleware

### DIFF
--- a/.changeset/five-apes-pretend.md
+++ b/.changeset/five-apes-pretend.md
@@ -1,0 +1,8 @@
+---
+'@data-client/react': patch
+'@data-client/core': patch
+---
+
+Manager.getMiddleware() -> Manager.middleware
+
+`getMiddleware()` is still supported to make this change non-breaking

--- a/.changeset/new-garlics-sort.md
+++ b/.changeset/new-garlics-sort.md
@@ -1,0 +1,7 @@
+---
+'@data-client/react': patch
+---
+
+Move manager lifecycle logic from DataStore to DataProvider
+
+This has no behavioral change, but creates a better seperation of concerns.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ const totalVotesForUser = useQuery(queryTotalVotes, { userId });
 
 ```ts
 class LoggingManager implements Manager {
-  getMiddleware = (): Middleware => controller => next => async action => {
+  middleware: Middleware => controller => next => async action => {
     console.log('before', action, controller.getState());
     await next(action);
     console.log('after', action, controller.getState());

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -455,28 +455,28 @@ export default class StreamManager implements Manager {
   ) {
     this.evtSource = evtSource;
     this.endpoints = endpoints;
-
-    this.middleware = controller => {
-      this.evtSource.onmessage = event => {
-        try {
-          const msg = JSON.parse(event.data);
-          if (msg.type in this.endpoints)
-            controller.setResponse(this.endpoints[msg.type], ...msg.args, msg.data);
-        } catch (e) {
-          console.error('Failed to handle message');
-          console.error(e);
-        }
-      };
-      return next => async action => next(action);
-    };
   }
+
+  middleware: Middleware = controller => {
+    this.evtSource.onmessage = event => {
+      try {
+        const msg = JSON.parse(event.data);
+        if (msg.type in this.endpoints)
+          controller.setResponse(
+            this.endpoints[msg.type],
+            ...msg.args,
+            msg.data,
+          );
+      } catch (e) {
+        console.error('Failed to handle message');
+        console.error(e);
+      }
+    };
+    return next => async action => next(action);
+  };
 
   cleanup() {
     this.evtSource.close();
-  }
-
-  getMiddleware() {
-    return this.middleware;
   }
 }
 ```
@@ -581,10 +581,10 @@ const currentTimeInterceptor: Interceptor = {
     path: '/api/currentTime/:id',
   }),
   response({ id }) {
-    return ({
+    return {
       id,
       updatedAt: new Date().toISOString(),
-    });
+    };
   },
   delay: () => 150,
 };
@@ -621,15 +621,15 @@ const incrementInterceptor: Interceptor = {
 ## Demo
 
 <Tabs
-  defaultValue="todo"
-  values={[
-    { label: 'Todo', value: 'todo' },
-    { label: 'GitHub', value: 'github' },
-    { label: 'NextJS SSR', value: 'nextjs' },
-  ]}
-  groupId="Demos"
->
-  <TabItem value="todo">
+defaultValue="todo"
+values={[
+{ label: 'Todo', value: 'todo' },
+{ label: 'GitHub', value: 'github' },
+{ label: 'NextJS SSR', value: 'nextjs' },
+]}
+groupId="Demos"
+
+>   <TabItem value="todo">
 
 <iframe
   loading="lazy"
@@ -651,7 +651,7 @@ const incrementInterceptor: Interceptor = {
 
 [![Explore on GitHub](https://badgen.net/badge/icon/github?icon=github&label)](https://github.com/reactive/data-client/tree/master/examples/github-app)
 </TabItem>
-  <TabItem value="nextjs">
+<TabItem value="nextjs">
 
 <iframe
   loading="lazy"

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -20,9 +20,9 @@ and retrieval performance.
 
 `Controller` is provided:
 
-  - [Managers](./Manager.md) as the first argument in [Manager.getMiddleware()](./Manager.md#getmiddleware)
-  - React with [useController()](./useController.md)
-  - [Unit testing hooks](../guides/unit-testing-hooks.md) with [renderDataClient()](./makeRenderDataClient.md#controller)
+- [Managers](./Manager.md) as the first argument in [Manager.middleware](./Manager.md#middleware)
+- React with [useController()](./useController.md)
+- [Unit testing hooks](../guides/unit-testing-hooks.md) with [renderDataClient()](./makeRenderDataClient.md#controller)
 
 ```ts
 class Controller {
@@ -366,7 +366,11 @@ function UserName() {
 Updates any [Queryable](/rest/api/schema#queryable) [Schema](/rest/api/schema#schema-overview).
 
 ```ts
-ctrl.set(Todo, { id: '5' }, { id: '5', title: 'tell me friends how great Data Client is' });
+ctrl.set(
+  Todo,
+  { id: '5' },
+  { id: '5', title: 'tell me friends how great Data Client is' },
+);
 ```
 
 Functions can be used in the value when derived data is used. This [prevents race conditions](https://react.dev/reference/react/useState#updating-state-based-on-the-previous-state).
@@ -546,31 +550,24 @@ import type { Manager, Middleware, actionTypes } from '@data-client/core';
 import type { EndpointInterface } from '@data-client/endpoint';
 
 export default class MyManager implements Manager {
-  protected declare middleware: Middleware;
-  constructor() {
-    this.middleware = controller => {
-      return next => async action => {
-        if (action.type === actionTypes.FETCH_TYPE) {
-          console.log('The existing response of the requested fetch');
-          console.log(
-            controller.getResponse(
-              action.endpoint,
-              ...(action.meta.args as Parameters<typeof action.endpoint>),
-              controller.getState(),
-            ).data,
-          );
-        }
-        next(action);
-      };
+  middleware: Middleware = controller => {
+    return next => async action => {
+      if (action.type === actionTypes.FETCH_TYPE) {
+        console.log('The existing response of the requested fetch');
+        console.log(
+          controller.getResponse(
+            action.endpoint,
+            ...(action.meta.args as Parameters<typeof action.endpoint>),
+            controller.getState(),
+          ).data,
+        );
+      }
+      next(action);
     };
-  }
+  };
 
   cleanup() {
     this.websocket.close();
-  }
-
-  getMiddleware<T extends StreamManager>(this: T) {
-    return this.middleware;
   }
 }
 ```

--- a/docs/core/api/Manager.md
+++ b/docs/core/api/Manager.md
@@ -22,7 +22,7 @@ The default managers orchestrate the complex asynchronous behavior that <abbr ti
 provides out of the box. These can easily be configured with [getDefaultManagers()](./getDefaultManagers.md), and
 extended with your own custom `Managers`.
 
-Managers must implement [getMiddleware()](#getmiddleware), which hooks them into the central store's
+Managers must implement [middleware](#middleware), which hooks them into the central store's
 [control flow](#control-flow). Additionally, [cleanup()](#cleanup) and [init()](#init) hook into the
 store's lifecycle for setup/teardown behaviors.
 
@@ -32,7 +32,7 @@ type Dispatch = (action: ActionTypes) => Promise<void>;
 type Middleware = (controller: Controller) => (next: Dispatch) => Dispatch;
 
 interface Manager {
-  getMiddleware(): Middleware;
+  middleware: Middleware;
   cleanup(): void;
   init?: (state: State<any>) => void;
 }
@@ -40,9 +40,9 @@ interface Manager {
 
 ## Lifecycle
 
-### getMiddleware()
+### middleware
 
-getMiddleware() returns a function that very similar to a [redux middleware](https://redux.js.org/advanced/middleware).
+`middleware` is very similar to a [redux middleware](https://redux.js.org/advanced/middleware).
 The only differences is that the `next()` function returns a `Promise`. This promise resolves when the reducer update is
 [committed](https://indepth.dev/inside-fiber-in-depth-overview-of-the-new-reconciliation-algorithm-in-react/#general-algorithm)
 when using &lt;DataProvider /\>. This is necessary since the commit phase is asynchronously scheduled. This enables building
@@ -246,7 +246,7 @@ import CurrentTime from './CurrentTime';
 export default class TimeManager implements Manager {
   protected declare intervalID?: ReturnType<typeof setInterval>;
 
-  getMiddleware = (): Middleware => controller => {
+  middleware: Middleware => controller => {
     this.intervalID = setInterval(() => {
       controller.set(CurrentTime, { id: 1 }, { id: 1, time: Date.now() });
     }, 1000);
@@ -273,7 +273,7 @@ import type { Manager, Middleware } from '@data-client/react';
 import { actionTypes } from '@data-client/react';
 
 export default class LoggingManager implements Manager {
-  getMiddleware = (): Middleware => controller => next => async action => {
+  middleware: Middleware => controller => next => async action => {
     switch (action.type) {
       case actionTypes.SET_RESPONSE_TYPE:
         if (action.endpoint.sideEffect) {
@@ -326,7 +326,7 @@ import isEntity from './isEntity';
 export default class CustomSubsManager implements Manager {
   protected declare entities: Record<string, EntityInterface>;
 
-  getMiddleware = (): Middleware => controller => next => async action => {
+  middleware: Middleware => controller => next => async action => {
     switch (action.type) {
       case actionTypes.SUBSCRIBE_TYPE:
       case actionTypes.UNSUBSCRIBE_TYPE:

--- a/docs/core/api/types.md
+++ b/docs/core/api/types.md
@@ -6,7 +6,7 @@ title: TypeScript Types
 
 ```typescript
 interface Manager<Actions = ActionTypes> {
-  getMiddleware(): Middleware<Actions>;
+  middleware: Middleware<Actions>;
   cleanup(): void;
   init?: (state: State<any>) => void;
 }

--- a/docs/core/guides/redux.md
+++ b/docs/core/guides/redux.md
@@ -110,7 +110,7 @@ You should only use ONE provider; nested another provider will override the prev
 
 :::info Note
 
-Because `Reactive Data Client` [manager middlewares](../api/Manager.md#getmiddleware) return promises,
+Because `Reactive Data Client` [manager middlewares](../api/Manager.md#middleware) return promises,
 all redux middlewares are placed after the [Managers](../concepts/managers.md).
 
 If you need a middlware to run before the managers, you will need to wrap it in a [manager](../api/Manager.md).

--- a/packages/core/src/manager/LogoutManager.ts
+++ b/packages/core/src/manager/LogoutManager.ts
@@ -1,54 +1,42 @@
 import { SET_RESPONSE_TYPE } from '../actionTypes.js';
-import Controller from '../controller/Controller.js';
+import type Controller from '../controller/Controller.js';
 import { UnknownError } from '../index.js';
-import { ActionTypes, Manager } from '../types.js';
+import type { Manager, Middleware } from '../types.js';
 
 /** Handling network unauthorized indicators like HTTP 401
  *
  * @see https://dataclient.io/docs/api/LogoutManager
  */
 export default class LogoutManager implements Manager {
-  protected declare middleware: Middleware;
-
   constructor({ handleLogout, shouldLogout }: Props = {}) {
     if (handleLogout) this.handleLogout = handleLogout;
     if (shouldLogout) this.shouldLogout = shouldLogout;
-    this.middleware = controller => next => async action => {
-      await next(action);
-      if (
-        action.type === SET_RESPONSE_TYPE &&
-        action.error &&
-        this.shouldLogout(action.response)
-      ) {
-        this.handleLogout(controller);
-      }
-    };
   }
+
+  middleware: Middleware = controller => next => async action => {
+    await next(action);
+    if (
+      action.type === SET_RESPONSE_TYPE &&
+      action.error &&
+      this.shouldLogout(action.response)
+    ) {
+      this.handleLogout(controller);
+    }
+  };
 
   cleanup() {}
-
-  getMiddleware() {
-    return this.middleware;
-  }
 
   protected shouldLogout(error: UnknownError) {
     // 401 indicates reauthorization is needed
     return error.status === 401;
   }
 
-  handleLogout(controller: Controller<Dispatch>) {
+  handleLogout(controller: Controller) {
     controller.resetEntireStore();
   }
 }
 
-type Dispatch = (value: ActionTypes) => Promise<void>;
-
-// this further restricts the types to be future compatible
-export type Middleware = <C extends Controller<Dispatch>>(
-  controller: C,
-) => (next: C['dispatch']) => C['dispatch'];
-
-type HandleLogout = (controller: Controller<Dispatch>) => void;
+type HandleLogout = (controller: Controller) => void;
 
 interface Props {
   handleLogout?: HandleLogout;

--- a/packages/core/src/manager/__tests__/applyManager.ts
+++ b/packages/core/src/manager/__tests__/applyManager.ts
@@ -1,5 +1,13 @@
+import { Article } from '__tests__/new';
+
+import { createSet } from '../../controller/actions';
 import Controller from '../../controller/Controller';
-import applyManager from '../applyManager';
+import { Dispatch, Middleware } from '../../middlewareTypes';
+import { Manager } from '../../types';
+import applyManager, {
+  ReduxMiddleware,
+  ReduxMiddlewareAPI,
+} from '../applyManager';
 import NetworkManager from '../NetworkManager';
 
 function onError(e: any) {
@@ -36,3 +44,55 @@ it('applyManagers should not console.warn() when NetworkManager is provided', ()
     warnspy.mockRestore();
   }
 });
+it('applyManagers should handle legacy Manager.getMiddleware()', () => {
+  let initCount = 0;
+  let actionCount = 0;
+  class MyManager implements Manager {
+    getMiddleware = (): Middleware => ctrl => {
+      initCount++;
+      return next => action => {
+        actionCount++;
+        return next(action);
+      };
+    };
+
+    cleanup() {}
+  }
+  const middlewares = applyManager(
+    [new MyManager(), new NetworkManager()],
+    new Controller(),
+  );
+
+  const rootDispatch = jest.fn((action: any) => {
+    return Promise.resolve();
+  });
+
+  const dispatch = middlewareDispatch(middlewares, rootDispatch);
+
+  expect(initCount).toBe(1);
+  expect(actionCount).toBe(0);
+  expect(rootDispatch.mock.calls.length).toBe(0);
+  dispatch(
+    createSet(Article, { args: [{ id: 1 }], value: { id: 1, title: 'hi' } }),
+  );
+  expect(initCount).toBe(1);
+  expect(actionCount).toBe(1);
+  expect(rootDispatch.mock.calls.length).toBe(1);
+});
+
+function middlewareDispatch(
+  middlewares: ReduxMiddleware[],
+  rootDispatch: Dispatch,
+) {
+  const middlewareAPI: ReduxMiddlewareAPI = {
+    getState: () => ({}),
+    dispatch: action => rootDispatch(action),
+  };
+  const comp = compose(
+    middlewares.map(middleware => middleware(middlewareAPI)),
+  );
+  const dispatch = comp(rootDispatch);
+  return dispatch;
+}
+const compose = (fns: ((...args: any) => any)[]) => (initial: any) =>
+  fns.reduceRight((v, f) => f(v), initial);

--- a/packages/core/src/manager/__tests__/logoutManager.ts
+++ b/packages/core/src/manager/__tests__/logoutManager.ts
@@ -21,11 +21,10 @@ describe('LogoutManager', () => {
   const manager = new LogoutManager();
   const getState = () => initialState;
 
-  describe('getMiddleware()', () => {
+  describe('middleware', () => {
     it('should return the same value every call', () => {
-      const a = manager.getMiddleware();
-      expect(a).toBe(manager.getMiddleware());
-      expect(a).toBe(manager.getMiddleware());
+      const a = manager.middleware;
+      expect(a).toBe(manager.middleware);
     });
   });
 
@@ -33,7 +32,6 @@ describe('LogoutManager', () => {
     afterEach(() => {
       jest.useRealTimers();
     });
-    const middleware = manager.getMiddleware();
     const next = jest.fn();
     const dispatch = jest.fn(action => Promise.resolve());
     const controller = new Controller({ dispatch, getState });
@@ -48,7 +46,7 @@ describe('LogoutManager', () => {
         args: [{ id: 5 }],
         response: { id: 5, title: 'hi' },
       });
-      await middleware(API)(next)(action);
+      await manager.middleware(API)(next)(action);
 
       expect(dispatch.mock.calls.length).toBe(0);
     });
@@ -60,7 +58,7 @@ describe('LogoutManager', () => {
         response: error,
         error: true,
       });
-      await middleware(API)(next)(action);
+      await manager.middleware(API)(next)(action);
 
       expect(dispatch.mock.calls.length).toBe(0);
     });
@@ -72,7 +70,7 @@ describe('LogoutManager', () => {
         response: error,
         error: true,
       });
-      await middleware(API)(next)(action);
+      await manager.middleware(API)(next)(action);
 
       expect(dispatch.mock.calls.length).toBe(1);
       expect(dispatch.mock.calls[0][0]?.type).toBe(RESET_TYPE);
@@ -85,7 +83,7 @@ describe('LogoutManager', () => {
           return error.status === 403;
         },
         handleLogout,
-      }).getMiddleware();
+      }).middleware;
       const error: any = new Error('network failed');
       error.status = 403;
       const action = createSetResponse(CoolerArticleResource.get, {
@@ -102,7 +100,7 @@ describe('LogoutManager', () => {
       const action = { type: FETCH_TYPE };
       next.mockReset();
 
-      await middleware(API)(next)(action as any);
+      await manager.middleware(API)(next)(action as any);
 
       expect(next.mock.calls.length).toBe(1);
     });

--- a/packages/core/src/manager/__tests__/manager.ts
+++ b/packages/core/src/manager/__tests__/manager.ts
@@ -1,9 +1,8 @@
 import Controller from '../../controller/Controller';
-import { Middleware } from '../../middlewareTypes';
 import { ActionTypes } from '../../types';
 import NetworkManager from '../NetworkManager';
 
-const middleware: Middleware = new NetworkManager().getMiddleware();
+const netMgr = new NetworkManager();
 it('middlewares should compose with non-data-client middlewares', () => {
   type AnotherAction = {
     type: 'BOB';
@@ -30,7 +29,7 @@ it('middlewares should compose with non-data-client middlewares', () => {
       counter++;
     };
 
-  const [a, b] = [middleware(API), nonRHMiddleware(API)];
+  const [a, b] = [netMgr.middleware(API), nonRHMiddleware(API)];
   const dispA = a(b(dispatch));
   const dispB = b(a(dispatch));
   expect(dispatch.mock.calls.length).toBe(0);

--- a/packages/core/src/manager/__tests__/networkManager.ts
+++ b/packages/core/src/manager/__tests__/networkManager.ts
@@ -33,18 +33,17 @@ describe('NetworkManager', () => {
     expect(hacked.getHacked()).toEqual(initialState);
   });
 
-  describe('getMiddleware()', () => {
+  describe('middleware', () => {
     it('should return the same value every call', () => {
-      const a = manager.getMiddleware();
-      expect(a).toBe(manager.getMiddleware());
-      expect(a).toBe(manager.getMiddleware());
+      const a = manager.middleware;
+      expect(a).toBe(manager.middleware);
     });
     it('should return the different value for a different instance', () => {
-      const a = manager.getMiddleware();
+      const a = manager.middleware;
       const manager2 = new NetworkManager();
-      const a2 = manager2.getMiddleware();
+      const a2 = manager2.middleware;
       expect(a).not.toBe(a2);
-      expect(a2).toBe(manager2.getMiddleware());
+      expect(a2).toBe(manager2.middleware);
       manager2.cleanup();
     });
   });
@@ -132,10 +131,8 @@ describe('NetworkManager', () => {
     (fetchRejectAction.meta.promise as any).catch((e: unknown) => {});
 
     let NM: NetworkManager;
-    let middleware: Middleware;
     beforeEach(() => {
       NM = new NetworkManager({ dataExpiryLength: 42, errorExpiryLength: 7 });
-      middleware = NM.getMiddleware();
     });
     afterEach(() => {
       NM.cleanup();
@@ -152,7 +149,7 @@ describe('NetworkManager', () => {
         },
       );
 
-      middleware(API)(next)(fetchResolveAction);
+      NM.middleware(API)(next)(fetchResolveAction);
 
       const response = await fetchResolveAction.endpoint(
         ...fetchResolveAction.args,
@@ -188,7 +185,7 @@ describe('NetworkManager', () => {
         },
       );
 
-      middleware(API)(next)(fetchSetWithUpdatersAction);
+      NM.middleware(API)(next)(fetchSetWithUpdatersAction);
 
       const response = await fetchSetWithUpdatersAction.endpoint(
         ...fetchSetWithUpdatersAction.args,
@@ -224,7 +221,7 @@ describe('NetworkManager', () => {
         },
       );
 
-      middleware(API)(next)(fetchRpcWithUpdatersAction);
+      NM.middleware(API)(next)(fetchRpcWithUpdatersAction);
 
       const response = await fetchRpcWithUpdatersAction.endpoint(
         ...fetchRpcWithUpdatersAction.args,
@@ -260,7 +257,7 @@ describe('NetworkManager', () => {
         },
       );
 
-      middleware(API)(next)(fetchRpcWithUpdatersAndOptimisticAction);
+      NM.middleware(API)(next)(fetchRpcWithUpdatersAndOptimisticAction);
 
       const response = await fetchRpcWithUpdatersAndOptimisticAction.endpoint(
         ...fetchRpcWithUpdatersAndOptimisticAction.args,
@@ -293,7 +290,7 @@ describe('NetworkManager', () => {
         },
       );
 
-      middleware(API)(() => Promise.resolve())({
+      NM.middleware(API)(() => Promise.resolve())({
         ...fetchResolveAction,
         endpoint: detailEndpoint.extend({ dataExpiryLength: 314 }),
       });
@@ -314,7 +311,7 @@ describe('NetworkManager', () => {
         },
       );
 
-      middleware(API)(() => Promise.resolve())({
+      NM.middleware(API)(() => Promise.resolve())({
         ...fetchResolveAction,
         endpoint: detailEndpoint.extend({ dataExpiryLength: undefined }),
       });
@@ -337,7 +334,7 @@ describe('NetworkManager', () => {
       );
 
       try {
-        await middleware(API)(next)(fetchRejectAction);
+        await NM.middleware(API)(next)(fetchRejectAction);
       } catch (error) {
         expect(next).not.toHaveBeenCalled();
         expect(dispatch).toHaveBeenCalledWith({
@@ -363,7 +360,7 @@ describe('NetworkManager', () => {
       );
 
       try {
-        await middleware(API)(() => Promise.resolve())({
+        await NM.middleware(API)(() => Promise.resolve())({
           ...fetchRejectAction,
           meta: {
             ...fetchRejectAction.meta,
@@ -386,7 +383,7 @@ describe('NetworkManager', () => {
       );
 
       try {
-        await middleware(API)(() => Promise.resolve())({
+        await NM.middleware(API)(() => Promise.resolve())({
           ...fetchRejectAction,
           meta: {
             ...fetchRejectAction.meta,

--- a/packages/core/src/manager/__tests__/subscriptionManager.ts
+++ b/packages/core/src/manager/__tests__/subscriptionManager.ts
@@ -27,11 +27,10 @@ describe('SubscriptionManager', () => {
   const manager = new SubscriptionManager(TestSubscription);
   const getState = () => initialState;
 
-  describe('getMiddleware()', () => {
+  describe('middleware', () => {
     it('should return the same value every call', () => {
-      const a = manager.getMiddleware();
-      expect(a).toBe(manager.getMiddleware());
-      expect(a).toBe(manager.getMiddleware());
+      const a = manager.middleware;
+      expect(a).toBe(manager.middleware);
     });
   });
 
@@ -74,7 +73,6 @@ describe('SubscriptionManager', () => {
     }
 
     const manager = new SubscriptionManager(TestSubscription);
-    const middleware = manager.getMiddleware();
     const next = jest.fn();
     const dispatch = () => Promise.resolve();
     const controller = new Controller({ dispatch, getState });
@@ -86,14 +84,14 @@ describe('SubscriptionManager', () => {
     );
     it('subscribe should add a subscription', () => {
       const action = createSubscribeAction({ id: 5 });
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect(next).not.toHaveBeenCalled();
       expect((manager as any).subscriptions[action.key]).toBeDefined();
     });
     it('subscribe should add a subscription (no frequency)', () => {
       const action = createSubscribeAction({ id: 597 });
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect(next).not.toHaveBeenCalled();
       expect((manager as any).subscriptions[action.key]).toBeDefined();
@@ -101,19 +99,19 @@ describe('SubscriptionManager', () => {
 
     it('subscribe with same should call subscription.add', () => {
       const action = createSubscribeAction({ id: 5, title: 'four' });
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect(
         (manager as any).subscriptions[action.key].add.mock.calls.length,
       ).toBe(1);
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
       expect(
         (manager as any).subscriptions[action.key].add.mock.calls.length,
       ).toBe(2);
     });
     it('subscribe with another should create another', () => {
       const action = createSubscribeAction({ id: 7, title: 'four cakes' });
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect((manager as any).subscriptions[action.key]).toBeDefined();
       expect(
@@ -134,13 +132,13 @@ describe('SubscriptionManager', () => {
         () => true,
       );
 
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect((manager as any).subscriptions[action.key]).not.toBeDefined();
     });
 
     it('unsubscribe should delete when remove returns true (no frequency)', () => {
-      middleware(API)(next)(
+      manager.middleware(API)(next)(
         createSubscribeAction({ id: 50, title: 'four cakes' }),
       );
 
@@ -149,7 +147,7 @@ describe('SubscriptionManager', () => {
         () => true,
       );
 
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect((manager as any).subscriptions[action.key]).not.toBeDefined();
     });
@@ -160,7 +158,7 @@ describe('SubscriptionManager', () => {
         () => false,
       );
 
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect((manager as any).subscriptions[action.key]).toBeDefined();
       expect(
@@ -174,7 +172,7 @@ describe('SubscriptionManager', () => {
 
       const action = createUnsubscribeAction({ id: 25 });
 
-      middleware(API)(next)(action);
+      manager.middleware(API)(next)(action);
 
       expect((manager as any).subscriptions[action.key]).not.toBeDefined();
 
@@ -190,7 +188,7 @@ describe('SubscriptionManager', () => {
       const action = { type: SET_RESPONSE_TYPE };
       next.mockReset();
 
-      middleware(API)(next)(action as any);
+      manager.middleware(API)(next)(action as any);
 
       expect(next.mock.calls.length).toBe(1);
     });

--- a/packages/core/src/middlewareTypes.ts
+++ b/packages/core/src/middlewareTypes.ts
@@ -1,15 +1,14 @@
 import type Controller from './controller/Controller.js';
 import type { ActionTypes, State } from './types.js';
 
-type ClientDispatch<Actions = ActionTypes> = (value: Actions) => Promise<void>;
+export type Dispatch<Actions = ActionTypes> = (value: Actions) => Promise<void>;
 
-export interface MiddlewareAPI
-  extends Controller<ClientDispatch<ActionTypes>> {}
+export interface MiddlewareAPI extends Controller<Dispatch<ActionTypes>> {}
 
 export interface MiddlewareController<Actions = ActionTypes>
-  extends Controller<ClientDispatch<Actions>> {}
+  extends Controller<Dispatch<Actions>> {}
 
-/** @see https://dataclient.io/docs/api/Manager#getmiddleware */
+/** @see https://dataclient.io/docs/api/Manager#middleware */
 export type Middleware<Actions = ActionTypes> = <
   C extends MiddlewareController<Actions>,
 >(
@@ -20,14 +19,3 @@ export type DataClientReducer = (
   prevState: State<unknown>,
   action: ActionTypes,
 ) => State<unknown>;
-
-/* The next are types from React; but we don't want dependencies on it */
-export type Dispatch<R extends Reducer<any, any>> = (
-  action: ReducerAction<R>,
-) => Promise<void>;
-
-export type Reducer<S, A> = (prevState: S, action: A) => S;
-export type ReducerState<R extends Reducer<any, any>> =
-  R extends Reducer<infer S, any> ? S : never;
-export type ReducerAction<R extends Reducer<any, any>> =
-  R extends Reducer<any, infer A> ? A : never;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,7 +61,9 @@ export interface State<T> {
  */
 export interface Manager<Actions = ActionTypes> {
   /** @see https://dataclient.io/docs/api/Manager#getmiddleware */
-  getMiddleware(): Middleware<Actions>;
+  getMiddleware?(): Middleware<Actions>;
+  /** @see https://dataclient.io/docs/api/Manager#middleware */
+  middleware?: Middleware<Actions>;
   /** @see https://dataclient.io/docs/api/Manager#cleanup */
   cleanup(): void;
   /** @see https://dataclient.io/docs/api/Manager#init */

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -159,7 +159,7 @@ const totalVotesForUser = useQuery(queryTotalVotes, { userId });
 
 ```ts
 class LoggingManager implements Manager {
-  getMiddleware = (): Middleware => controller => next => async action => {
+  middleware: Middleware => controller => next => async action => {
     console.log('before', action, controller.getState());
     await next(action);
     console.log('after', action, controller.getState());

--- a/packages/react/src/components/DataStore.tsx
+++ b/packages/react/src/components/DataStore.tsx
@@ -4,7 +4,7 @@
 import type { State, Manager } from '@data-client/core';
 import { createReducer, Controller } from '@data-client/core';
 import useEnhancedReducer from '@data-client/use-enhanced-reducer';
-import type { Middleware } from '@data-client/use-enhanced-reducer';
+import type { Middleware as GenericMiddleware } from '@data-client/use-enhanced-reducer';
 import React, { useEffect, useMemo, memo } from 'react';
 
 import BackupLoading from './BackupLoading.js';
@@ -13,8 +13,8 @@ import { StateContext } from '../context.js';
 
 interface StoreProps {
   children: React.ReactNode;
-  managers: Manager[];
-  middlewares: Middleware[];
+  mgrEffect: () => void;
+  middlewares: GenericMiddleware[];
   initialState: State<unknown>;
   controller: Controller;
 }
@@ -24,7 +24,7 @@ interface StoreProps {
  */
 function DataStore({
   children,
-  managers,
+  mgrEffect,
   middlewares,
   initialState,
   controller,
@@ -39,19 +39,8 @@ function DataStore({
     [masterReducer, state],
   );
 
-  // if we change out the manager we need to make sure it has no hanging async
-  useEffect(() => {
-    for (let i = 0; i < managers.length; ++i) {
-      managers[i].init?.(state);
-    }
-    return () => {
-      for (let i = 0; i < managers.length; ++i) {
-        managers[i].cleanup();
-      }
-    };
-    // we're ignoring state here, because it shouldn't trigger inits
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [managers]);
+  // only run once everything is prepared
+  useEffect(mgrEffect, [mgrEffect]);
 
   return (
     <StateContext.Provider value={optimisticState}>

--- a/packages/react/src/components/__tests__/provider.tsx
+++ b/packages/react/src/components/__tests__/provider.tsx
@@ -158,23 +158,16 @@ describe('<DataProvider />', () => {
 
   it('should ignore dispatches after unmount', async () => {
     class InjectorManager implements Manager {
-      protected declare middleware: Middleware;
       declare controller: Controller;
-
-      constructor() {
-        this.middleware = controller => {
-          this.controller = controller;
-          return next => async action => {
-            await next(action);
-          };
-        };
-      }
 
       cleanup() {}
 
-      getMiddleware() {
-        return this.middleware;
-      }
+      middleware: Middleware = controller => {
+        this.controller = controller;
+        return next => async action => {
+          await next(action);
+        };
+      };
     }
     const injector = new InjectorManager();
     const managers = [injector, ...getDefaultManagers()];


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simplification

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

We previously used `getMiddleware()` so we wouldn't have to worry about object binding (we could assign middleware variable instead of calling manager.middleware()). However, applyManagers gives us full control of how it is is called, so this is no longer necessary.

#### Before

```ts
class LoggingManager implements Manager {
  getMiddleware = (): Middleware => controller => next => async action => {
    console.log('before', action, controller.getState());
    await next(action);
    console.log('after', action, controller.getState());
  };

  cleanup() {}
}
```

#### After

```ts
class LoggingManager implements Manager {
  middleware: Middleware => controller => next => async action => {
    console.log('before', action, controller.getState());
    await next(action);
    console.log('after', action, controller.getState());
  };

  cleanup() {}
}
```