### PR TITLE
feat: Queries can take object schemas

### DIFF
--- a/.changeset/green-dogs-lay.md
+++ b/.changeset/green-dogs-lay.md
@@ -7,7 +7,7 @@
 '@data-client/rest': patch
 ---
 
-Query can take Object Schemas
+[Query](https://dataclient.io/rest/api/Query) can take [Object Schemas](https://dataclient.io/rest/api/Object)
 
 This enables joining arbitrary objects (whose pk works with the same arguments.)
 

--- a/.changeset/green-dogs-lay.md
+++ b/.changeset/green-dogs-lay.md
@@ -1,0 +1,35 @@
+---
+'@data-client/normalizr': patch
+'@data-client/endpoint': patch
+'@data-client/react': patch
+'@data-client/core': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+---
+
+Query can take Object Schemas
+
+This enables joining arbitrary objects (whose pk works with the same arguments.)
+
+```ts
+class Ticker extends Entity {
+  product_id = '';
+  price = 0;
+
+  pk(): string {
+    return this.product_id;
+  }
+}
+class Stats extends Entity {
+  product_id = '';
+  last = 0;
+
+  pk(): string {
+    return this.product_id;
+  }
+}
+const queryPrice = new schema.Query(
+  { ticker: Ticker, stats: Stats },
+  ({ ticker, stats }) => ticker?.price ?? stats?.last,
+);
+```

--- a/docs/core/api/useQuery.md
+++ b/docs/core/api/useQuery.md
@@ -66,7 +66,7 @@ interface Queryable {
     getIndex: GetIndex,
     // Must be non-void
   ): {};
-};
+}
 ```
 
 ## Examples
@@ -147,4 +147,13 @@ render(<UsersPage />);
 
 [Queries](/rest/api/Query) can also be used to compute aggregates
 
-<StackBlitz app="todo-app" file="src/resources/TodoResource.ts,src/pages/Home/TodoStats.tsx" />
+<StackBlitz app="todo-app" file="src/resources/TodoResource.ts,src/pages/Home/TodoStats.tsx" height="420" />
+
+### Data fallbacks
+
+In this case `Ticker` is constantly updated from a websocket stream. However, there is no bulk/list
+fetch for `Ticker` - making it inefficient for getting the prices on a list view.
+
+So in this case we can fetch a list of `Stats` as a fallback since it has price data as well.
+
+<StackBlitz app="coin-app" file="src/pages/Home/CurrencyList.tsx,src/resources/fallbackQueries.ts,src/pages/Home/AssetPrice.tsx" />

--- a/docs/rest/api/Query.md
+++ b/docs/rest/api/Query.md
@@ -270,3 +270,14 @@ render(<TodosPage />);
 ```
 
 </HooksPlayground>
+
+### Fallback joins
+
+import StackBlitz from '@site/src/components/StackBlitz';
+
+In this case `Ticker` is constantly updated from a websocket stream. However, there is no bulk/list
+fetch for `Ticker` - making it inefficient for getting the prices on a list view.
+
+So in this case we can fetch a list of `Stats` as a fallback since it has price data as well.
+
+<StackBlitz app="coin-app" file="src/pages/Home/CurrencyList.tsx,src/pages/Home/AssetPrice.tsx,src/resources/fallbackQueries.ts" />

--- a/examples/coin-app/src/pages/Home/AssetPrice.tsx
+++ b/examples/coin-app/src/pages/Home/AssetPrice.tsx
@@ -1,5 +1,5 @@
-import { useCache, useSubscription } from '@data-client/react';
-import { StatsResource } from 'resources/Stats';
+import { useQuery, useSubscription } from '@data-client/react';
+import { queryPrice } from 'resources/fallbackQueries';
 import { getTicker } from 'resources/Ticker';
 
 import { formatPrice } from '../../components/formatPrice';
