### PR TITLE
enhance: Entity.pk() default provided that uses id

### DIFF
--- a/.changeset/hot-cows-refuse.md
+++ b/.changeset/hot-cows-refuse.md
@@ -1,0 +1,9 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+---
+
+Do not require [Entity.pk()](https://dataclient.io/rest/api/Entity#pk)
+
+Default implementation uses `this.id`

--- a/.changeset/pink-plums-cross.md
+++ b/.changeset/pink-plums-cross.md
@@ -1,0 +1,11 @@
+---
+'@data-client/normalizr': patch
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/react': patch
+'@data-client/core': patch
+'@data-client/rest': patch
+'@data-client/test': patch
+---
+
+Update README to remove Entity.pk() when it is default ('id')

--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ For more details, see [the Installation docs page](https://dataclient.io/docs/ge
 class User extends Entity {
   id = '';
   username = '';
-
-  pk() {
-    return this.id;
-  }
 }
 
 class Article extends Entity {
@@ -57,10 +53,6 @@ class Article extends Entity {
   body = '';
   author = User.fromJS();
   createdAt = Temporal.Instant.fromEpochSeconds(0);
-
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     author: User,

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -18,16 +18,6 @@ import React, { createContext, useContext } from 'react';
 /** Represents data with primary key being from 'id' field. */
 export class IDEntity extends Entity {
   readonly id: string | number | undefined = undefined;
-
-  /**
-   * A unique identifier for each Entity
-   *
-   * @param [parent] When normalizing, the object which included the entity
-   * @param [key] When normalizing, the key where this entity was found
-   */
-  pk(parent?: any, key?: string): string | undefined {
-    return `${this.id}`;
-  }
 }
 
 class Vis {
@@ -42,10 +32,6 @@ export class VisSettings extends Entity implements Vis {
   readonly visType: 'graph' | 'line' = 'graph';
   readonly numCols: number = 0;
   readonly updatedAt: number = 0;
-
-  pk() {
-    return `${this.id}`;
-  }
 
   static shouldUpdate(
     existingMeta: { date: number },

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -162,10 +162,6 @@ export class User extends Entity {
   readonly username: string = '';
   readonly email: string = '';
   readonly isAdmin: boolean = false;
-
-  pk() {
-    return this.id?.toString();
-  }
 }
 export const UserResource = resource({
   path: 'http\\://test.com/user/:id',
@@ -178,10 +174,6 @@ export class Article extends Entity {
   readonly content: string = '';
   readonly author: User | null = null;
   readonly tags: string[] = [];
-
-  pk() {
-    return this.id?.toString();
-  }
 
   static schema = {
     author: User,
@@ -621,10 +613,6 @@ export abstract class UnionBase extends Entity {
   readonly id: string = '';
   readonly body: string = '';
   readonly type: string = '';
-
-  pk() {
-    return this.id;
-  }
 }
 export class FirstUnion extends UnionBase {
   readonly type = 'first';

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -160,7 +160,7 @@ export class Todo extends Entity {
   completed = false;
 
   pk() {
-    return `${this.id}`;
+    return this.id;
   }
 }
 ```
@@ -346,10 +346,6 @@ class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-
-  pk() {
-    return `${this.id}`;
-  }
 }
 
 const TodoResource = resource({

--- a/docs/core/api/Manager.md
+++ b/docs/core/api/Manager.md
@@ -233,9 +233,6 @@ import { Entity } from '@data-client/endpoint';
 export default class CurrentTime extends Entity {
   id = 0;
   time = 0;
-  pk() {
-    return this.id;
-  }
 }
 ```
 

--- a/docs/core/api/useCache.md
+++ b/docs/core/api/useCache.md
@@ -37,9 +37,7 @@ export class User extends Entity {
   id = '';
   name = '';
   isAdmin = false;
-  pk() {
-    return this.id;
-  }
+
   static key = 'User';
 }
 export const UserResource = resource({

--- a/docs/core/api/useDLE.md
+++ b/docs/core/api/useDLE.md
@@ -34,9 +34,6 @@ export class Profile extends Entity {
   fullName = '';
   bio = '';
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Profile';
 }
 
@@ -148,9 +145,6 @@ export class Profile extends Entity {
   fullName = '';
   bio = '';
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Profile';
 }
 
@@ -202,9 +196,6 @@ export class Post extends Entity {
   title = '';
   body = '';
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Post';
 }
 export const PostResource = resource({
@@ -224,9 +215,6 @@ export class User extends Entity {
     return `https://i.pravatar.cc/64?img=${this.id + 4}`;
   }
 
-  pk() {
-    return `${this.id}`;
-  }
   static key = 'User';
 }
 export const UserResource = resource({
@@ -272,9 +260,6 @@ export class PaginatedPost extends Entity {
   title = '';
   content = '';
 
-  pk() {
-    return this.id;
-  }
   static key = 'PaginatedPost';
 }
 

--- a/docs/core/api/useQuery.md
+++ b/docs/core/api/useQuery.md
@@ -95,9 +95,7 @@ export class User extends Entity {
   id = '';
   name = '';
   isAdmin = false;
-  pk() {
-    return this.id;
-  }
+
   static key = 'User';
 }
 export const UserResource = resource({

--- a/docs/core/api/useSubscription.md
+++ b/docs/core/api/useSubscription.md
@@ -91,7 +91,6 @@ function useSubscription<
 ### Only subscribe while element is visible
 
 ```tsx title="MasterPrice.tsx"
-import { useRef } from 'react';
 import { useSuspense, useSubscription } from '@data-client/react';
 import { getPrice } from 'api/Price';
 

--- a/docs/core/api/useSuspense.md
+++ b/docs/core/api/useSuspense.md
@@ -52,9 +52,6 @@ export class Profile extends Entity {
   fullName = '';
   bio = '';
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Profile';
 }
 
@@ -204,9 +201,6 @@ export class Profile extends Entity {
   fullName = '';
   bio = '';
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Profile';
 }
 
@@ -276,9 +270,6 @@ export class Post extends Entity {
   title = '';
   body = '';
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Post';
 }
 export const PostResource = resource({
@@ -298,9 +289,6 @@ export class User extends Entity {
     return `https://i.pravatar.cc/64?img=${this.id + 4}`;
   }
 
-  pk() {
-    return `${this.id}`;
-  }
   static key = 'User';
 }
 export const UserResource = resource({
@@ -336,15 +324,12 @@ When entities are stored in [nested structures](/rest/guides/relational-data#nes
 
 <TypeScriptEditor row={false}>
 
-```typescript title="api/Post" {15-19}
+```typescript title="api/Post" {12-16}
 export class PaginatedPost extends Entity {
   id = '';
   title = '';
   content = '';
 
-  pk() {
-    return this.id;
-  }
   static key = 'PaginatedPost';
 }
 

--- a/docs/core/concepts/error-policy.md
+++ b/docs/core/concepts/error-policy.md
@@ -49,9 +49,6 @@ delay: () => 150,
 export class TimedEntity extends Entity {
   id = '';
   updatedAt = Temporal.Instant.fromEpochSeconds(0);
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     updatedAt: Temporal.Instant.from,

--- a/docs/core/concepts/expiry-policy.md
+++ b/docs/core/concepts/expiry-policy.md
@@ -74,9 +74,6 @@ export class TimedEntity extends Entity {
   id = '';
   updatedAt = Temporal.Instant.fromEpochSeconds(0);
 
-  pk() {
-    return this.id;
-  }
   static schema = {
     updatedAt: Temporal.Instant.from,
   };
@@ -216,9 +213,6 @@ delay: () => 150,
 export class TimedEntity extends Entity {
   id = '';
   updatedAt = Temporal.Instant.fromEpochSeconds(0);
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     updatedAt: Temporal.Instant.from,
@@ -314,9 +308,6 @@ delay: () => 150,
 export class TimedEntity extends Entity {
   id = '';
   updatedAt = Temporal.Instant.fromEpochSeconds(0);
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     updatedAt: Temporal.Instant.from,
@@ -378,9 +369,6 @@ delay: () => 150,
 export class TimedEntity extends Entity {
   id = '';
   updatedAt = Temporal.Instant.fromEpochSeconds(0);
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     updatedAt: Temporal.Instant.from,
@@ -482,9 +470,6 @@ delay: () => 150,
 export class TimedEntity extends Entity {
   id = '';
   updatedAt = Temporal.Instant.fromEpochSeconds(0);
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     updatedAt: Temporal.Instant.from,
@@ -595,9 +580,6 @@ delay: () => 150,
 export class TimedEntity extends Entity {
   id = '';
   updatedAt = Temporal.Instant.fromEpochSeconds(0);
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     updatedAt: Temporal.Instant.from,

--- a/docs/core/concepts/normalization.md
+++ b/docs/core/concepts/normalization.md
@@ -90,10 +90,7 @@ class Presentation extends Entity {
   id = '';
   title = '';
 
-  pk() {
-    return this.id;
-  }
-  static key = 'presentation';
+  static key = 'Presentation';
 }
 ```
 
@@ -303,9 +300,6 @@ class Todo extends Entity {
   title = '';
   completed = false;
 
-  pk() {
-    return `${this.id}`;
-  }
   static key = 'Todo';
 
   // highlight-start
@@ -319,9 +313,6 @@ class User extends Entity {
   id = 0;
   username = '';
 
-  pk() {
-    return `${this.id}`;
-  }
   static key = 'User';
 }
 ```
@@ -362,9 +353,6 @@ class Todo extends Entity {
   // highlight-next-line
   dueDate = Temporal.Instant.fromEpochSeconds(0);
 
-  pk() {
-    return `${this.id}`;
-  }
   static key = 'Todo';
 
   static schema = {

--- a/docs/core/concepts/validation.md
+++ b/docs/core/concepts/validation.md
@@ -45,12 +45,8 @@ delay: 150,
 
 ```typescript title="api/Article"
 export class Article extends Entity {
-  readonly id: string = '';
-  readonly title: string = '';
-
-  pk() {
-    return this.id;
-  }
+  id = '';
+  title = '';
 
   static validate(processedEntity) {
     if (!Object.hasOwn(processedEntity, 'title')) return 'missing title field';
@@ -79,7 +75,7 @@ render(<ArticlePage id="2" />);
 
 ### All fields check
 
-Here's a recipe for checking that every defined field is present.
+[validateRequired()](/rest/api/validateRequired) can be used to check if all defined fields are present.
 
 <HooksPlayground fixtures={[
 {
@@ -104,20 +100,11 @@ delay: 150,
 
 ```tsx title="api/Article"
 export class Article extends Entity {
-  readonly id: string = '';
-  readonly title: string = '';
-
-  pk() {
-    return this.id;
-  }
+  id = '';
+  title = '';
 
   static validate(processedEntity) {
-    if (
-      !Object.keys(this.defaults).every(key =>
-        Object.hasOwn(processedEntity, key),
-      )
-    )
-      return 'a field is missing';
+    return validateRequired(processedEntity, this.defaults);
   }
 }
 

--- a/docs/core/concepts/validation.md
+++ b/docs/core/concepts/validation.md
@@ -170,12 +170,9 @@ delay: 150,
 
 ```typescript title="api/Article"
 export class ArticlePreview extends Entity {
-  readonly id: string = '';
-  readonly title: string = '';
+  id = '';
+  title = '';
 
-  pk() {
-    return this.id;
-  }
   static key = 'Article';
 }
 export const getArticleList = new RestEndpoint({
@@ -184,8 +181,8 @@ export const getArticleList = new RestEndpoint({
 });
 
 export class ArticleFull extends ArticlePreview {
-  readonly content: string = '';
-  readonly createdAt = Temporal.Instant.fromEpochSeconds(0);
+  content = '';
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
 
   static schema = {
     createdAt: Temporal.Instant.from,

--- a/docs/core/getting-started/data-dependency.md
+++ b/docs/core/getting-started/data-dependency.md
@@ -40,9 +40,6 @@ export class User extends Entity {
     return `https://i.pravatar.cc/64?img=${this.id + 4}`;
   }
 
-  pk() {
-    return this.id;
-  }
   static key = 'User';
 }
 export const UserResource = resource({
@@ -57,9 +54,6 @@ export class Post extends Entity {
   title = '';
   body = '';
 
-  pk() {
-    return this.id;
-  }
   static key = 'Post';
 
   static schema = {
@@ -322,9 +316,6 @@ export class Profile extends Entity {
   fullName = '';
   bio = '';
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Profile';
 }
 

--- a/docs/core/getting-started/mutations.md
+++ b/docs/core/getting-started/mutations.md
@@ -35,9 +35,7 @@ export class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-  pk() {
-    return `${this.id}`;
-  }
+
   static key = 'Todo';
 }
 export const TodoResource = resource({

--- a/docs/core/getting-started/resource.md
+++ b/docs/core/getting-started/resource.md
@@ -49,9 +49,6 @@ export class Todo extends Entity {
   title = '';
   completed = false;
 
-  pk() {
-    return `${this.id}`;
-  }
   static key = 'Todo';
 }
 

--- a/docs/core/guides/storybook.md
+++ b/docs/core/guides/storybook.md
@@ -36,9 +36,6 @@ export class Article extends Entity {
   author: number | null = null;
   contributors: number[] = [];
 
-  pk() {
-    return this.id?.toString();
-  }
   static key = 'Article';
 }
 export const ArticleResource = resource({

--- a/docs/core/shared/_VoteDemo.mdx
+++ b/docs/core/shared/_VoteDemo.mdx
@@ -13,9 +13,6 @@ export class Post extends Entity {
   body = '';
   votes = 0;
 
-  pk() {
-    return this.id;
-  }
   static key = 'Post';
 
   static schema = {

--- a/docs/core/shared/_useCancelling.mdx
+++ b/docs/core/shared/_useCancelling.mdx
@@ -8,9 +8,7 @@ export class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-  pk() {
-    return `${this.id}`;
-  }
+
   static key = 'Todo';
 }
 export const TodoResource = resource({

--- a/docs/core/shared/_useLoading.mdx
+++ b/docs/core/shared/_useLoading.mdx
@@ -13,9 +13,6 @@ export class Post extends Entity {
   body = '';
   votes = 0;
 
-  pk() {
-    return this.id;
-  }
   static key = 'Post';
 
   get img() {

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -40,6 +40,8 @@ export class User extends Entity {
   pk() {
     return this.id;
   }
+
+  static key = 'User';
 }
 ```
 
@@ -59,12 +61,12 @@ export class Article extends Entity {
     return this.id;
   }
 
+  static key = 'Article';
+
   static schema = {
     author: User,
     createdAt: Temporal.Instant.from,
   };
-
-  static key = 'Article';
 }
 
 export const ArticleResource = resource({
@@ -263,14 +265,20 @@ resolves to the new Resource created by the API. It will automatically be added 
 import { useController } from '@data-client/react';
 import { Article, ArticleResource } from 'api/article';
 
-export default function ArticleWithDelete({ article }: { article: Article }) {
+export default function ArticleWithDelete({
+  article,
+}: {
+  article: Article;
+}) {
   const ctrl = useController();
   return (
     <article>
       <h2>{article.title}</h2>
       <div>{article.content}</div>
       <button
-        onClick={() => ctrl.fetch(ArticleResource.delete, { id: article.id })}
+        onClick={() =>
+          ctrl.fetch(ArticleResource.delete, { id: article.id })
+        }
       >
         Delete
       </button>

--- a/docs/rest/api/All.md
+++ b/docs/rest/api/All.md
@@ -134,9 +134,6 @@ delay: 150,
 export abstract class FeedItem extends Entity {
   readonly id: number = 0;
   declare readonly type: 'link' | 'post';
-  pk() {
-    return `${this.id}`;
-  }
 }
 export class Link extends FeedItem {
   readonly type = 'link' as const;
@@ -208,9 +205,6 @@ delay: 150,
 export abstract class FeedItem extends Entity {
   readonly id: number = 0;
   declare readonly type: 'link' | 'post';
-  pk() {
-    return `${this.id}`;
-  }
 }
 export class Link extends FeedItem {
   readonly type = 'link' as const;

--- a/docs/rest/api/Array.md
+++ b/docs/rest/api/Array.md
@@ -109,9 +109,6 @@ delay: 150,
 export abstract class FeedItem extends Entity {
   readonly id: number = 0;
   declare readonly type: 'link' | 'post';
-  pk() {
-    return `${this.id}`;
-  }
 }
 export class Link extends FeedItem {
   readonly type = 'link' as const;
@@ -183,9 +180,6 @@ delay: 150,
 export abstract class FeedItem extends Entity {
   readonly id: number = 0;
   declare readonly type: 'link' | 'post';
-  pk() {
-    return `${this.id}`;
-  }
 }
 export class Link extends FeedItem {
   readonly type = 'link' as const;

--- a/docs/rest/api/Endpoint.md
+++ b/docs/rest/api/Endpoint.md
@@ -233,10 +233,8 @@ import { Entity } from '@data-client/normalizr';
 import { Endpoint } from '@data-client/endpoint';
 
 class User extends Entity {
-  readonly id: string = '';
-  readonly username: string = '';
-
-  pk() { return this.id;}
+  id = '';
+  username = '';
 }
 
 const getUser = new Endpoint(
@@ -291,10 +289,8 @@ import { Endpoint } from '@data-client/endpoint';
 import { Entity } from '@data-client/react';
 
 class User extends Entity {
-  readonly id: string = '';
-  readonly username: string = '';
-
-  pk() { return this.id; }
+  id = '';
+  username = '';
 }
 
 const UserDetail = new Endpoint(
@@ -311,10 +307,8 @@ import { Endpoint } from '@data-client/endpoint';
 import { Entity } from '@data-client/react';
 
 class User extends Entity {
-  readonly id: string = '';
-  readonly username: string = '';
-
-  pk() { return this.id; }
+  id = '';
+  username = '';
 }
 
 const UserList = new Endpoint(

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -35,7 +35,7 @@ import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 performance, data consistency and atomic mutations.
 
 `Entities` enable customizing the data processing lifecycle by defining its static members like [schema](#schema)
-and overriding its [lifecycle methods](#data-lifecycle).
+and overriding its [lifecycle methods](#lifecycle).
 
 ## Usage
 
@@ -48,6 +48,7 @@ export class User extends Entity {
   id = '';
   username = '';
 
+  static key = 'User';
   pk() {
     return this.id;
   }
@@ -101,19 +102,15 @@ used to make Entities.
 
 Other static members overrides allow customizing the data lifecycle as seen below.
 
-## Data lifecycle
+## Members
 
-import Lifecycle from '../diagrams/\_entity_lifecycle.mdx';
+### pk(parent?, key?, args?): string | number | undefined {#pk}
 
-<Lifecycle/>
+<abbr title="Primary Key">pk</abbr> stands for [_primary key_](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-PRIMARY-KEYS), uniquely identifying an `Entity` instance.
+By default this returns the an Entity's `id` field.
 
-## Methods
-
-### abstract pk(parent?, key?, args?): string? {#pk}
-
-PK stands for _primary key_ and is intended to provide a standard means of retrieving
-a key identifier for any `Entity`. In many cases there will simply be an 'id' field
-member to return. In case of multicolumn you can simply join them together.
+Override this method to use other fields, or to for other cases like
+multicolumn primary keys.
 
 #### undefined value
 
@@ -152,7 +149,7 @@ pk() {
 
 ### static key: string {#key}
 
-This defines the key for the Entity itself, rather than an instance. This needs to be a globally
+This defines the key for the Entity kind, rather than an instance. This needs to be a globally
 unique value.
 
 :::warning
@@ -160,7 +157,7 @@ unique value.
 This defaults to `this.name`; however this may break in production builds that change class names.
 This is often know as [class name mangling](https://terser.org/docs/api-reference#mangle-options).
 
-In these cases you can override `key` or disable class mangling.
+In these cases you can override `key` or disable class name mangling.
 
 :::
 
@@ -168,14 +165,205 @@ In these cases you can override `key` or disable class mangling.
 class User extends Entity {
   id = '';
   username = '';
+
   pk() {
     return this.id;
   }
-
   // highlight-next-line
   static key = 'User';
 }
 ```
+
+### static schema: \{ [k: keyof this]: Schema } {#schema}
+
+Defines [related entity](/rest/guides/relational-data) members, or
+[field deserialization](/rest/guides/network-transform#deserializing-fields) like Date and BigNumber.
+
+<HooksPlayground groupId="schema" defaultOpen="y" fixtures={[
+{
+endpoint: new RestEndpoint({path: '/posts/:id'}),
+args: [{ id: '123' }],
+response: {
+id: '5',
+author: { id: '123', name: 'Jim' },
+content: 'Happy day',
+createdAt: '2019-01-23T06:07:48.311Z',
+},
+delay: 150,
+},
+]}>
+
+```ts title="User" collapsed
+import { Entity } from '@data-client/rest';
+
+export class User extends Entity {
+  id = '';
+  name = '';
+
+  pk() {
+    return this.id;
+  }
+  static key = 'User';
+}
+```
+
+```ts title="Post" {16-20}
+import { Entity } from '@data-client/rest';
+import { User } from './User';
+
+export class Post extends Entity {
+  id = '';
+  author = User.fromJS();
+  createdAt = Temporal.Instant.fromEpochSeconds(0);
+  content = '';
+  title = '';
+
+  pk() {
+    return this.id;
+  }
+  static key = 'Post';
+
+  static schema = {
+    author: User,
+    createdAt: Temporal.Instant.from,
+  };
+}
+```
+
+```tsx title="PostPage" collapsed
+import { Post } from './Post';
+
+export const getPost = new RestEndpoint({
+  path: '/posts/:id',
+  schema: Post,
+});
+function PostPage() {
+  const post = useSuspense(getPost, { id: '123' });
+  return (
+    <div>
+      <p>
+        {post.content} - <cite>{post.author.name}</cite>
+      </p>
+      <time>
+        {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
+          post.createdAt,
+        )}
+      </time>
+    </div>
+  );
+}
+render(<PostPage />);
+```
+
+</HooksPlayground>
+
+#### Optional members
+
+Entities references here whose default values in the Record definition itself are
+considered 'optional'
+
+```typescript
+class User extends Entity {
+  friend: User | null = null; // this field is optional
+  lastUpdated = Temporal.Instant.fromEpochSeconds(0);
+
+  static schema = {
+    friend: User,
+    lastUpdated: Temporal.Instant.from,
+  };
+}
+```
+
+### static indexes?: (keyof this)[] {#indexes}
+
+Indexes enable increased performance when doing lookups based on those parameters. Add
+fieldnames (like `slug`, `username`) to the list that you want to send as params to lookup
+later.
+
+:::note
+
+Don't add your primary key like `id` to the indexes list, as that will already be optimized.
+
+:::
+
+#### useSuspense()
+
+With [useSuspense()](/docs/api/useSuspense) this will eagerly infer the results from entities table if possible,
+rendering without needing to complete the fetch. This is typically helpful when the entities
+cache has already been populated by another request like a list request.
+
+```typescript
+export class User extends Entity {
+  id: number | undefined = undefined;
+  username = '';
+  email = '';
+  isAdmin = false;
+
+  // highlight-next-line
+  static indexes = ['username' as const];
+}
+export const UserResource = resource({
+  path: '/user/:id',
+  schema: User,
+});
+```
+
+```tsx
+const user = useSuspense(UserResource.get, { username: 'bob' });
+```
+
+#### useQuery()
+
+With [useQuery()](/docs/api/useQuery), this enables accessing results retrieved inside other requests - even
+if there is no endpoint it can be fetched from.
+
+```typescript
+class LatestPrice extends Entity {
+  id = '';
+  symbol = '';
+  price = '0.0';
+
+  static indexes = ['symbol' as const];
+}
+```
+
+```typescript
+class Asset extends Entity {
+  id = '';
+  price = '';
+
+  static schema = {
+    price: LatestPrice,
+  };
+}
+const getAssets = new RestEndpoint({
+  path: '/assets',
+  schema: [Asset],
+});
+```
+
+Some top level component:
+
+```tsx
+const assets = useSuspense(getAssets);
+```
+
+Nested below:
+
+```tsx
+const price = useQuery(LatestPrice, { symbol: 'BTC' });
+```
+
+## Lifecycle
+
+import Lifecycle from '../diagrams/\_entity_lifecycle.mdx';
+
+<Lifecycle/>
+
+### static fromJS(props): Entity {#fromJS}
+
+Factory method that copies props to a new instance. Use this instead of `new MyEntity()`,
+to ensure default props are overridden.
 
 ### static process(input, parent, key, args): processedEntity {#process}
 
@@ -444,190 +632,3 @@ By **default** does some basic field existance checks in development mode only. 
 disable or customize.
 
 [Using validation for endpoints with incomplete fields](../guides/partial-entities.md)
-
-### static fromJS(props): Entity {#fromJS}
-
-Factory method that copies props to a new instance. Use this instead of `new MyEntity()`,
-to ensure default props are overridden.
-
-## Fields
-
-### static schema: \{ [k: keyof this]: Schema } {#schema}
-
-Defines [related entity](/rest/guides/relational-data) members, or
-[field deserialization](/rest/guides/network-transform#deserializing-fields) like Date and BigNumber.
-
-<HooksPlayground groupId="schema" defaultOpen="y" fixtures={[
-{
-endpoint: new RestEndpoint({path: '/posts/:id'}),
-args: [{ id: '123' }],
-response: {
-id: '5',
-author: { id: '123', name: 'Jim' },
-content: 'Happy day',
-createdAt: '2019-01-23T06:07:48.311Z',
-},
-delay: 150,
-},
-]}>
-
-```ts title="User" collapsed
-import { Entity } from '@data-client/rest';
-
-export class User extends Entity {
-  id = '';
-  name = '';
-  pk() {
-    return this.id;
-  }
-}
-```
-
-```ts title="Post"
-import { Entity } from '@data-client/rest';
-import { User } from './User';
-
-export class Post extends Entity {
-  id = '';
-  author = User.fromJS({});
-  createdAt = Temporal.Instant.fromEpochSeconds(0);
-  content = '';
-  title = '';
-
-  static schema = {
-    author: User,
-    createdAt: Temporal.Instant.from,
-  };
-  pk() {
-    return this.id;
-  }
-  static key = 'Post';
-}
-```
-
-```tsx title="PostPage" collapsed
-import { Post } from './Post';
-
-export const getPost = new RestEndpoint({
-  path: '/posts/:id',
-  schema: Post,
-});
-function PostPage() {
-  const post = useSuspense(getPost, { id: '123' });
-  return (
-    <div>
-      <p>
-        {post.content} - <cite>{post.author.name}</cite>
-      </p>
-      <time>
-        {DateTimeFormat('en-US', { dateStyle: 'medium' }).format(
-          post.createdAt,
-        )}
-      </time>
-    </div>
-  );
-}
-render(<PostPage />);
-```
-
-</HooksPlayground>
-
-#### Optional members
-
-Entities references here whose default values in the Record definition itself are
-considered 'optional'
-
-```typescript
-class User extends Entity {
-  friend: User | null = null; // this field is optional
-  lastUpdated = Temporal.Instant.fromEpochSeconds(0);
-
-  static schema = {
-    friend: User,
-    lastUpdated: Temporal.Instant.from,
-  };
-}
-```
-
-### static indexes?: (keyof this)[] {#indexes}
-
-Indexes enable increased performance when doing lookups based on those parameters. Add
-fieldnames (like `slug`, `username`) to the list that you want to send as params to lookup
-later.
-
-:::note
-
-Don't add your primary key like `id` to the indexes list, as that will already be optimized.
-
-:::
-
-#### useSuspense()
-
-With [useSuspense()](/docs/api/useSuspense) this will eagerly infer the results from entities table if possible,
-rendering without needing to complete the fetch. This is typically helpful when the entities
-cache has already been populated by another request like a list request.
-
-```typescript
-export class User extends Entity {
-  id: number | undefined = undefined;
-  username = '';
-  email = '';
-  isAdmin = false;
-
-  pk() {
-    return this.id?.toString();
-  }
-
-  // highlight-next-line
-  static indexes = ['username' as const];
-}
-export const UserResource = resource({
-  path: '/user/:id',
-  schema: User,
-});
-```
-
-```tsx
-const user = useSuspense(UserResource.get, { username: 'bob' });
-```
-
-#### useQuery()
-
-With [useQuery()](/docs/api/useQuery), this enables accessing results retrieved inside other requests - even
-if there is no endpoint it can be fetched from.
-
-```typescript
-class LatestPrice extends Entity {
-  id = '';
-  symbol = '';
-  price = '0.0';
-  static indexes = ['symbol' as const];
-}
-```
-
-```typescript
-class Asset extends Entity {
-  id = '';
-  price = '';
-
-  static schema = {
-    price: LatestPrice,
-  };
-}
-const getAssets = new RestEndpoint({
-  path: '/assets',
-  schema: [Asset],
-});
-```
-
-Some top level component:
-
-```tsx
-const assets = useSuspense(getAssets);
-```
-
-Nested below:
-
-```tsx
-const price = useQuery(LatestPrice, { symbol: 'BTC' });
-```

--- a/docs/rest/api/Values.md
+++ b/docs/rest/api/Values.md
@@ -51,10 +51,7 @@ delay: 150,
 
 ```tsx title="ItemPage.tsx"
 export class Item extends Entity {
-  readonly id: number = 0;
-  pk() {
-    return `${this.id}`;
-  }
+  id = 0;
 }
 export const getItems = new RestEndpoint({
   path: '/items',
@@ -95,11 +92,8 @@ delay: 150,
 
 ```tsx title="api/Feed"
 export abstract class FeedItem extends Entity {
-  readonly id: number = 0;
+  id = 0;
   declare readonly type: 'link' | 'post';
-  pk() {
-    return `${this.id}`;
-  }
 }
 export class Link extends FeedItem {
   readonly type = 'link' as const;
@@ -172,11 +166,8 @@ delay: 150,
 
 ```typescript title="api/Feed"
 export abstract class FeedItem extends Entity {
-  readonly id: number = 0;
+  id = 0;
   declare readonly type: 'link' | 'post';
-  pk() {
-    return `${this.id}`;
-  }
 }
 export class Link extends FeedItem {
   readonly type = 'link' as const;

--- a/docs/rest/api/schema.Entity.md
+++ b/docs/rest/api/schema.Entity.md
@@ -94,7 +94,7 @@ Specifies the [Entity.schema](./Entity.md#schema)
 
 ## Methods
 
-`schema.Entity` mixin has the same [methods as the Entity](./Entity.md#methods) class.
+`schema.Entity` mixin has the same [methods as the Entity](./Entity.md#lifecycle) class.
 
 ## const vs class
 

--- a/docs/rest/guides/auth.md
+++ b/docs/rest/guides/auth.md
@@ -38,9 +38,6 @@ import AuthdEndpoint from './AuthdEndpoint';
 class MyEntity extends Entity {
   id = '';
   title = '';
-  pk() {
-    return this.id;
-  }
 }
 
 export const MyResource = resource({
@@ -120,9 +117,6 @@ import AuthdEndpoint from './AuthdEndpoint';
 class MyEntity extends Entity {
   id = '';
   title = '';
-  pk() {
-    return this.id;
-  }
 }
 
 export const MyResource = resource({

--- a/docs/rest/guides/django.md
+++ b/docs/rest/guides/django.md
@@ -66,9 +66,6 @@ import DjangoEndpoint from './DjangoEndpoint';
 class MyEntity extends Entity {
   id = '';
   title = '';
-  pk() {
-    return this.id;
-  }
 }
 
 export const MyResource = resource({

--- a/docs/rest/guides/mocking-unfinished.md
+++ b/docs/rest/guides/mocking-unfinished.md
@@ -20,9 +20,6 @@ export class Rating extends Entity {
   author = '';
   date = Temporal.Instant.fromEpochSeconds(0);
 
-  pk() {
-    return this.id;
-  }
   static key = 'Rating';
 
   static schema = {

--- a/docs/rest/guides/optimistic-updates.md
+++ b/docs/rest/guides/optimistic-updates.md
@@ -26,7 +26,7 @@ handles these for you.
 
 <HooksPlayground defaultOpen="n" row fixtures={todoFixtures}>
 
-```ts title="TodoResource" {18}
+```ts title="TodoResource" {16}
 import { Entity, resource } from '@data-client/rest';
 
 export class Todo extends Entity {
@@ -34,9 +34,7 @@ export class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-  pk() {
-    return `${this.id}`;
-  }
+
   static key = 'Todo';
 }
 export const TodoResource = resource({

--- a/docs/rest/guides/pagination.md
+++ b/docs/rest/guides/pagination.md
@@ -129,10 +129,36 @@ interface Props {
 }
 ```
 
-```tsx title="ValidatorList" {12-16}
+```tsx title="LoadMore" {8-11}
+import { useController, useLoading } from '@data-client/react';
+import { getValidators } from './Validator';
+
+export default function LoadMore({ next_key, limit }) {
+  const ctrl = useController();
+  const [handleLoadMore, isPending] = useLoading(
+    () =>
+      ctrl.fetch(getValidators.getPage, {
+        'pagination.limit': limit,
+        'pagination.key': next_key,
+      }),
+    [next_key, limit],
+  );
+  if (!next_key) return null;
+  return (
+    <center>
+      <button onClick={handleLoadMore} disabled={isPending}>
+        {isPending ? '...' : 'Load more'}
+      </button>
+    </center>
+  );
+}
+```
+
+```tsx title="ValidatorList" collapsed
 import { useSuspense } from '@data-client/react';
 import ValidatorItem from './ValidatorItem';
 import { getValidators } from './Validator';
+import LoadMore from './LoadMore';
 
 const PAGE_LIMIT = '3';
 
@@ -140,23 +166,13 @@ export default function ValidatorList() {
   const { validators, pagination } = useSuspense(getValidators, {
     'pagination.limit': PAGE_LIMIT,
   });
-  const ctrl = useController();
-  const handleLoadMore = () =>
-    ctrl.fetch(getValidators.getPage, {
-      'pagination.limit': PAGE_LIMIT,
-      'pagination.key': pagination.next_key,
-    });
 
   return (
     <div>
       {validators.map(validator => (
         <ValidatorItem key={validator.pk()} validator={validator} />
       ))}
-      {pagination.next_key ? (
-        <center>
-          <button onClick={handleLoadMore}>Load more</button>
-        </center>
-      ) : null}
+      <LoadMore next_key={pagination.next_key} limit={PAGE_LIMIT} />
     </div>
   );
 }

--- a/docs/rest/guides/partial-entities.md
+++ b/docs/rest/guides/partial-entities.md
@@ -74,9 +74,6 @@ export class ArticleSummary extends Entity {
   id = '';
   title = '';
 
-  pk() {
-    return this.id;
-  }
   // this ensures `Article` maps to the same entity
   static key = 'Article';
 
@@ -178,9 +175,6 @@ class ArticleSummary extends Entity {
     meta: ArticleMeta,
   };
 
-  pk() {
-    return this.id;
-  }
   // this ensures `Article` maps to the same entity
   // highlight-next-line
   static key = 'Article';

--- a/docs/rest/guides/relational-data.md
+++ b/docs/rest/guides/relational-data.md
@@ -100,20 +100,12 @@ import { Entity } from '@data-client/rest';
 export class User extends Entity {
   id = '';
   name = '';
-
-  pk() {
-    return this.id;
-  }
 }
 
 export class Comment extends Entity {
   id = '';
   content = '';
   commenter = User.fromJS();
-
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     commenter: User,
@@ -125,10 +117,6 @@ export class Post extends Entity {
   title = '';
   author = User.fromJS();
   comments: Comment[] = [];
-
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     author: User,
@@ -193,9 +181,6 @@ export class User extends Entity {
   name = '';
   email = '';
   website = '';
-  pk() {
-    return this.id;
-  }
 }
 export const UserResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
@@ -213,9 +198,6 @@ export class Todo extends Entity {
   user? = User.fromJS({});
   title = '';
   completed = false;
-  pk() {
-    return this.id;
-  }
   static schema = {
     user: User,
   };
@@ -348,10 +330,6 @@ export class User extends Entity {
   posts: Post[] = [];
   comments: Comment[] = [];
 
-  pk() {
-    return this.id;
-  }
-
   static merge(existing, incoming) {
     return {
       ...existing,
@@ -382,10 +360,6 @@ export class Comment extends Entity {
   commenter = User.fromJS();
   post = Post.fromJS();
 
-  pk() {
-    return this.id;
-  }
-
   static schema: Record<string, Schema> = {
     commenter: User,
   };
@@ -399,10 +373,6 @@ export class Post extends Entity {
   title = '';
   author = User.fromJS();
   comments: Comment[] = [];
-
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     author: User,
@@ -541,10 +511,6 @@ export class Post extends Entity {
   title = '';
   author = User.fromJS();
 
-  pk() {
-    return this.id;
-  }
-
   static schema = {
     author: User,
   };
@@ -571,10 +537,6 @@ export class User extends Entity {
   name = '';
   posts: Post[] = [];
   createdAt = Temporal.Instant.fromEpochSeconds(0);
-
-  pk() {
-    return this.id;
-  }
 
   static schema: Record<string, Schema | Date> = {
     createdAt: Temporal.Instant.from,

--- a/docs/rest/shared/_SortDemo.mdx
+++ b/docs/rest/shared/_SortDemo.mdx
@@ -9,16 +9,13 @@ import {
 ```ts title="getPosts" {20-27}
 import { Entity, RestEndpoint } from '@data-client/rest';
 
-class Post extends Entity {
+export class Post extends Entity {
   id = '';
   title = '';
   group = '';
   author = '';
-
-  pk() {
-    return this.id;
-  }
 }
+
 export const getPosts = new RestEndpoint({
   path: '/:group/posts',
   searchParams: {} as { orderBy?: string; author?: string },

--- a/examples/benchmark/schemas.js
+++ b/examples/benchmark/schemas.js
@@ -8,17 +8,9 @@ export class BuildTypeDescription extends Entity {
   paused = false;
   projectId = 'OpenSourceProjects_AbsaOSS_Commons';
 
-  pk() {
-    return this.id;
-  }
-
   static key = 'BuildTypeDescription';
 }
 export class BuildTypeDescriptionEmpty extends Entity {
-  pk() {
-    return this.id;
-  }
-
   static key = 'BuildTypeDescription';
 }
 export const BuildTypeDescriptionEntity = schema.Entity(
@@ -46,10 +38,6 @@ export class ProjectWithBuildTypesDescription extends Entity {
     buildType: [],
   };
 
-  pk() {
-    return this.id;
-  }
-
   static schema = {
     buildTypes: { buildType: [BuildTypeDescription] },
   };
@@ -57,10 +45,6 @@ export class ProjectWithBuildTypesDescription extends Entity {
   static key = 'ProjectWithBuildTypesDescription';
 }
 export class ProjectWithBuildTypesDescriptionEmpty extends Entity {
-  pk() {
-    return this.id;
-  }
-
   static schema = {
     buildTypes: { buildType: [BuildTypeDescriptionEmpty] },
   };
@@ -108,10 +92,6 @@ export const ProjectQuerySorted = new schema.Query(
 );
 
 class BuildTypeDescriptionSimpleMerge extends Entity {
-  pk() {
-    return this.id;
-  }
-
   static merge(existing, incoming) {
     return incoming;
   }
@@ -120,10 +100,6 @@ class BuildTypeDescriptionSimpleMerge extends Entity {
 }
 
 export class ProjectWithBuildTypesDescriptionSimpleMerge extends Entity {
-  pk() {
-    return this.id;
-  }
-
   static schema = {
     buildTypes: { buildType: [BuildTypeDescriptionSimpleMerge] },
   };

--- a/packages/core/src/controller/__tests__/get.ts
+++ b/packages/core/src/controller/__tests__/get.ts
@@ -7,9 +7,6 @@ describe('Controller.get()', () => {
   class Tacos extends Entity {
     type = '';
     id = '';
-    pk() {
-      return this.id;
-    }
   }
   const TacoList = new schema.Collection([Tacos]);
   const entities = {
@@ -53,10 +50,6 @@ describe('Controller.get()', () => {
     class User extends Entity {
       id = '';
       username = '';
-
-      pk() {
-        return this.id;
-      }
 
       static indexes = ['username'] as const;
     }
@@ -223,9 +216,6 @@ describe('Controller.get()', () => {
   it('Union based on args', () => {
     class IDEntity extends Entity {
       id: string = '';
-      pk() {
-        return this.id;
-      }
     }
     class User extends IDEntity {
       type = 'user';

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -10,9 +10,6 @@ describe('Controller.getResponse()', () => {
     class Tacos extends Entity {
       type = '';
       id = '';
-      pk() {
-        return this.id;
-      }
     }
     const ep = new Endpoint(() => Promise.resolve(), {
       key() {
@@ -129,9 +126,6 @@ describe('Controller.getResponse()', () => {
     class Tacos extends Entity {
       type = '';
       id = '';
-      pk() {
-        return this.id;
-      }
     }
     const ep = new Endpoint(({ id }: { id: string }) => Promise.resolve(), {
       key({ id }) {

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -211,9 +211,6 @@ describe('reducer', () => {
     class Counter extends Entity {
       id = 0;
       counter = 0;
-      pk() {
-        return this.id;
-      }
 
       static key = 'Counter';
     }
@@ -241,9 +238,6 @@ describe('reducer', () => {
     class Counter extends Entity {
       id = 0;
       counter = 0;
-      pk() {
-        return this.id;
-      }
 
       static key = 'Counter';
     }

--- a/packages/endpoint/README.md
+++ b/packages/endpoint/README.md
@@ -178,13 +178,11 @@ import { Entity } from '@data-client/normalizr';
 import { Endpoint } from '@data-client/endpoint';
 
 class User extends Entity {
-  readonly id: string = '';
-  readonly username: string = '';
-
-  pk() { return this.id;}
+  id = '';
+  username = '';
 }
 
-const UserDetail = new Endpoint(
+const getUser = new Endpoint(
     ({ id }) ⇒ fetch(`/users/${id}`),
     { schema: User }
 );
@@ -210,10 +208,9 @@ import { Entity } from '@data-client/normalizr';
 import { Index } from '@data-client/endpoint';
 
 class User extends Entity {
-  readonly id: string = '';
-  readonly username: string = '';
+  id = '';
+  username = '';\
 
-  pk() { return this.id;}
   static indexes = ['username'] as const;
 }
 

--- a/packages/endpoint/src/__tests__/endpoint.ts
+++ b/packages/endpoint/src/__tests__/endpoint.ts
@@ -507,9 +507,6 @@ describe.each([true, false])(`Endpoint (CSP %s)`, mockCSP => {
       const url = ({ id }: { id: string }) => `/users/${id}`;
       class User extends Entity {
         readonly id: string = '';
-        pk() {
-          return this.id;
-        }
       }
       const UserDetail = new Endpoint(
         function ({ id }: { id: string }) {

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -16,20 +16,6 @@ const EmptyBase = class {} as any as abstract new (...args: any[]) => {
  * @see https://dataclient.io/rest/api/Entity
  */
 export default abstract class Entity extends EntitySchema(EmptyBase) {
-  /**
-   * A unique identifier for each Entity
-   *
-   * @param [parent] When normalizing, the object which included the entity
-   * @param [key] When normalizing, the key where this entity was found
-   * @param [args] ...args sent to Endpoint
-   * @see https://dataclient.io/rest/api/Entity#pk
-   */
-  abstract pk(
-    parent?: any,
-    key?: string,
-    args?: readonly any[],
-  ): string | number | undefined;
-
   /** Control how automatic schema validation is handled
    *
    * `undefined`: Defaults - throw error in worst offense
@@ -42,8 +28,8 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
 
   /** Factory method to convert from Plain JS Objects.
    *
-   * @param [props] Plain Object of properties to assign.
    * @see https://dataclient.io/rest/api/Entity#fromJS
+   * @param [props] Plain Object of properties to assign.
    */
   declare static fromJS: <T extends typeof Entity>(
     this: T,
@@ -54,6 +40,7 @@ export default abstract class Entity extends EntitySchema(EmptyBase) {
   /**
    * A unique identifier for each Entity
    *
+   * @see https://dataclient.io/rest/api/Entity#pk
    * @param [value] POJO of the entity or subset used
    * @param [parent] When normalizing, the object which included the entity
    * @param [key] When normalizing, the key where this entity was found
@@ -112,19 +99,4 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     args: readonly any[],
     unvisit: (schema: any, input: any) => any,
   ) => AbstractInstanceType<T>;
-}
-
-if (process.env.NODE_ENV !== 'production') {
-  /* istanbul ignore else */
-  const superFrom = Entity.fromJS;
-  // for those not using TypeScript this is a good catch to ensure they are defining
-  // the abstract members
-  Entity.fromJS = function fromJS<T extends typeof Entity>(
-    this: T,
-    props?: Partial<AbstractInstanceType<T>>,
-  ): AbstractInstanceType<T> {
-    if ((this as any).prototype.pk === Entity.prototype.pk)
-      throw new Error('cannot construct on abstract types');
-    return superFrom.call(this, props) as any;
-  };
 }

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -384,9 +384,6 @@ describe(`${Entity.name} normalization`, () => {
       const makeSchema = () =>
         class extends Entity {
           readonly id: number = 0;
-          pk() {
-            return `${this.id}`;
-          }
         };
       expect(() => makeSchema().key).toThrow();
     });

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -34,9 +34,6 @@ class ArticleEntity extends Entity {
   readonly title: string = '';
   readonly author: string = '';
   readonly content: string = '';
-  pk() {
-    return this.id;
-  }
 }
 
 class WithOptional extends Entity {
@@ -44,10 +41,6 @@ class WithOptional extends Entity {
   readonly article: ArticleEntity | null = null;
   readonly requiredArticle = ArticleEntity.fromJS();
   readonly nextPage: string = '';
-
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     article: ArticleEntity,
@@ -65,13 +58,20 @@ describe(`${Entity.name} normalization`, () => {
   );
 
   test('normalizes an entity', () => {
-    class MyEntity extends IDEntity {}
+    class MyEntity extends Entity {}
     expect(normalize(MyEntity, { id: '1' })).toMatchSnapshot();
   });
 
+  test('normalize throws error when id missing with no pk', () => {
+    class MyEntity extends Entity {}
+    expect(() =>
+      normalize(MyEntity, { slug: '1' }),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
   test('normalizes already processed entities', () => {
-    class MyEntity extends IDEntity {}
-    class Nested extends IDEntity {
+    class MyEntity extends Entity {}
+    class Nested extends Entity {
       title = '';
       nest = MyEntity.fromJS();
       static schema = {
@@ -88,7 +88,7 @@ describe(`${Entity.name} normalization`, () => {
   });
 
   test('normalizes does not change value when shouldUpdate() returns false', () => {
-    class MyEntity extends IDEntity {
+    class MyEntity extends Entity {
       id = '';
       title = '';
       static shouldUpdate() {
@@ -607,9 +607,9 @@ describe(`${Entity.name} denormalization`, () => {
     expect(denormalize(Tacos, '1', fromJS(entities))).toMatchSnapshot();
   });
 
-  class Food extends IDEntity {}
-  class Menu extends IDEntity {
-    readonly food: Food = Food.fromJS();
+  class Food extends Entity {}
+  class Menu extends Entity {
+    food: Food = Food.fromJS();
 
     static schema = { food: Food };
   }

--- a/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
@@ -146,6 +146,9 @@ describe(`${schema.Entity.name} construction`, () => {
       expect(MyEntity.pk({ username: 'bob' })).toBeUndefined();
       // @ts-expect-error
       expect(MyEntity.fromJS({ username: 'bob' }).pk()).toBeUndefined();
+      expect(() =>
+        normalize(MyEntity, { username: 'bob' }),
+      ).toThrowErrorMatchingSnapshot();
     });
     it('should use id field if no pk specified', () => {
       class MyData {

--- a/packages/endpoint/src/schemas/__tests__/Object.test.js
+++ b/packages/endpoint/src/schemas/__tests__/Object.test.js
@@ -33,11 +33,7 @@ describe(`${schema.Object.name} normalization`, () => {
   });
 
   test('filters out undefined and null values', () => {
-    class User extends Entity {
-      pk() {
-        return this.id;
-      }
-    }
+    class User extends Entity {}
     const users = new schema.Object({ foo: User, bar: User, baz: User });
     const oldenv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
@@ -45,9 +45,7 @@ Menu {
 
 exports[`Entity denormalization denormalizes deep entities 2`] = `
 Menu {
-  "food": Food {
-    "id": undefined,
-  },
+  "food": Food {},
   "id": "2",
 }
 `;
@@ -236,6 +234,19 @@ exports[`Entity normalization mergeStrategy defaults to plain merging 1`] = `
     "1",
   ],
 }
+`;
+
+exports[`Entity normalization normalize throws error when id missing with no pk 1`] = `
+"Missing usable primary key when normalizing response.
+
+  'id' missing but needed for default pk(). Try defining pk() for your Entity.
+  Learn more about primary keys: https://dataclient.io/rest/api/Entity#pk
+
+  Entity: MyEntity
+  Value (processed): {
+  "slug": "1"
+}
+"
 `;
 
 exports[`Entity normalization normalizes already processed entities 1`] = `

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/EntitySchema.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EntitySchema construction pk should fail with no id and pk unspecified 1`] = `
+"Missing usable primary key when normalizing response.
+
+  'id' missing but needed for default pk(). Try defining pk() for your Entity.
+  Learn more about primary keys: https://dataclient.io/rest/api/Entity#pk
+
+  Entity: MyEntity
+  Value (processed): {
+  "username": "bob"
+}
+"
+`;
+
 exports[`EntitySchema denormalization can denormalize already partially denormalized data 1`] = `
 Menu {
   "food": Food {

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -26,8 +26,8 @@ const gql = new GQLEndpoint('https://nosy-baritone.glitch.me');
 
 ```typescript
 class User extends GQLEntity {
-  readonly name: string = '';
-  readonly email: string = '';
+  name = '';
+  email = '';
 }
 ```
 

--- a/packages/graphql/src/GQLEntity.ts
+++ b/packages/graphql/src/GQLEntity.ts
@@ -2,7 +2,4 @@ import { Entity } from '@data-client/endpoint';
 
 export default class GQLEntity extends Entity {
   readonly id: string = '';
-  pk() {
-    return this.id;
-  }
 }

--- a/packages/normalizr/README.md
+++ b/packages/normalizr/README.md
@@ -90,18 +90,10 @@ import { schema, Entity } from '@data-client/endpoint';
 import { Temporal } from '@js-temporal/polyfill';
 
 // Define a users schema
-class User extends Entity {
-  pk() {
-    return this.id;
-  }
-}
+class User extends Entity {}
 
 // Define your comments schema
 class Comment extends Entity {
-  pk() {
-    return this.id;
-  }
-
   static schema = {
     commenter: User,
     createdAt: Temporal.Instant.from,
@@ -110,10 +102,6 @@ class Comment extends Entity {
 
 // Define your article
 class Article extends Entity {
-  pk() {
-    return this.id;
-  }
-
   static schema = {
     author: User,
     comments: [Comment],

--- a/packages/normalizr/src/__tests__/MemoCache.ts
+++ b/packages/normalizr/src/__tests__/MemoCache.ts
@@ -634,7 +634,7 @@ describe('MemoCache', () => {
           {},
         ),
       ).toEqual({
-        data: { article: '5' },
+        data: { article: 5 },
       });
     });
 
@@ -785,7 +785,7 @@ describe('MemoCache', () => {
         ),
       ).toEqual({
         pagination: { next: '', previous: '' },
-        data: '5',
+        data: 5,
       });
     });
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -47,10 +47,6 @@ For more details, see [the Installation docs page](https://dataclient.io/docs/ge
 class User extends Entity {
   id = '';
   username = '';
-
-  pk() {
-    return this.id;
-  }
 }
 
 class Article extends Entity {
@@ -59,10 +55,6 @@ class Article extends Entity {
   body = '';
   author = User.fromJS();
   createdAt = Temporal.Instant.fromEpochSeconds(0);
-
-  pk() {
-    return this.id;
-  }
 
   static schema = {
     author: User,

--- a/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
@@ -761,10 +761,6 @@ describe.each([
       class Toggle extends Entity {
         readonly id: number = 0;
         readonly visible: boolean = true;
-
-        pk() {
-          return `${this.id}`;
-        }
       }
       const getbool = new Endpoint(
         (id: number): Promise<{ id: number; visible: boolean }> =>

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -51,9 +51,6 @@ class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-  pk() {
-    return `${this.id}`;
-  }
 }
 const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
@@ -136,7 +133,7 @@ const groupTodoByUser = new schema.Query(
   todos => Object.groupBy(todos, todo => todo.userId),
 );
 const todosByUser = useQuery(groupTodoByUser);
-```
+```\
 
 ### TypeScript requirements
 

--- a/packages/rest/src/__tests__/Resource.test.ts
+++ b/packages/rest/src/__tests__/Resource.test.ts
@@ -5,8 +5,8 @@ import { CacheProvider } from '@data-client/react';
 import nock from 'nock';
 
 import { makeRenderDataClient } from '../../../test';
-import resource from '../resource';
 import { ResourcePath } from '../pathTypes';
+import resource from '../resource';
 import RestEndpoint from '../RestEndpoint';
 import {
   payload,
@@ -25,10 +25,6 @@ export class User extends Entity {
   readonly username: string = '';
   readonly email: string = '';
   readonly isAdmin: boolean = false;
-
-  pk() {
-    return this.id?.toString();
-  }
 }
 export const UserResource = resource({
   path: 'http\\://test.com/user/:id',
@@ -40,10 +36,6 @@ export class PaginatedArticle extends Entity {
   readonly content: string = '';
   readonly author: number | null = null;
   readonly tags: string[] = [];
-
-  pk() {
-    return this.id?.toString();
-  }
 
   static schema = {
     author: User,

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -26,10 +26,6 @@ export class User extends Entity {
   readonly username: string = '';
   readonly email: string = '';
   readonly isAdmin: boolean = false;
-
-  pk() {
-    return this.id?.toString();
-  }
 }
 const getUser = new RestEndpoint({
   path: 'http\\://test.com/user/:id',
@@ -44,10 +40,6 @@ export class PaginatedArticle extends Entity {
   readonly content: string = '';
   readonly author: number | null = null;
   readonly tags: string[] = [];
-
-  pk() {
-    return this.id?.toString();
-  }
 
   static schema = {
     author: User,
@@ -804,10 +796,6 @@ describe('RestEndpoint', () => {
         readonly username2: string = '';
         readonly email: string = '';
         readonly isAdmin: boolean = false;
-
-        pk() {
-          return this.id?.toString();
-        }
       }
 
       const getUserBase = new MyEndpoint({

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -27,10 +27,6 @@ export default class Article extends Entity {
   content = '';
   author: number | null = null;
   contributors: number[] = [];
-
-  pk() {
-    return this.id?.toString();
-  }
 }
 export const ArticleResource = resource({
   urlRoot: 'http://test.com',

--- a/website/src/components/Demo/code/posts-app/rest/resources.ts
+++ b/website/src/components/Demo/code/posts-app/rest/resources.ts
@@ -6,9 +6,6 @@ export class Post extends Entity {
   userId = 0;
   title = '';
   body = '';
-  pk() {
-    return `${this.id}`;
-  }
 }
 export const PostResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
@@ -28,10 +25,6 @@ export class User extends Entity {
 
   get profileImage() {
     return `//i.pravatar.cc/64?img=${this.id + 4}`;
-  }
-
-  pk() {
-    return `${this.id}`;
   }
 }
 export const UserResource = resource({

--- a/website/src/components/Demo/code/profile-edit/rest/resources.ts
+++ b/website/src/components/Demo/code/profile-edit/rest/resources.ts
@@ -5,9 +5,6 @@ export class Post extends Entity {
   userId = 0;
   title = '';
   body = '';
-  pk() {
-    return this.id;
-  }
 }
 export const PostResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
@@ -27,10 +24,6 @@ export class User extends Entity {
 
   get profileImage() {
     return `https://i.pravatar.cc/64?img=${this.id + 4}`;
-  }
-
-  pk() {
-    return this.id;
   }
 }
 export const UserResource = resource({

--- a/website/src/components/Demo/code/simple/rest/api.ts
+++ b/website/src/components/Demo/code/simple/rest/api.ts
@@ -3,9 +3,6 @@ export class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-  pk() {
-    return `${this.id}`;
-  }
 }
 export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',

--- a/website/src/components/Demo/code/todo-app/rest/resources.ts
+++ b/website/src/components/Demo/code/todo-app/rest/resources.ts
@@ -5,9 +5,6 @@ export class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-  pk() {
-    return this.id;
-  }
 }
 export const TodoResource = resource({
   urlPrefix: 'https://jsonplaceholder.typicode.com',
@@ -27,10 +24,6 @@ export class User extends Entity {
 
   get profileImage() {
     return `https://i.pravatar.cc/64?img=${this.id + 4}`;
-  }
-
-  pk() {
-    return this.id;
   }
 
   static schema = {

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -1113,15 +1113,6 @@ declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
  * @see https://dataclient.io/rest/api/Entity
  */
 declare abstract class Entity extends Entity_base {
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     * @param [args] ...args sent to Endpoint
-     * @see https://dataclient.io/rest/api/Entity#pk
-     */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -1133,13 +1124,14 @@ declare abstract class Entity extends Entity_base {
     protected static automaticValidation?: 'warn' | 'silent';
     /** Factory method to convert from Plain JS Objects.
      *
-     * @param [props] Plain Object of properties to assign.
      * @see https://dataclient.io/rest/api/Entity#fromJS
+     * @param [props] Plain Object of properties to assign.
      */
     static fromJS: <T extends typeof Entity>(this: T, props?: Partial<AbstractInstanceType<T>>) => AbstractInstanceType<T>;
     /**
      * A unique identifier for each Entity
      *
+     * @see https://dataclient.io/rest/api/Entity#pk
      * @param [value] POJO of the entity or subset used
      * @param [parent] When normalizing, the object which included the entity
      * @param [key] When normalizing, the key where this entity was found

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -1113,15 +1113,6 @@ declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
  * @see https://dataclient.io/rest/api/Entity
  */
 declare abstract class Entity extends Entity_base {
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     * @param [args] ...args sent to Endpoint
-     * @see https://dataclient.io/rest/api/Entity#pk
-     */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -1133,13 +1124,14 @@ declare abstract class Entity extends Entity_base {
     protected static automaticValidation?: 'warn' | 'silent';
     /** Factory method to convert from Plain JS Objects.
      *
-     * @param [props] Plain Object of properties to assign.
      * @see https://dataclient.io/rest/api/Entity#fromJS
+     * @param [props] Plain Object of properties to assign.
      */
     static fromJS: <T extends typeof Entity>(this: T, props?: Partial<AbstractInstanceType<T>>) => AbstractInstanceType<T>;
     /**
      * A unique identifier for each Entity
      *
+     * @see https://dataclient.io/rest/api/Entity#pk
      * @param [value] POJO of the entity or subset used
      * @param [parent] When normalizing, the object which included the entity
      * @param [key] When normalizing, the key where this entity was found
@@ -1163,7 +1155,6 @@ type NI<T> = NoInfer<T>;
 
 declare class GQLEntity extends Entity {
     readonly id: string;
-    pk(): string;
 }
 
 interface GQLOptions<Variables, S extends Schema | undefined = Schema | undefined, M extends boolean | undefined = boolean | undefined> extends EndpointOptions<(v: Variables) => Promise<any>, S, M> {

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -1111,15 +1111,6 @@ declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
  * @see https://dataclient.io/rest/api/Entity
  */
 declare abstract class Entity extends Entity_base {
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     * @param [args] ...args sent to Endpoint
-     * @see https://dataclient.io/rest/api/Entity#pk
-     */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -1131,13 +1122,14 @@ declare abstract class Entity extends Entity_base {
     protected static automaticValidation?: 'warn' | 'silent';
     /** Factory method to convert from Plain JS Objects.
      *
-     * @param [props] Plain Object of properties to assign.
      * @see https://dataclient.io/rest/api/Entity#fromJS
+     * @param [props] Plain Object of properties to assign.
      */
     static fromJS: <T extends typeof Entity>(this: T, props?: Partial<AbstractInstanceType<T>>) => AbstractInstanceType<T>;
     /**
      * A unique identifier for each Entity
      *
+     * @see https://dataclient.io/rest/api/Entity#pk
      * @param [value] POJO of the entity or subset used
      * @param [parent] When normalizing, the object which included the entity
      * @param [key] When normalizing, the key where this entity was found

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -1115,15 +1115,6 @@ declare const Entity_base: IEntityClass<abstract new (...args: any[]) => {
  * @see https://dataclient.io/rest/api/Entity
  */
 declare abstract class Entity extends Entity_base {
-    /**
-     * A unique identifier for each Entity
-     *
-     * @param [parent] When normalizing, the object which included the entity
-     * @param [key] When normalizing, the key where this entity was found
-     * @param [args] ...args sent to Endpoint
-     * @see https://dataclient.io/rest/api/Entity#pk
-     */
-    abstract pk(parent?: any, key?: string, args?: readonly any[]): string | number | undefined;
     /** Control how automatic schema validation is handled
      *
      * `undefined`: Defaults - throw error in worst offense
@@ -1135,13 +1126,14 @@ declare abstract class Entity extends Entity_base {
     protected static automaticValidation?: 'warn' | 'silent';
     /** Factory method to convert from Plain JS Objects.
      *
-     * @param [props] Plain Object of properties to assign.
      * @see https://dataclient.io/rest/api/Entity#fromJS
+     * @param [props] Plain Object of properties to assign.
      */
     static fromJS: <T extends typeof Entity>(this: T, props?: Partial<AbstractInstanceType<T>>) => AbstractInstanceType<T>;
     /**
      * A unique identifier for each Entity
      *
+     * @see https://dataclient.io/rest/api/Entity#pk
      * @param [value] POJO of the entity or subset used
      * @param [parent] When normalizing, the object which included the entity
      * @param [key] When normalizing, the key where this entity was found

--- a/website/src/components/Playground/resources/PlaceholderBaseResource.ts
+++ b/website/src/components/Playground/resources/PlaceholderBaseResource.ts
@@ -1,17 +1,7 @@
-import {
-  Entity,
-  resource,
-  RestEndpoint,
-  Schema,
-} from '@data-client/rest';
+import { Entity, resource, RestEndpoint, Schema } from '@data-client/rest';
 
 export abstract class PlaceholderEntity extends Entity {
-  readonly id: number = 0;
-
-  // all Resources of `jsonplaceholder` use an id for the primary key
-  pk() {
-    return `${this.id}`;
-  }
+  id = 0;
 }
 
 /** Common patterns in the https://jsonplaceholder.typicode.com API */

--- a/website/src/fixtures/todos.ts
+++ b/website/src/fixtures/todos.ts
@@ -6,9 +6,6 @@ export class Todo extends Entity {
   userId = 0;
   title = '';
   completed = false;
-  pk() {
-    return `${this.id}`;
-  }
 
   static key = 'Todo';
 }
@@ -30,10 +27,6 @@ export class User extends Entity {
 
   get profileImage() {
     return `https://i.pravatar.cc/64?img=${this.id + 4}`;
-  }
-
-  pk() {
-    return `${this.id}`;
   }
 
   static key = 'User';


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
More terse common case.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### Outcome

- [Entity](https://dataclient.io/rest/api/Entity) with no [pk()](https://dataclient.io/rest/api/Entity#pk) override will use the `id` member
- In DEV mode normalize with missing `id` will alert user they need to override [Entity.pk()](https://dataclient.io/rest/api/Entity#pk)

#### Changes

- Remove [Entity](https://dataclient.io/rest/api/Entity)'s special abstract [pk()](https://dataclient.io/rest/api/Entity#pk) type ([schema.Entity mixin](https://dataclient.io/rest/api/schema.Entity) already defaults to `this.id`)
- Add special error message in EntitySchema.normalize() when default implementation is used but `id` is not present