@@ -16,9 +16,5 @@ interface Props {
 
 function useLivePrice(product_id: string) {
   useSubscription(getTicker, { product_id });
-  const ticker = useCache(getTicker, { product_id });
-  const stats = useCache(StatsResource.get, { id: product_id });
-  // fallback to stats, as we can load those in a bulk fetch for SSR
-  // it would be preferable to simply provide bulk fetch of ticker to simplify code here
-  return ticker?.price ?? stats?.last;
+  return useQuery(queryPrice, { product_id });
 }

--- a/examples/coin-app/src/resources/Stats.ts
+++ b/examples/coin-app/src/resources/Stats.ts
@@ -1,8 +1,9 @@
+import { SchemaArgs } from '@data-client/react';
 import { Entity, resource, schema } from '@data-client/rest';
 
 export class Stats extends Entity {
-  id = '';
-  open = '0.15';
+  product_id = '';
+  open = 0;
   high = 0;
   low = 0;
   last = 0;
@@ -13,12 +14,17 @@ export class Stats extends Entity {
     return this.volume_30day * this.last;
   }
 
+  get gain_24() {
+    return (this.last - this.open) / this.open;
+  }
+
   pk(parent: any, key: string, args: any[]) {
-    return this.id ?? key ?? args[0]?.id;
+    return this.product_id ?? key ?? args[0]?.product_id;
   }
 
   static key = 'Stats';
   static schema = {
+    open: Number,
     high: Number,
     low: Number,
     volume: Number,
@@ -27,13 +33,16 @@ export class Stats extends Entity {
   };
 
   process(value: any, parent: any, key: string, args: any[]) {
-    return { ...value, id: value.id ?? key ?? args[0]?.id };
+    return {
+      ...value,
+      product_id: value.product_id ?? key ?? args[0]?.product_id,
+    };
   }
 }
 
 export const StatsResource = resource({
   urlPrefix: 'https://api.exchange.coinbase.com',
-  path: '/products/:id/stats',
+  path: '/products/:product_id/stats',
   schema: Stats,
 }).extend({
   getList: {

--- a/examples/coin-app/src/resources/Ticker.ts
+++ b/examples/coin-app/src/resources/Ticker.ts
@@ -6,12 +6,11 @@ export class Ticker extends Entity {
   trade_id = 0;
   price = 0;
   time = new Date(0);
-  // last_size = '0';
-  // best_bid = '0';
-  // best_ask = '0';
-  // volume_24h = '';
-  // volume_30d = '';
   open_24h = 0;
+
+  get gain_24() {
+    return (this.price - this.open_24h) / this.open_24h;
+  }
 
   pk(): string {
     return this.product_id;

--- a/examples/coin-app/src/resources/fallbackQueries.ts
+++ b/examples/coin-app/src/resources/fallbackQueries.ts
@@ -1,0 +1,22 @@
+import { schema } from '@data-client/rest';
+
+import { Stats } from './Stats';
+import { Ticker } from './Ticker';
+
+/** Computes price; falling back to stats data
+ * Stats can be bulk-fetched which makes it good for list views
+ */
+export const queryPrice = new schema.Query(
+  { ticker: Ticker, stats: Stats },
+  ({ ticker, stats }) => ticker?.price ?? stats?.last,
+);
+
+/** Computes 24 hour gain; falling back to stats data
+ * Stats can be bulk-fetched which makes it good for list views
+ */
+export const queryGain24 = new schema.Query(
+  { ticker: Ticker, stats: Stats },
+  ({ ticker, stats }) => {
+    return ticker?.gain_24 ?? stats?.gain_24 ?? 0;
+  },
+);

--- a/packages/endpoint/src-4.0-types/schemaArgs.d.ts
+++ b/packages/endpoint/src-4.0-types/schemaArgs.d.ts
@@ -1,0 +1,13 @@
+import type { Schema, EntityInterface } from './interface.js';
+import type { EntityFields } from './schemas/EntityFields.js';
+export type SchemaArgs<S extends Schema> = S extends EntityInterface<infer U> ? [EntityFields<U>] : S extends ({
+    queryKey(args: infer Args, ...rest: any): any;
+}) ? Args : S extends {
+    [K: string]: any;
+} ? ObjectArgs<S> : never;
+export type ObjectArgs<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends ({
+        queryKey(args: infer Args, ...rest: any): any;
+    }) ? Args : never;
+}[keyof S];
+//# sourceMappingURL=schemaArgs.d.ts.map

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -29,6 +29,7 @@ export type {
   PolymorphicInterface,
   Queryable,
 } from './interface.js';
+export type { EntityFields } from './schemas/EntityFields.js';
 export type {
   AbstractInstanceType,
   Normalize,
@@ -36,6 +37,14 @@ export type {
   Denormalize,
   DenormalizeNullable,
   SchemaArgs,
+  ObjectArgs,
+  EntityMap,
+  RecordClass,
+  NormalizedNullableObject,
+  NormalizeObject,
+  NormalizedEntity,
+  DenormalizeObject,
+  DenormalizeNullableObject,
 } from './normal.js';
 export type {
   EndpointExtraOptions,

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -10,9 +10,9 @@ export type Schema =
   | SchemaSimple
   | Serializable;
 
-export interface Queryable {
+export interface Queryable<Args extends readonly any[] = readonly any[]> {
   queryKey(
-    args: readonly any[],
+    args: Args,
     queryKey: (...args: any) => any,
     getEntity: GetEntity,
     getIndex: GetIndex,
@@ -24,7 +24,7 @@ export type Serializable<
   T extends { toJSON(): string } = { toJSON(): string },
 > = (value: any) => T;
 
-export interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
+export interface SchemaSimple<T = any, Args extends readonly any[] = any> {
   normalize(
     input: any,
     parent: any,
@@ -48,15 +48,12 @@ export interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
   ): any;
 }
 
-export interface SchemaClass<
-  T = any,
-  N = T | undefined,
-  Args extends any[] = any[],
-> extends SchemaSimple<T, Args> {
+export interface SchemaClass<T = any, Args extends readonly any[] = any>
+  extends SchemaSimple<T, Args> {
   // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
   _normalizeNullable(): any;
   // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo
-  _denormalizeNullable(): N;
+  _denormalizeNullable(): any;
 }
 
 export interface EntityInterface<T = any> extends SchemaSimple {

--- a/packages/endpoint/src/normal.ts
+++ b/packages/endpoint/src/normal.ts
@@ -3,9 +3,8 @@ import type {
   Serializable,
   EntityInterface,
   NormalizedIndex,
-  Queryable,
 } from './interface.js';
-import { EntityFields } from './schemas/EntityFields.js';
+export * from './schemaArgs.js';
 
 // TypeScript <4.2 InstanceType<> does not work on abstract classes
 export type AbstractInstanceType<T> =
@@ -118,18 +117,3 @@ export type NormalizedSchema<E, R> = {
 export interface EntityMap<T = any> {
   readonly [k: string]: EntityInterface<T>;
 }
-
-export type SchemaArgs<S extends Schema> =
-  S extends EntityInterface<infer U> ? [EntityFields<U>]
-  : S extends (
-    {
-      queryKey(args: infer Args, ...rest: any): any;
-    }
-  ) ?
-    Args
-  : // : S extends { [K: string]: any } ? ObjectArgs<S>
-    never;
-
-export type ObjectArgs<S extends Record<string, any>> = {
-  [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
-}[keyof S];

--- a/packages/endpoint/src/normal.ts
+++ b/packages/endpoint/src/normal.ts
@@ -127,8 +127,8 @@ export type SchemaArgs<S extends Schema> =
     }
   ) ?
     Args
-  : S extends { [K: string]: any } ? ObjectArgs<S>
-  : never;
+  : // : S extends { [K: string]: any } ? ObjectArgs<S>
+    never;
 
 export type ObjectArgs<S extends Record<string, any>> = {
   [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;

--- a/packages/endpoint/src/normal.ts
+++ b/packages/endpoint/src/normal.ts
@@ -123,13 +123,13 @@ export type SchemaArgs<S extends Schema> =
   S extends EntityInterface<infer U> ? [EntityFields<U>]
   : S extends (
     {
-      queryKey(
-        args: infer Args,
-        queryKey: (...args: any) => any,
-        getEntity: any,
-        getIndex: any,
-      ): any;
+      queryKey(args: infer Args, ...rest: any): any;
     }
   ) ?
     Args
+  : S extends { [K: string]: any } ? ObjectArgs<S>
   : never;
+
+export type ObjectArgs<S extends Record<string, any>> = {
+  [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -18,6 +18,7 @@ import type {
   NormalizeObject,
   NormalizedNullableObject,
   EntityMap,
+  ObjectArgs,
 } from './normal.js';
 import { EntityFields } from './schemas/EntityFields.js';
 import type {
@@ -164,7 +165,7 @@ export class All<
  * Represents objects with statically known members
  * @see https://dataclient.io/rest/api/Object
  */
-export class Object<O extends Record<string, any> = Record<string, Schema>>
+export class Object<O extends Record<string, any> = Record<string, any>>
   implements SchemaClass
 {
   /**
@@ -196,7 +197,7 @@ export class Object<O extends Record<string, any> = Record<string, Schema>>
   ): DenormalizeObject<O>;
 
   queryKey(
-    args: readonly any[],
+    args: ObjectArgs<O>,
     queryKey: (...args: any) => any,
     getEntity: GetEntity,
     getIndex: GetIndex,

--- a/packages/endpoint/src/schemaArgs.ts
+++ b/packages/endpoint/src/schemaArgs.ts
@@ -1,0 +1,17 @@
+import type { Schema, EntityInterface } from './interface.js';
+import type { EntityFields } from './schemas/EntityFields.js';
+
+export type SchemaArgs<S extends Schema> =
+  S extends EntityInterface<infer U> ? [EntityFields<U>]
+  : S extends (
+    {
+      queryKey(args: infer Args, ...rest: any): any;
+    }
+  ) ?
+    Args
+  : S extends { [K: string]: any } ? ObjectArgs<S>
+  : never;
+
+export type ObjectArgs<S extends Record<string, any>> = {
+  [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];

--- a/packages/endpoint/src/schemas/Query.ts
+++ b/packages/endpoint/src/schemas/Query.ts
@@ -12,7 +12,7 @@ import type { Denormalize, NormalizeNullable, SchemaArgs } from '../normal.js';
  * @see https://dataclient.io/rest/api/Query
  */
 export default class Query<
-  S extends Queryable,
+  S extends Queryable | { [k: string]: Queryable },
   P extends (entries: Denormalize<S>, ...args: any) => any,
 > implements SchemaSimple<ReturnType<P> | undefined, ProcessParameters<P, S>>
 {
@@ -61,7 +61,7 @@ export default class Query<
   declare _normalizeNullable: () => NormalizeNullable<S>;
 }
 
-type ProcessParameters<P, S extends Queryable> =
+type ProcessParameters<P, S extends Queryable | { [k: string]: Queryable }> =
   P extends (entries: any, ...args: infer Par) => any ?
     Par extends [] ?
       SchemaArgs<S>

--- a/packages/endpoint/typescript-tests/query.ts
+++ b/packages/endpoint/typescript-tests/query.ts
@@ -1,0 +1,65 @@
+import { useQuery } from 'packages/react/lib';
+
+import { schema, Entity } from '../src';
+
+export class Ticker extends Entity {
+  product_id = '';
+  trade_id = 0;
+  price = 0;
+  time = new Date(0);
+  open_24h = 0;
+
+  pk(): string {
+    return this.product_id;
+  }
+
+  // convert price to a float and time to a Date
+  // see https://dataclient.io/rest/api/Entity#schema
+  static schema = {
+    price: Number,
+    open_24h: Number,
+    time: (iso: string) => new Date(iso),
+  };
+}
+export class Stats extends Entity {
+  product_id = '';
+  open = 0;
+  high = 0;
+  low = 0;
+  last = 0;
+  volume = 0;
+  volume_30day = 0;
+
+  pk(): string {
+    return this.product_id;
+  }
+}
+
+const queryPrice = new schema.Query(
+  { ticker: Ticker, stats: Stats },
+  ({ ticker, stats }) => ticker?.price ?? stats?.last,
+);
+const queryPrice2 = new schema.Query(
+  new schema.Object({ ticker: Ticker, stats: Stats }),
+  ({ ticker, stats }) => ticker?.price ?? stats?.last,
+);
+
+function useTest() {
+  const price = useQuery(queryPrice, { product_id: 5 });
+  // @ts-expect-error
+  useQuery(queryPrice);
+  // @ts-expect-error
+  useQuery(queryPrice, { product_id2: 5 });
+  // @ts-expect-error
+  useQuery(queryPrice, { product_id: 5 }, { product_id: 5 });
+}
+
+function useTest2() {
+  const price = useQuery(queryPrice2, { product_id: 5 });
+  // @ts-expect-error
+  useQuery(queryPrice2);
+  // @ts-expect-error
+  useQuery(queryPrice2, { product_id2: 5 });
+  // @ts-expect-error
+  useQuery(queryPrice2, { product_id: 5 }, { product_id: 5 });
+}

--- a/packages/normalizr/src-4.0-types/schemaArgs.d.ts
+++ b/packages/normalizr/src-4.0-types/schemaArgs.d.ts
@@ -1,0 +1,13 @@
+import type { EntityFields } from './EntityFields.js';
+import type { Schema, EntityInterface } from './interface.js';
+export type SchemaArgs<S extends Schema> = S extends EntityInterface<infer U> ? [EntityFields<U>] : S extends ({
+    queryKey(args: infer Args, ...rest: any): any;
+}) ? Args : S extends {
+    [K: string]: any;
+} ? ObjectArgs<S> : never;
+export type ObjectArgs<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends ({
+        queryKey(args: infer Args, ...rest: any): any;
+    }) ? Args : never;
+}[keyof S];
+//# sourceMappingURL=schemaArgs.d.ts.map

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -6,9 +6,9 @@ export type Schema =
   | SchemaSimple
   | Serializable;
 
-export interface Queryable {
+export interface Queryable<Args extends readonly any[] = readonly any[]> {
   queryKey(
-    args: readonly any[],
+    args: Args,
     queryKey: (...args: any) => any,
     getEntity: GetEntity,
     getIndex: GetIndex,
@@ -20,7 +20,7 @@ export type Serializable<
   T extends { toJSON(): string } = { toJSON(): string },
 > = (value: any) => T;
 
-export interface SchemaSimple<T = any, Args extends any[] = any[]> {
+export interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
   normalize(
     input: any,
     parent: any,
@@ -44,15 +44,12 @@ export interface SchemaSimple<T = any, Args extends any[] = any[]> {
   ): any;
 }
 
-export interface SchemaClass<
-  T = any,
-  N = T | undefined,
-  Args extends any[] = any[],
-> extends SchemaSimple<T, Args> {
+export interface SchemaClass<T = any, Args extends readonly any[] = any[]>
+  extends SchemaSimple<T, Args> {
   // this is not an actual member, but is needed for the recursive NormalizeNullable<> type algo
   _normalizeNullable(): any;
   // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo
-  _denormalizeNullable(): N;
+  _denormalizeNullable(): any;
 }
 
 export interface EntityInterface<T = any> extends SchemaSimple {

--- a/packages/normalizr/src/schemaArgs.ts
+++ b/packages/normalizr/src/schemaArgs.ts
@@ -1,0 +1,17 @@
+import type { EntityFields } from './EntityFields.js';
+import type { Schema, EntityInterface } from './interface.js';
+
+export type SchemaArgs<S extends Schema> =
+  S extends EntityInterface<infer U> ? [EntityFields<U>]
+  : S extends (
+    {
+      queryKey(args: infer Args, ...rest: any): any;
+    }
+  ) ?
+    Args
+  : S extends { [K: string]: any } ? ObjectArgs<S>
+  : never;
+
+export type ObjectArgs<S extends Record<string, any>> = {
+  [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -147,8 +147,8 @@ export type SchemaArgs<S extends Schema> =
     }
   ) ?
     Args
-  : S extends { [K: string]: any } ? ObjectArgs<S>
-  : never;
+  : // : S extends { [K: string]: any } ? ObjectArgs<S>
+    never;
 
 export type ObjectArgs<S extends Record<string, any>> = {
   [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -139,17 +139,17 @@ export interface NormalizeMeta {
 
 export type EntityMap<T = any> = Record<string, EntityInterface<T>>;
 
-export type SchemaArgs<S extends Queryable> =
+export type SchemaArgs<S extends Schema> =
   S extends EntityInterface<infer U> ? [EntityFields<U>]
   : S extends (
     {
-      queryKey(
-        args: infer Args,
-        queryKey: (...args: any) => any,
-        getEntity: any,
-        getIndex: any,
-      ): any;
+      queryKey(args: infer Args, ...rest: any): any;
     }
   ) ?
     Args
+  : S extends { [K: string]: any } ? ObjectArgs<S>
   : never;
+
+export type ObjectArgs<S extends Record<string, any>> = {
+  [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -1,11 +1,10 @@
-import { EntityFields } from './EntityFields.js';
 import type {
   Schema,
   Serializable,
   EntityInterface,
   NormalizedIndex,
-  Queryable,
 } from './interface.js';
+export * from './schemaArgs.js';
 
 export interface EntityPath {
   key: string;
@@ -138,18 +137,3 @@ export interface NormalizeMeta {
 }
 
 export type EntityMap<T = any> = Record<string, EntityInterface<T>>;
-
-export type SchemaArgs<S extends Schema> =
-  S extends EntityInterface<infer U> ? [EntityFields<U>]
-  : S extends (
-    {
-      queryKey(args: infer Args, ...rest: any): any;
-    }
-  ) ?
-    Args
-  : // : S extends { [K: string]: any } ? ObjectArgs<S>
-    never;
-
-export type ObjectArgs<S extends Record<string, any>> = {
-  [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
-}[keyof S];

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -11,6 +11,7 @@ export type {
   EndpointInterface,
   EntityInterface,
   Queryable,
+  SchemaArgs,
   Schema,
   SchemaClass,
   DenormalizeNullable,

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -16,6 +16,14 @@ type EntityFields<U> = {
 type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
+type NormalizedEntity<T> = T extends ({
+    prototype: infer U;
+    schema: infer S;
+}) ? {
+    [K in Exclude<keyof U, keyof S>]: U[K];
+} & {
+    [K in keyof S]: string;
+} : never;
 type DenormalizeObject<S extends Record<string, any>> = {
     [K in keyof S]: S[K] extends Schema ? Denormalize<S[K]> : S[K];
 };
@@ -63,8 +71,13 @@ interface EntityMap<T = any> {
     readonly [k: string]: EntityInterface<T>;
 }
 type SchemaArgs<S extends Schema> = S extends EntityInterface<infer U> ? [EntityFields<U>] : S extends ({
-    queryKey(args: infer Args, queryKey: (...args: any) => any, getEntity: any, getIndex: any): any;
-}) ? Args : never;
+    queryKey(args: infer Args, ...rest: any): any;
+}) ? Args : S extends {
+    [K: string]: any;
+} ? ObjectArgs<S> : never;
+type ObjectArgs<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];
 
 interface SnapshotInterface {
     readonly fetchedAt: number;
@@ -129,22 +142,22 @@ interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
 type Schema = null | string | {
     [K: string]: any;
 } | Schema[] | SchemaSimple | Serializable;
-interface Queryable {
-    queryKey(args: readonly any[], queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
+interface Queryable<Args extends readonly any[] = readonly any[]> {
+    queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
 }
 type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
 }> = (value: any) => T;
-interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
+interface SchemaSimple<T = any, Args extends readonly any[] = any> {
     normalize(input: any, parent: any, key: any, args: any[], visit: (...args: any) => any, addEntity: (...args: any) => any, getEntity: (...args: any) => any, checkLoop: (...args: any) => any): any;
     denormalize(input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any): T;
     queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): any;
 }
-interface SchemaClass<T = any, N = T | undefined, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
+interface SchemaClass<T = any, Args extends readonly any[] = any> extends SchemaSimple<T, Args> {
     _normalizeNullable(): any;
-    _denormalizeNullable(): N;
+    _denormalizeNullable(): any;
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
@@ -480,7 +493,9 @@ declare class Invalidate<E extends EntityInterface & {
  *
  * @see https://dataclient.io/rest/api/Query
  */
-declare class Query<S extends Queryable, P extends (entries: Denormalize<S>, ...args: any) => any> implements SchemaSimple<ReturnType<P> | undefined, ProcessParameters<P, S>> {
+declare class Query<S extends Queryable | {
+    [k: string]: Queryable;
+}, P extends (entries: Denormalize<S>, ...args: any) => any> implements SchemaSimple<ReturnType<P> | undefined, ProcessParameters<P, S>> {
     schema: S;
     process: P;
     /**
@@ -495,7 +510,9 @@ declare class Query<S extends Queryable, P extends (entries: Denormalize<S>, ...
     _denormalizeNullable: (input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any) => ReturnType<P> | undefined;
     _normalizeNullable: () => NormalizeNullable<S>;
 }
-type ProcessParameters<P, S extends Queryable> = P extends (entries: any, ...args: infer Par) => any ? Par extends [] ? SchemaArgs<S> : Par & SchemaArgs<S> : SchemaArgs<S>;
+type ProcessParameters<P, S extends Queryable | {
+    [k: string]: Queryable;
+}> = P extends (entries: any, ...args: infer Par) => any ? Par extends [] ? SchemaArgs<S> : Par & SchemaArgs<S> : SchemaArgs<S>;
 
 type CollectionOptions<Args extends any[] = DefaultArgs, Parent = any> = ({
     /** Defines lookups for Collections nested in other schemas.
@@ -749,7 +766,7 @@ declare class All<
  * Represents objects with statically known members
  * @see https://dataclient.io/rest/api/Object
  */
-declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
+declare class Object$1<O extends Record<string, any> = Record<string, any>>
   implements SchemaClass
 {
   /**
@@ -781,7 +798,7 @@ declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
   ): DenormalizeObject<O>;
 
   queryKey(
-    args: readonly any[],
+    args: ObjectArgs<O>,
     queryKey: (...args: any) => any,
     getEntity: GetEntity,
     getIndex: GetIndex,
@@ -1022,9 +1039,11 @@ type schema_d_Invalidate<E extends EntityInterface & {
     process: any;
 }> = Invalidate<E>;
 declare const schema_d_Invalidate: typeof Invalidate;
-type schema_d_Query<S extends Queryable, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
+type schema_d_Query<S extends Queryable | {
+    [k: string]: Queryable;
+}, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
 declare const schema_d_Query: typeof Query;
-type schema_d_SchemaClass<T = any, N = T | undefined, Args extends any[] = any[]> = SchemaClass<T, N, Args>;
+type schema_d_SchemaClass<T = any, Args extends readonly any[] = any> = SchemaClass<T, Args>;
 type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
 declare const schema_d_All: typeof All;
 type schema_d_UnionConstructor = UnionConstructor;
@@ -1141,4 +1160,4 @@ declare const INVALID: unique symbol;
 /** https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type */
 type NI<T> = NoInfer<T>;
 
-export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -16,6 +16,14 @@ type EntityFields<U> = {
 type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
+type NormalizedEntity<T> = T extends ({
+    prototype: infer U;
+    schema: infer S;
+}) ? {
+    [K in Exclude<keyof U, keyof S>]: U[K];
+} & {
+    [K in keyof S]: string;
+} : never;
 type DenormalizeObject<S extends Record<string, any>> = {
     [K in keyof S]: S[K] extends Schema ? Denormalize<S[K]> : S[K];
 };
@@ -63,8 +71,13 @@ interface EntityMap<T = any> {
     readonly [k: string]: EntityInterface<T>;
 }
 type SchemaArgs<S extends Schema> = S extends EntityInterface<infer U> ? [EntityFields<U>] : S extends ({
-    queryKey(args: infer Args, queryKey: (...args: any) => any, getEntity: any, getIndex: any): any;
-}) ? Args : never;
+    queryKey(args: infer Args, ...rest: any): any;
+}) ? Args : S extends {
+    [K: string]: any;
+} ? ObjectArgs<S> : never;
+type ObjectArgs<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];
 
 interface SnapshotInterface {
     readonly fetchedAt: number;
@@ -129,22 +142,22 @@ interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
 type Schema = null | string | {
     [K: string]: any;
 } | Schema[] | SchemaSimple | Serializable;
-interface Queryable {
-    queryKey(args: readonly any[], queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
+interface Queryable<Args extends readonly any[] = readonly any[]> {
+    queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
 }
 type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
 }> = (value: any) => T;
-interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
+interface SchemaSimple<T = any, Args extends readonly any[] = any> {
     normalize(input: any, parent: any, key: any, args: any[], visit: (...args: any) => any, addEntity: (...args: any) => any, getEntity: (...args: any) => any, checkLoop: (...args: any) => any): any;
     denormalize(input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any): T;
     queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): any;
 }
-interface SchemaClass<T = any, N = T | undefined, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
+interface SchemaClass<T = any, Args extends readonly any[] = any> extends SchemaSimple<T, Args> {
     _normalizeNullable(): any;
-    _denormalizeNullable(): N;
+    _denormalizeNullable(): any;
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
@@ -480,7 +493,9 @@ declare class Invalidate<E extends EntityInterface & {
  *
  * @see https://dataclient.io/rest/api/Query
  */
-declare class Query<S extends Queryable, P extends (entries: Denormalize<S>, ...args: any) => any> implements SchemaSimple<ReturnType<P> | undefined, ProcessParameters<P, S>> {
+declare class Query<S extends Queryable | {
+    [k: string]: Queryable;
+}, P extends (entries: Denormalize<S>, ...args: any) => any> implements SchemaSimple<ReturnType<P> | undefined, ProcessParameters<P, S>> {
     schema: S;
     process: P;
     /**
@@ -495,7 +510,9 @@ declare class Query<S extends Queryable, P extends (entries: Denormalize<S>, ...
     _denormalizeNullable: (input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any) => ReturnType<P> | undefined;
     _normalizeNullable: () => NormalizeNullable<S>;
 }
-type ProcessParameters<P, S extends Queryable> = P extends (entries: any, ...args: infer Par) => any ? Par extends [] ? SchemaArgs<S> : Par & SchemaArgs<S> : SchemaArgs<S>;
+type ProcessParameters<P, S extends Queryable | {
+    [k: string]: Queryable;
+}> = P extends (entries: any, ...args: infer Par) => any ? Par extends [] ? SchemaArgs<S> : Par & SchemaArgs<S> : SchemaArgs<S>;
 
 type CollectionOptions<Args extends any[] = DefaultArgs, Parent = any> = ({
     /** Defines lookups for Collections nested in other schemas.
@@ -749,7 +766,7 @@ declare class All<
  * Represents objects with statically known members
  * @see https://dataclient.io/rest/api/Object
  */
-declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
+declare class Object$1<O extends Record<string, any> = Record<string, any>>
   implements SchemaClass
 {
   /**
@@ -781,7 +798,7 @@ declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
   ): DenormalizeObject<O>;
 
   queryKey(
-    args: readonly any[],
+    args: ObjectArgs<O>,
     queryKey: (...args: any) => any,
     getEntity: GetEntity,
     getIndex: GetIndex,
@@ -1022,9 +1039,11 @@ type schema_d_Invalidate<E extends EntityInterface & {
     process: any;
 }> = Invalidate<E>;
 declare const schema_d_Invalidate: typeof Invalidate;
-type schema_d_Query<S extends Queryable, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
+type schema_d_Query<S extends Queryable | {
+    [k: string]: Queryable;
+}, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
 declare const schema_d_Query: typeof Query;
-type schema_d_SchemaClass<T = any, N = T | undefined, Args extends any[] = any[]> = SchemaClass<T, N, Args>;
+type schema_d_SchemaClass<T = any, Args extends readonly any[] = any> = SchemaClass<T, Args>;
 type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
 declare const schema_d_All: typeof All;
 type schema_d_UnionConstructor = UnionConstructor;
@@ -1183,4 +1202,4 @@ interface GQLError {
     path: (string | number)[];
 }
 
-export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
@@ -1,22 +1,22 @@
 type Schema = null | string | {
     [K: string]: any;
 } | Schema[] | SchemaSimple | Serializable;
-interface Queryable {
-    queryKey(args: readonly any[], queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
+interface Queryable<Args extends readonly any[] = readonly any[]> {
+    queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
 }
 type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
 }> = (value: any) => T;
-interface SchemaSimple<T = any, Args extends any[] = any[]> {
+interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
     normalize(input: any, parent: any, key: any, args: any[], visit: (...args: any) => any, addEntity: (...args: any) => any, getEntity: (...args: any) => any, checkLoop: (...args: any) => any): any;
     denormalize(input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any): T;
     queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): any;
 }
-interface SchemaClass<T = any, N = T | undefined, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
+interface SchemaClass<T = any, Args extends readonly any[] = any[]> extends SchemaSimple<T, Args> {
     _normalizeNullable(): any;
-    _denormalizeNullable(): N;
+    _denormalizeNullable(): any;
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
@@ -139,9 +139,14 @@ interface NormalizeMeta {
     date: number;
     fetchedAt: number;
 }
-type SchemaArgs<S extends Queryable> = S extends EntityInterface<infer U> ? [EntityFields<U>] : S extends ({
-    queryKey(args: infer Args, queryKey: (...args: any) => any, getEntity: any, getIndex: any): any;
-}) ? Args : never;
+type SchemaArgs<S extends Schema> = S extends EntityInterface<infer U> ? [EntityFields<U>] : S extends ({
+    queryKey(args: infer Args, ...rest: any): any;
+}) ? Args : S extends {
+    [K: string]: any;
+} ? ObjectArgs<S> : never;
+type ObjectArgs<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];
 
 declare function denormalize<S extends Schema>(schema: S | undefined, input: any, entities: any, args?: readonly any[]): DenormalizeNullable<S> | symbol;
 

--- a/website/src/components/Playground/editor-types/@data-client/react.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/react.d.ts
@@ -1,6 +1,6 @@
 import * as _data_client_core from '@data-client/core';
 import { NetworkManager, Manager, State, Controller, DevToolsManager, DevToolsConfig, SubscriptionManager, EndpointInterface as EndpointInterface$1, FetchFunction as FetchFunction$1, Schema as Schema$1, ResolveType as ResolveType$1, Denormalize as Denormalize$1, DenormalizeNullable as DenormalizeNullable$1, Queryable as Queryable$1, NI, SchemaArgs, NetworkError as NetworkError$1, UnknownError as UnknownError$1, ErrorTypes as ErrorTypes$2, __INTERNAL__, createReducer, applyManager, actions } from '@data-client/core';
-export { AbstractInstanceType, ActionTypes, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, EntityInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, Queryable, ResetAction, ResolveType, Schema, SchemaClass, SetAction, SetResponseAction, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@data-client/core';
+export { AbstractInstanceType, ActionTypes, Controller, DataClientDispatch, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, EntityInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, GenericDispatch, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, Queryable, ResetAction, ResolveType, Schema, SchemaArgs, SchemaClass, SetAction, SetResponseAction, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@data-client/core';
 import * as react_jsx_runtime from 'react/jsx-runtime';
 import React, { JSX, Context } from 'react';
 
@@ -234,15 +234,15 @@ declare function useDebounce<T>(value: T, delay: number, updatable?: boolean): T
 type Schema = null | string | {
     [K: string]: any;
 } | Schema[] | SchemaSimple | Serializable;
-interface Queryable {
-    queryKey(args: readonly any[], queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
+interface Queryable<Args extends readonly any[] = readonly any[]> {
+    queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
 }
 type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
 }> = (value: any) => T;
-interface SchemaSimple<T = any, Args extends any[] = any[]> {
+interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
     normalize(input: any, parent: any, key: any, args: any[], visit: (...args: any) => any, addEntity: (...args: any) => any, getEntity: (...args: any) => any, checkLoop: (...args: any) => any): any;
     denormalize(input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any): T;
     queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): any;

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -18,6 +18,14 @@ type EntityFields<U> = {
 type AbstractInstanceType<T> = T extends new (...args: any) => infer U ? U : T extends {
     prototype: infer U;
 } ? U : never;
+type NormalizedEntity<T> = T extends ({
+    prototype: infer U;
+    schema: infer S;
+}) ? {
+    [K in Exclude<keyof U, keyof S>]: U[K];
+} & {
+    [K in keyof S]: string;
+} : never;
 type DenormalizeObject<S extends Record<string, any>> = {
     [K in keyof S]: S[K] extends Schema ? Denormalize<S[K]> : S[K];
 };
@@ -65,8 +73,13 @@ interface EntityMap<T = any> {
     readonly [k: string]: EntityInterface<T>;
 }
 type SchemaArgs<S extends Schema> = S extends EntityInterface<infer U> ? [EntityFields<U>] : S extends ({
-    queryKey(args: infer Args, queryKey: (...args: any) => any, getEntity: any, getIndex: any): any;
-}) ? Args : never;
+    queryKey(args: infer Args, ...rest: any): any;
+}) ? Args : S extends {
+    [K: string]: any;
+} ? ObjectArgs<S> : never;
+type ObjectArgs<S extends Record<string, any>> = {
+    [K in keyof S]: S[K] extends Schema ? SchemaArgs<S[K]> : never;
+}[keyof S];
 
 interface SnapshotInterface {
     readonly fetchedAt: number;
@@ -131,22 +144,22 @@ interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
 type Schema = null | string | {
     [K: string]: any;
 } | Schema[] | SchemaSimple | Serializable;
-interface Queryable {
-    queryKey(args: readonly any[], queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
+interface Queryable<Args extends readonly any[] = readonly any[]> {
+    queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): {};
 }
 type Serializable<T extends {
     toJSON(): string;
 } = {
     toJSON(): string;
 }> = (value: any) => T;
-interface SchemaSimple<T = any, Args extends readonly any[] = any[]> {
+interface SchemaSimple<T = any, Args extends readonly any[] = any> {
     normalize(input: any, parent: any, key: any, args: any[], visit: (...args: any) => any, addEntity: (...args: any) => any, getEntity: (...args: any) => any, checkLoop: (...args: any) => any): any;
     denormalize(input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any): T;
     queryKey(args: Args, queryKey: (...args: any) => any, getEntity: GetEntity, getIndex: GetIndex): any;
 }
-interface SchemaClass<T = any, N = T | undefined, Args extends any[] = any[]> extends SchemaSimple<T, Args> {
+interface SchemaClass<T = any, Args extends readonly any[] = any> extends SchemaSimple<T, Args> {
     _normalizeNullable(): any;
-    _denormalizeNullable(): N;
+    _denormalizeNullable(): any;
 }
 interface EntityInterface<T = any> extends SchemaSimple {
     createIfValid(props: any): any;
@@ -478,7 +491,9 @@ declare class Invalidate<E extends EntityInterface & {
  *
  * @see https://dataclient.io/rest/api/Query
  */
-declare class Query<S extends Queryable, P extends (entries: Denormalize<S>, ...args: any) => any> implements SchemaSimple<ReturnType<P> | undefined, ProcessParameters<P, S>> {
+declare class Query<S extends Queryable | {
+    [k: string]: Queryable;
+}, P extends (entries: Denormalize<S>, ...args: any) => any> implements SchemaSimple<ReturnType<P> | undefined, ProcessParameters<P, S>> {
     schema: S;
     process: P;
     /**
@@ -493,7 +508,9 @@ declare class Query<S extends Queryable, P extends (entries: Denormalize<S>, ...
     _denormalizeNullable: (input: {}, args: readonly any[], unvisit: (schema: any, input: any) => any) => ReturnType<P> | undefined;
     _normalizeNullable: () => NormalizeNullable<S>;
 }
-type ProcessParameters<P, S extends Queryable> = P extends (entries: any, ...args: infer Par) => any ? Par extends [] ? SchemaArgs<S> : Par & SchemaArgs<S> : SchemaArgs<S>;
+type ProcessParameters<P, S extends Queryable | {
+    [k: string]: Queryable;
+}> = P extends (entries: any, ...args: infer Par) => any ? Par extends [] ? SchemaArgs<S> : Par & SchemaArgs<S> : SchemaArgs<S>;
 
 type CollectionOptions<Args extends any[] = DefaultArgs, Parent = any> = ({
     /** Defines lookups for Collections nested in other schemas.
@@ -747,7 +764,7 @@ declare class All<
  * Represents objects with statically known members
  * @see https://dataclient.io/rest/api/Object
  */
-declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
+declare class Object$1<O extends Record<string, any> = Record<string, any>>
   implements SchemaClass
 {
   /**
@@ -779,7 +796,7 @@ declare class Object$1<O extends Record<string, any> = Record<string, Schema>>
   ): DenormalizeObject<O>;
 
   queryKey(
-    args: readonly any[],
+    args: ObjectArgs<O>,
     queryKey: (...args: any) => any,
     getEntity: GetEntity,
     getIndex: GetIndex,
@@ -1020,9 +1037,11 @@ type schema_d_Invalidate<E extends EntityInterface & {
     process: any;
 }> = Invalidate<E>;
 declare const schema_d_Invalidate: typeof Invalidate;
-type schema_d_Query<S extends Queryable, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
+type schema_d_Query<S extends Queryable | {
+    [k: string]: Queryable;
+}, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
 declare const schema_d_Query: typeof Query;
-type schema_d_SchemaClass<T = any, N = T | undefined, Args extends any[] = any[]> = SchemaClass<T, N, Args>;
+type schema_d_SchemaClass<T = any, Args extends readonly any[] = any> = SchemaClass<T, Args>;
 type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
 declare const schema_d_All: typeof All;
 type schema_d_UnionConstructor = UnionConstructor;
@@ -1743,4 +1762,4 @@ declare class NetworkError extends Error {
     constructor(response: Response);
 }
 
-export { AbstractInstanceType, AddEndpoint, Array$1 as Array, Collection, CustomResource, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };
+export { AbstractInstanceType, AddEndpoint, Array$1 as Array, Collection, CustomResource, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Client-side joins should all be doable in [Queries](https://dataclient.io/rest/api/Query).

This enables joins across arbitrary elements (not just nested entities).

For instance, with our [crypto live price demo](https://dataclient.io/demos), we need to fallback to `Stats` when loading a page until the websocket `Ticker` has updated. This ensures [SSR](https://dataclient.io/docs/guides/ssr) and initial page loads work. 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

```ts
class Ticker extends Entity {
  product_id = '';
  price = 0;

  pk(): string {
    return this.product_id;
  }
}
class Stats extends Entity {
  product_id = '';
  last = 0;

  pk(): string {
    return this.product_id;
  }
}
const queryPrice = new schema.Query(
  { ticker: Ticker, stats: Stats },
  ({ ticker, stats }) => ticker?.price ?? stats?.last,
);
```

This allows simple lookups for the price:

```tsx
const price = useQuery(queryPrice, { product_id });
```