### PR TITLE
enhance: schema.Entity -> EntityMixin

### DIFF
--- a/.changeset/four-terms-leave.md
+++ b/.changeset/four-terms-leave.md
@@ -1,0 +1,5 @@
+---
+'@data-client/normalizr': patch
+---
+
+Update README to link to [EntityMixin](https://dataclient.io/rest/api/EntityMixin)

--- a/.changeset/wise-seals-cross.md
+++ b/.changeset/wise-seals-cross.md
@@ -1,0 +1,22 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+---
+
+`schema.Entity` -> [EntityMixin](https://dataclient.io/rest/api/EntityMixin)
+
+```ts
+import { EntityMixin } from '@data-client/rest';
+
+export class Article {
+  id = '';
+  title = '';
+  content = '';
+  tags: string[] = [];
+}
+
+export class ArticleEntity extends EntityMixin(Article) {}
+```
+
+We keep `schema.Entity` for legacy, and add schema.EntityMixin and [EntityMixin](https://dataclient.io/rest/api/EntityMixin) as direct export

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://da
 <tbody><tr>
 <td rowSpan="4"><a href="https://en.wikipedia.org/wiki/Object_(computer_science)">Object</a></td>
 <td align="center">✅</td>
-<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/schema.Entity">schema.Entity</a> mixin</td>
+<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/EntityMixin">EntityMixin</a></td>
 <td>single <em>unique</em> object</td>
 <td align="center">✅</td>
 </tr>

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -1,3 +1,6 @@
+import { Temporal } from '@js-temporal/polyfill';
+import React, { createContext, useContext } from 'react';
+
 import {
   schema,
   Endpoint,
@@ -5,6 +8,7 @@ import {
   RestEndpoint,
   Schema,
   Entity,
+  EntityMixin,
   RestGenerics,
   hookifyResource,
   RestType,
@@ -12,8 +16,6 @@ import {
   Resource,
   ResourceOptions,
 } from '@data-client/rest';
-import { Temporal } from '@js-temporal/polyfill';
-import React, { createContext, useContext } from 'react';
 
 /** Represents data with primary key being from 'id' field. */
 export class IDEntity extends Entity {
@@ -44,7 +46,7 @@ export class VisSettings extends Entity implements Vis {
 
   static key = 'VisSettings';
 }
-export class VisSettingsFromMixin extends schema.Entity(Vis) {
+export class VisSettingsFromMixin extends EntityMixin(Vis) {
   static cmpIncoming(
     existingMeta: { date: number; fetchedAt: number },
     incomingMeta: { date: number; fetchedAt: number },
@@ -179,7 +181,7 @@ class ArticleData {
   readonly author: User | null = null;
   readonly tags: string[] = [];
 }
-export class ArticleFromMixin extends schema.Entity(ArticleData, {
+export class ArticleFromMixin extends EntityMixin(ArticleData, {
   schema: { author: User },
 }) {}
 class ArticleEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {}

--- a/docs/core/getting-started/resource.md
+++ b/docs/core/getting-started/resource.md
@@ -139,7 +139,7 @@ export const TodoResource = {
   <PkgInstall pkgs="@data-client/endpoint" />
 
 Pre-existing TypeScript definitions can be used in <abbr title="Reactive Data Client">Data Client</abbr> with
-[Endpoint](/rest/api/Endpoint) and [schema.Entity](/rest/api/schema.Entity).
+[Endpoint](/rest/api/Endpoint) and [EntityMixin](/rest/api/EntityMixin).
 
 <TypeScriptEditor row={false}>
 
@@ -187,7 +187,7 @@ export const deleteTodo = (body: Partial<Todo>) =>
 ```
 
 ```typescript title="TodoResource"
-import { schema, Endpoint } from '@data-client/endpoint';
+import { schema, EntityMixin, Endpoint } from '@data-client/endpoint';
 import {
   Todo,
   getTodo,
@@ -198,7 +198,7 @@ import {
   deleteTodo,
 } from './existing/Todo';
 
-export const TodoEntity = schema.Entity(Todo, { key: 'Todo' });
+export const TodoEntity = EntityMixin(Todo, { key: 'Todo' });
 
 export const TodoResource = {
   get: new Endpoint(getTodo, { schema: TodoEntity }),
@@ -289,5 +289,5 @@ To aid in defining `Resources`, composable and extensible protocol specific help
 [Image/binary](../guides/img-media.md), [Websockets+SSE](../concepts/managers.md#data-stream).
 
 To use existing API definitions, or define your own protocol specific helpers, use
-[Endpoint](/rest/api/Endpoint) and [schema.Entity](/rest/api/schema.Entity) from [@data-client/endpoint](https://www.npmjs.com/package/@data-client/endpoint).
+[Endpoint](/rest/api/Endpoint) and [EntityMixin](/rest/api/EntityMixin) from [@data-client/endpoint](https://www.npmjs.com/package/@data-client/endpoint).
 [See `Async/Promise` tab above]

--- a/docs/core/shared/_VoteDemo.mdx
+++ b/docs/core/shared/_VoteDemo.mdx
@@ -16,7 +16,7 @@ export class Post extends Entity {
   static key = 'Post';
 
   static schema = {
-    author: schema.Entity(
+    author: EntityMixin(
       class User {
         id = 0;
       },

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -82,17 +82,17 @@ export const ArticleResource = resource({
 <TypeScriptEditor>
 
 ```typescript title="User" collapsed
-import { schema } from '@data-client/rest';
+import { EntityMixin } from '@data-client/rest';
 
 export class User {
   id = '';
   username = '';
 }
-export class UserEntity extends schema.Entity(User) {}
+export class UserEntity extends EntityMixin(User) {}
 ```
 
 ```typescript title="Article"
-import { schema, resource } from '@data-client/rest';
+import { EntityMixin, resource } from '@data-client/rest';
 import { UserEntity } from './User';
 
 export class Article {
@@ -104,7 +104,7 @@ export class Article {
   createdAt = Temporal.Instant.fromEpochSeconds(0);
 }
 
-export class ArticleEntity extends schema.Entity(Article, {
+export class ArticleEntity extends EntityMixin(Article, {
   schema: {
     author: UserEntity,
     createdAt: Temporal.Instant.from,

--- a/docs/rest/api/Entity.md
+++ b/docs/rest/api/Entity.md
@@ -95,7 +95,7 @@ Entities are bound to Endpoints using [resource.schema](./resource.md#schema) or
 
 :::tip
 
-If you already have your classes defined, [schema.Entity](./schema.Entity.md) mixin can also be
+If you already have your classes defined, [EntityMixin](./EntityMixin.md) mixin can also be
 used to make Entities.
 
 :::

--- a/docs/rest/api/EntityMixin.md
+++ b/docs/rest/api/EntityMixin.md
@@ -1,6 +1,6 @@
 ---
-title: schema.Entity - Entity mixin
-sidebar_label: schema.Entity
+title: EntityMixin - Declarative unique objects for pre-existing classes
+sidebar_label: EntityMixin
 ---
 
 <head>
@@ -12,16 +12,16 @@ import LanguageTabs from '@site/src/components/LanguageTabs';
 import { RestEndpoint } from '@data-client/rest';
 import TypeScriptEditor from '@site/src/components/TypeScriptEditor';
 
-# schema.Entity
+# EntityMixin
 
 `Entity` defines a single _unique_ object.
 
-If you already have classes for your data-types, `schema.Entity` mixin may be for you.
+If you already have classes for your data-types, `EntityMixin` mixin may be for you.
 
 <TypeScriptEditor>
 
 ```typescript {10}
-import { schema } from '@data-client/rest';
+import { EntityMixin } from '@data-client/rest';
 
 export class Article {
   id = '';
@@ -30,7 +30,7 @@ export class Article {
   tags: string[] = [];
 }
 
-export class ArticleEntity extends schema.Entity(Article) {}
+export class ArticleEntity extends EntityMixin(Article) {}
 ```
 
 </TypeScriptEditor>
@@ -48,7 +48,7 @@ class User {
   username = '';
   createdAt = Temporal.Instant.fromEpochSeconds(0);
 }
-class UserEntity extends schema.Entity(User, {
+class UserEntity extends EntityMixin(User, {
   pk: 'username',
   key: 'User',
   schema: { createdAt: Temporal.Instant.from },
@@ -75,7 +75,7 @@ class Thread {
   slug = '';
   content = '';
 }
-class ThreadEntity extends schema.Entity(Thread, {
+class ThreadEntity extends EntityMixin(Thread, {
   pk(value) {
     return [value.forum, value.slug].join(',');
   },
@@ -94,7 +94,7 @@ Specifies the [Entity.schema](./Entity.md#schema)
 
 ## Methods
 
-`schema.Entity` mixin has the same [methods as the Entity](./Entity.md#lifecycle) class.
+`EntityMixin` mixin has the same [methods as the Entity](./Entity.md#lifecycle) class.
 
 ## const vs class
 
@@ -118,8 +118,8 @@ export class Article {
   tags: string[] = [];
 }
 
-export class ArticleEntity extends schema.Entity(Article) {}
-export const ArticleEntity2 = schema.Entity(Article);
+export class ArticleEntity extends EntityMixin(Article) {}
+export const ArticleEntity2 = EntityMixin(Article);
 
 const article: ArticleEntity = ArticleEntity.fromJS();
 const articleFails: ArticleEntity2 = ArticleEntity2.fromJS();

--- a/examples/benchmark/schemas.js
+++ b/examples/benchmark/schemas.js
@@ -1,4 +1,4 @@
-import { Entity, schema } from './dist/index.js';
+import { Entity, EntityMixin, schema } from './dist/index.js';
 
 export class BuildTypeDescription extends Entity {
   id = '';
@@ -13,7 +13,7 @@ export class BuildTypeDescription extends Entity {
 export class BuildTypeDescriptionEmpty extends Entity {
   static key = 'BuildTypeDescription';
 }
-export const BuildTypeDescriptionEntity = schema.Entity(
+export const BuildTypeDescriptionEntity = EntityMixin(
   class {
     id = '';
     internalId = 'bt17590';
@@ -51,7 +51,7 @@ export class ProjectWithBuildTypesDescriptionEmpty extends Entity {
 
   static key = 'ProjectWithBuildTypesDescription';
 }
-export const ProjectWithBuildTypesDescriptionEntity = schema.Entity(
+export const ProjectWithBuildTypesDescriptionEntity = EntityMixin(
   class {
     id = '';
     internalId = 'project3239';

--- a/examples/benchmark/src/index.ts
+++ b/examples/benchmark/src/index.ts
@@ -5,4 +5,4 @@ export {
   MemoCache,
 } from '@data-client/normalizr';
 export * from '@data-client/core';
-export { Endpoint, Entity, schema } from '@data-client/endpoint';
+export { Endpoint, Entity, EntityMixin, schema } from '@data-client/endpoint';

--- a/packages/endpoint/README.md
+++ b/packages/endpoint/README.md
@@ -42,10 +42,10 @@ export const updateTodo = (id: string, body: Partial<Todo>) =>
 ### 2) Turn them into Resources
 
 ```typescript
-import { schema, Endpoint } from '@data-client/endpoint';
+import { EntityMixin, Endpoint } from '@data-client/endpoint';
 import { Todo, getTodoList, updateTodo } from './existing';
 
-export const TodoEntity = schema.Entity(Todo, { key: 'Todo' });
+export const TodoEntity = EntityMixin(Todo, { key: 'Todo' });
 
 export const TodoResource = {
   get: new Endpoint(getTodo, {
@@ -221,7 +221,7 @@ Networking definition: [Endpoints](https://dataclient.io/rest/api/Endpoint)
 <tbody><tr>
 <td rowSpan="4"><a href="https://en.wikipedia.org/wiki/Object_(computer_science)">Object</a></td>
 <td align="center">✅</td>
-<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/schema.Entity">schema.Entity</a> mixin</td>
+<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/EntityMixin">EntityMixin</a></td>
 <td>single <em>unique</em> object</td>
 <td align="center">✅</td>
 </tr>

--- a/packages/endpoint/src-4.0-types/schemas/EntityTypes.d.ts
+++ b/packages/endpoint/src-4.0-types/schemas/EntityTypes.d.ts
@@ -48,7 +48,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): string | number | undefined;
   /** Return true to merge incoming data; false keeps existing entity
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
+   * @see https://dataclient.io/docs/api/Entity#shouldUpdate
    */
   shouldUpdate(
     existingMeta: {
@@ -64,7 +64,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): boolean;
   /** Determines the order of incoming entity vs entity already in store
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#shouldReorder
+   * @see https://dataclient.io/docs/api/Entity#shouldReorder
    * @returns true if incoming entity should be first argument of merge()
    */
   shouldReorder(
@@ -81,12 +81,12 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): boolean;
   /** Creates new instance copying over defined values of arguments
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#merge
+   * @see https://dataclient.io/docs/api/Entity#merge
    */
   merge(existing: any, incoming: any): any;
   /** Run when an existing entity is found in the store
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+   * @see https://dataclient.io/docs/api/Entity#mergeWithStore
    */
   mergeWithStore(
     existingMeta: {
@@ -102,7 +102,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): any;
   /** Run when an existing entity is found in the store
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#mergeMetaWithStore
+   * @see https://dataclient.io/docs/api/Entity#mergeMetaWithStore
    */
   mergeMetaWithStore(
     existingMeta: {

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -15,6 +15,7 @@ export * as schema from './schema.js';
 // Clue 1) It only happens with types mentioned in return types of other types
 export type { Array, Invalidate, Collection, DefaultArgs } from './schema.js';
 export { default as Entity } from './schemas/Entity.js';
+export { default as EntityMixin } from './schemas/EntityMixin.js';
 export { default as validateRequired } from './validateRequired.js';
 export { INVALID } from './special.js';
 export type {

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -21,15 +21,10 @@ import type {
   ObjectArgs,
 } from './normal.js';
 import { EntityFields } from './schemas/EntityFields.js';
-import type {
-  IEntityClass,
-  IEntityInstance,
-  EntityOptions,
-  RequiredPKOptions,
-  IDClass,
-  Constructor,
-  PKClass,
-} from './schemas/EntityTypes.js';
+import {
+  default as EntityMixin,
+  default as Entity,
+} from './schemas/EntityMixin.js';
 import { default as Invalidate } from './schemas/Invalidate.js';
 import { default as Query } from './schemas/Query.js';
 import type {
@@ -40,7 +35,7 @@ import type {
   UnionResult,
 } from './schemaTypes.js';
 
-export { EntityMap, Invalidate, Query };
+export { EntityMap, Invalidate, Query, EntityMixin, Entity };
 
 export type { SchemaClass };
 
@@ -410,35 +405,3 @@ export declare class Collection<
   Args extends any[] = DefaultArgs,
   Parent = any,
 > extends CollectionRoot<S, Args, Parent> {}
-
-/**
- * Entity defines a single (globally) unique object.
- * @see https://dataclient.io/rest/api/schema.Entity
- */
-export function Entity<TBase extends PKClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase;
-
-// id is in Instance, so we default to that as pk
-export function Entity<TBase extends IDClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-// pk was specified in options, so we don't need to redefine
-export function Entity<TBase extends Constructor>(
-  Base: TBase,
-  opt: RequiredPKOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-/* TODO: figure out how to make abstract class mixins work. until then we will require PK in options
-export function Entity<TBase extends Constructor>(
-  Base: TBase,
-  opt?: EntityOptions<keyof InstanceType<TBase>>,
-): (abstract new (...args: any[]) => {
-  pk(parent?: any, key?: string): string | number | undefined;
-}) &
-  IEntityClass<TBase> &
-  TBase;
-*/

--- a/packages/endpoint/src/schema.js
+++ b/packages/endpoint/src/schema.js
@@ -6,5 +6,8 @@ export { default as All } from './schemas/All.js';
 export { default as Object } from './schemas/Object.js';
 export { default as Invalidate } from './schemas/Invalidate.js';
 export { default as Collection } from './schemas/Collection.js';
-export { default as Entity } from './schemas/EntityMixin.js';
+export {
+  default as EntityMixin,
+  default as Entity,
+} from './schemas/EntityMixin.js';
 export { default as Query } from './schemas/Query.js';

--- a/packages/endpoint/src/schemaTypes.ts
+++ b/packages/endpoint/src/schemaTypes.ts
@@ -96,7 +96,7 @@ export interface CollectionInterface<
 
   /** Run when an existing Collection is found in the store
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+   * @see https://dataclient.io/docs/api/Collection#mergeWithStore
    */
   mergeWithStore(
     existingMeta: {

--- a/packages/endpoint/src/schemas/EntityMixin.ts
+++ b/packages/endpoint/src/schemas/EntityMixin.ts
@@ -1,4 +1,3 @@
-import { Constructor, EntityOptions } from './EntityTypes.js';
 import type {
   Schema,
   GetIndex,
@@ -7,11 +6,37 @@ import type {
   Visit,
 } from '../interface.js';
 import { AbstractInstanceType } from '../normal.js';
+import type {
+  IEntityClass,
+  IEntityInstance,
+  EntityOptions,
+  RequiredPKOptions,
+  IDClass,
+  Constructor,
+  PKClass,
+} from './EntityTypes.js';
 
 /**
- * Entity defines a single (globally) unique object.
- * @see https://dataclient.io/rest/api/schema.Entity
+ * Turns any class into an Entity.
+ * @see https://dataclient.io/rest/api/EntityMixin
  */
+export default function EntityMixin<TBase extends PKClass>(
+  Base: TBase,
+  opt?: EntityOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase;
+
+// id is in Instance, so we default to that as pk
+export default function EntityMixin<TBase extends IDClass>(
+  Base: TBase,
+  opt?: EntityOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+
+// pk was specified in options, so we don't need to redefine
+export default function EntityMixin<TBase extends Constructor>(
+  Base: TBase,
+  opt: RequiredPKOptions<InstanceType<TBase>>,
+): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+
 export default function EntityMixin<TBase extends Constructor>(
   Base: TBase,
   options: EntityOptions<InstanceType<TBase>> = {},

--- a/packages/endpoint/src/schemas/EntityTypes.ts
+++ b/packages/endpoint/src/schemas/EntityTypes.ts
@@ -1,6 +1,10 @@
 import type { Schema, GetEntity, GetIndex } from '../interface.js';
 import { AbstractInstanceType } from '../normal.js';
 
+/**
+ * Entity defines a single (globally) unique object.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
 export interface IEntityClass<TBase extends Constructor = any> {
   toJSON(): {
     name: string;
@@ -50,7 +54,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): string | number | undefined;
   /** Return true to merge incoming data; false keeps existing entity
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
+   * @see https://dataclient.io/docs/api/Entity#shouldUpdate
    */
   shouldUpdate(
     existingMeta: {
@@ -66,7 +70,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): boolean;
   /** Determines the order of incoming entity vs entity already in store
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#shouldReorder
+   * @see https://dataclient.io/docs/api/Entity#shouldReorder
    * @returns true if incoming entity should be first argument of merge()
    */
   shouldReorder(
@@ -77,12 +81,12 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): boolean;
   /** Creates new instance copying over defined values of arguments
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#merge
+   * @see https://dataclient.io/docs/api/Entity#merge
    */
   merge(existing: any, incoming: any): any;
   /** Run when an existing entity is found in the store
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+   * @see https://dataclient.io/docs/api/Entity#mergeWithStore
    */
   mergeWithStore(
     existingMeta: {
@@ -98,7 +102,7 @@ export interface IEntityClass<TBase extends Constructor = any> {
   ): any;
   /** Run when an existing entity is found in the store
    *
-   * @see https://dataclient.io/docs/api/schema.Entity#mergeMetaWithStore
+   * @see https://dataclient.io/docs/api/Entity#mergeMetaWithStore
    */
   mergeMetaWithStore(
     existingMeta: {

--- a/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntitySchema.test.ts
@@ -5,12 +5,12 @@ import { Temporal } from '@js-temporal/polyfill';
 import { fromJS, Record } from 'immutable';
 
 import SimpleMemoCache from './denormalize';
-import { schema } from '../..';
+import { schema, EntityMixin } from '../..';
 
 let dateSpy: jest.SpyInstance;
 beforeAll(() => {
   dateSpy = jest
-    // eslint-disable-next-line no-undef
+
     .spyOn(global.Date, 'now')
     .mockImplementation(() => new Date('2019-05-14T11:01:58.135Z').valueOf());
 });
@@ -26,7 +26,7 @@ class TacoData {
   name = '';
   alias: string | undefined = undefined;
 }
-class Tacos extends schema.Entity(TacoData) {}
+class Tacos extends EntityMixin(TacoData) {}
 
 class ArticleData {
   readonly id: string = '';
@@ -34,7 +34,7 @@ class ArticleData {
   readonly author: string = '';
   readonly content: string = '';
 }
-class ArticleEntity extends schema.Entity(ArticleData) {}
+class ArticleEntity extends EntityMixin(ArticleData) {}
 
 class OptionalData {
   readonly id: string = '';
@@ -42,7 +42,7 @@ class OptionalData {
   readonly requiredArticle = ArticleEntity.fromJS();
   readonly nextPage: string = '';
 }
-class WithOptional extends schema.Entity(OptionalData, {
+class WithOptional extends EntityMixin(OptionalData, {
   schema: {
     article: ArticleEntity,
     requiredArticle: ArticleEntity,
@@ -63,7 +63,7 @@ describe(`${schema.Entity.name} construction`, () => {
           return this.username;
         }
       }
-      const MyEntity = schema.Entity(MyData);
+      const MyEntity = EntityMixin(MyData);
       expect(MyEntity.pk({ username: 'bob' })).toBe('bob');
       const entity = MyEntity.fromJS({ username: 'bob' });
       expect(entity.pk()).toBe('bob');
@@ -78,7 +78,7 @@ describe(`${schema.Entity.name} construction`, () => {
           return this.username;
         }
       }
-      class MyEntity extends schema.Entity(MyData) {
+      class MyEntity extends EntityMixin(MyData) {
         pk() {
           return this.title;
         }
@@ -91,7 +91,7 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      class MyEntity extends schema.Entity(MyData, { pk: 'username' }) {
+      class MyEntity extends EntityMixin(MyData, { pk: 'username' }) {
         pk() {
           return this.title;
         }
@@ -104,7 +104,7 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      class MyEntity extends schema.Entity(MyData, { pk: 'username' }) {}
+      class MyEntity extends EntityMixin(MyData, { pk: 'username' }) {}
       expect(MyEntity.pk({ username: 'bob' })).toBe('bob');
       expect(MyEntity.fromJS({ username: 'bob' }).pk()).toBe('bob');
     });
@@ -113,7 +113,7 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      class MyEntity extends schema.Entity(MyData, {
+      class MyEntity extends EntityMixin(MyData, {
         pk(v) {
           //@ts-expect-error
           v.sdlfkjsd;
@@ -129,7 +129,7 @@ describe(`${schema.Entity.name} construction`, () => {
         title = '';
       }
       // @ts-expect-error
-      class MyEntity extends schema.Entity(MyData, { pk: 'id' }) {}
+      class MyEntity extends EntityMixin(MyData, { pk: 'id' }) {}
       // @ts-expect-error
       expect(MyEntity.pk({ username: 'bob' })).toBeUndefined();
       // @ts-expect-error
@@ -141,7 +141,7 @@ describe(`${schema.Entity.name} construction`, () => {
         title = '';
       }
       // @ts-expect-error
-      class MyEntity extends schema.Entity(MyData) {}
+      class MyEntity extends EntityMixin(MyData) {}
       // @ts-expect-error
       expect(MyEntity.pk({ username: 'bob' })).toBeUndefined();
       // @ts-expect-error
@@ -156,7 +156,7 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      class MyEntity extends schema.Entity(MyData) {}
+      class MyEntity extends EntityMixin(MyData) {}
       expect(MyEntity.pk({ id: '5' })).toBe('5');
       expect(MyEntity.fromJS({ id: '5' }).pk()).toBe('5');
     });
@@ -168,11 +168,11 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      const MyEntity = schema.Entity(MyData);
+      const MyEntity = EntityMixin(MyData);
       expect(MyEntity.key).toBe('MyData');
     });
     it('should error with no discernable name', () => {
-      const MyEntity = schema.Entity(
+      const MyEntity = EntityMixin(
         class {
           id = '';
           username = '';
@@ -190,7 +190,7 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      class MyEntity extends schema.Entity(MyData) {}
+      class MyEntity extends EntityMixin(MyData) {}
       expect(MyEntity.key).toBe('MyEntity');
     });
     it('should use key in options', () => {
@@ -199,9 +199,9 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      const MyEntity = schema.Entity(MyData, { key: 'MYKEY' });
+      const MyEntity = EntityMixin(MyData, { key: 'MYKEY' });
       expect(MyEntity.key).toBe('MYKEY');
-      class MyEntity2 extends schema.Entity(MyData, { key: 'MYKEY' }) {}
+      class MyEntity2 extends EntityMixin(MyData, { key: 'MYKEY' }) {}
       expect(MyEntity2.key).toBe('MYKEY');
     });
     it('should use static key in base class', () => {
@@ -212,7 +212,7 @@ describe(`${schema.Entity.name} construction`, () => {
 
         static key = 'MYKEY';
       }
-      const MyEntity = schema.Entity(MyData);
+      const MyEntity = EntityMixin(MyData);
       expect(MyEntity.key).toBe('MYKEY');
     });
     it('should have options.key override base class', () => {
@@ -223,7 +223,7 @@ describe(`${schema.Entity.name} construction`, () => {
 
         static key = 'MYKEY';
       }
-      const MyEntity = schema.Entity(MyData, { key: 'OVERRIDE' });
+      const MyEntity = EntityMixin(MyData, { key: 'OVERRIDE' });
       expect(MyEntity.key).toBe('OVERRIDE');
     });
     it('static key in Entity should override options', () => {
@@ -232,7 +232,7 @@ describe(`${schema.Entity.name} construction`, () => {
         username = '';
         title = '';
       }
-      class MyEntity extends schema.Entity(MyData, { key: 'OPTIONSKEY' }) {
+      class MyEntity extends EntityMixin(MyData, { key: 'OPTIONSKEY' }) {
         static key = 'STATICKEY';
       }
       expect(MyEntity.key).toBe('STATICKEY');
@@ -246,7 +246,7 @@ describe(`${schema.Entity.name} construction`, () => {
         title = '';
         createdAt = Temporal.Instant.fromEpochSeconds(0);
       }
-      class MyEntity extends schema.Entity(MyData, {
+      class MyEntity extends EntityMixin(MyData, {
         schema: { createdAt: Temporal.Instant.from },
       }) {}
       expect(MyEntity.schema).toEqual({ createdAt: Temporal.Instant.from });
@@ -261,7 +261,7 @@ describe(`${schema.Entity.name} construction`, () => {
           user: Temporal.Instant.from,
         };
       }
-      class MyEntity extends schema.Entity(MyData, {
+      class MyEntity extends EntityMixin(MyData, {
         schema: { createdAt: Temporal.Instant.from },
       }) {}
       expect(MyEntity.schema).toEqual({ createdAt: Temporal.Instant.from });
@@ -276,7 +276,7 @@ describe(`${schema.Entity.name} construction`, () => {
           createdAt: Temporal.Instant.from,
         };
       }
-      class MyEntity extends schema.Entity(MyData) {}
+      class MyEntity extends EntityMixin(MyData) {}
       expect(MyEntity.schema).toEqual({ createdAt: Temporal.Instant.from });
     });
     it('static schema in Entity should override options', () => {
@@ -286,7 +286,7 @@ describe(`${schema.Entity.name} construction`, () => {
         title = '';
         createdAt = Temporal.Instant.fromEpochSeconds(0);
       }
-      class MyEntity extends schema.Entity(MyData, {
+      class MyEntity extends EntityMixin(MyData, {
         schema: { createdAt: Temporal.Instant.from },
       }) {
         static schema = {
@@ -308,18 +308,18 @@ describe(`${schema.Entity.name} normalization`, () => {
   );
 
   test('normalizes an entity', () => {
-    class MyEntity extends schema.Entity(IDData) {}
+    class MyEntity extends EntityMixin(IDData) {}
     expect(normalize(MyEntity, { id: '1' })).toMatchSnapshot();
   });
 
   test('normalizes already processed entities', () => {
-    class MyEntity extends schema.Entity(IDData) {}
+    class MyEntity extends EntityMixin(IDData) {}
     class MyData {
       id = '';
       title = '';
       nest = MyEntity.fromJS();
     }
-    class Nested extends schema.Entity(MyData, {
+    class Nested extends EntityMixin(MyData, {
       schema: {
         nest: MyEntity,
       },
@@ -339,7 +339,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       id = '';
       title = '';
     }
-    class MyEntity extends schema.Entity(MyData) {
+    class MyEntity extends EntityMixin(MyData) {
       static shouldUpdate() {
         return false;
       }
@@ -363,7 +363,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       name = '';
       secondthing = '';
     }
-    const MyEntity = schema.Entity(MyData, { pk: 'name' });
+    const MyEntity = EntityMixin(MyData, { pk: 'name' });
 
     function normalizeBad() {
       normalize(MyEntity, { secondthing: 'hi' });
@@ -371,7 +371,7 @@ describe(`${schema.Entity.name} normalization`, () => {
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
 
     // @ts-expect-error
-    schema.Entity(MyData, { pk: 'sdfasd' });
+    EntityMixin(MyData, { pk: 'sdfasd' });
   });
 
   it('should not throw if schema key is missing from Entity', () => {
@@ -380,7 +380,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       secondthing = '';
     }
     // @ts-expect-error
-    const MyEntity = schema.Entity(MyData, {
+    const MyEntity = EntityMixin(MyData, {
       pk: 'name',
       schema: {
         blarb: Temporal.Instant.from,
@@ -398,7 +398,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       readonly secondthing: string = '';
       readonly blarb: Date | undefined = undefined;
     }
-    class MyEntity extends schema.Entity(MyData, {
+    class MyEntity extends EntityMixin(MyData, {
       pk: 'name',
       schema: {
         blarb: Temporal.Instant.from,
@@ -436,7 +436,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       name = '';
       secondthing = '';
     }
-    const MyEntity = schema.Entity(MyData, { pk: 'name' });
+    const MyEntity = EntityMixin(MyData, { pk: 'name' });
     function normalizeBad() {
       normalize(MyEntity, {});
     }
@@ -448,7 +448,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       name = '';
       secondthing = '';
     }
-    const MyEntity = schema.Entity(MyData, { pk: 'name' });
+    const MyEntity = EntityMixin(MyData, { pk: 'name' });
     function normalizeBad() {
       normalize(MyEntity, [
         { name: 'hi', secondthing: 'ho' },
@@ -464,7 +464,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       readonly name: string = '';
     }
     // @ts-expect-error
-    class MyEntity extends schema.Entity(MyData, { pk: 'e' }) {}
+    class MyEntity extends EntityMixin(MyData, { pk: 'e' }) {}
 
     expect(() =>
       normalize(MyEntity, {
@@ -478,7 +478,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       readonly name: string = '';
       readonly a: string = '';
     }
-    class MyEntity extends schema.Entity(MyData, { pk: 'name' }) {}
+    class MyEntity extends EntityMixin(MyData, { pk: 'name' }) {}
 
     expect(
       normalize(MyEntity, {
@@ -524,7 +524,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         return 'another2';
       }
     }
-    class MyEntity extends schema.Entity(MyData, { pk: 'name' }) {}
+    class MyEntity extends EntityMixin(MyData, { pk: 'name' }) {}
     function normalizeBad() {
       normalize(MyEntity, { name: 'bob' });
     }
@@ -541,7 +541,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         return this.name;
       }
     }
-    const MyEntity = schema.Entity(MyData);
+    const MyEntity = EntityMixin(MyData);
     function normalizeBad() {
       normalize({ data: MyEntity }, 'hibho');
     }
@@ -554,7 +554,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         id = '';
       }
       // @ts-expect-error
-      class MyEntity extends schema.Entity(MyData) {
+      class MyEntity extends EntityMixin(MyData) {
         static get key() {
           return 42;
         }
@@ -568,7 +568,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         readonly idStr: string = '';
         readonly name: string = '';
       }
-      const UserEntity = schema.Entity(User, { pk: 'idStr' });
+      const UserEntity = EntityMixin(User, { pk: 'idStr' });
       expect(
         normalize(UserEntity, { idStr: '134351', name: 'Kathy' }),
       ).toMatchSnapshot();
@@ -578,7 +578,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       class User {
         readonly name: string = '';
       }
-      const UserEntity = schema.Entity(User, {
+      const UserEntity = EntityMixin(User, {
         pk(value, parent, key) {
           return key;
         },
@@ -602,7 +602,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         readonly id: string = '';
         readonly name: string = '';
       }
-      const UserEntity = schema.Entity(User, {
+      const UserEntity = EntityMixin(User, {
         pk(value, parent, key) {
           return `${parent.name}-${key}-${value.id}`;
         },
@@ -683,7 +683,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         readonly parentId: string = '';
         readonly parentKey: string = '';
       }
-      class ChildEntity extends schema.Entity(Child) {
+      class ChildEntity extends EntityMixin(Child) {
         static process(input: any, parent: any, key: string | undefined): any {
           return {
             ...input,
@@ -697,7 +697,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         readonly content: string = '';
         readonly child: ChildEntity = ChildEntity.fromJS({});
       }
-      const ParentEntity = schema.Entity(Parent, {
+      const ParentEntity = EntityMixin(Parent, {
         schema: { child: ChildEntity },
       });
 
@@ -714,7 +714,7 @@ describe(`${schema.Entity.name} normalization`, () => {
     });
 
     describe('schema denormalization', () => {
-      class AttachmentsEntity extends schema.Entity(
+      class AttachmentsEntity extends EntityMixin(
         class {
           id = '';
         },
@@ -725,7 +725,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         readonly type: string = '';
         data = { attachment: undefined };
       }
-      class EntriesEntity extends schema.Entity(Entries) {
+      class EntriesEntity extends EntityMixin(Entries) {
         static schema = {
           data: { attachment: AttachmentsEntity },
         };
@@ -737,7 +737,7 @@ describe(`${schema.Entity.name} normalization`, () => {
           };
         }
       }
-      class EntriesEntity2 extends schema.Entity(Entries, {
+      class EntriesEntity2 extends EntityMixin(Entries, {
         schema: {
           data: { attachment: AttachmentsEntity },
         },
@@ -777,7 +777,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
     expect(denormalize(Tacos, '1', fromJS(entities))).toMatchSnapshot();
   });
 
-  class Food extends schema.Entity(
+  class Food extends EntityMixin(
     class {
       id = '';
     },
@@ -786,7 +786,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
     id = '';
     readonly food: Food = Food.fromJS();
   }
-  class Menu extends schema.Entity(MenuData, { schema: { food: Food } }) {}
+  class Menu extends EntityMixin(MenuData, { schema: { food: Food } }) {}
 
   test('denormalizes deep entities', () => {
     const entities = {
@@ -870,7 +870,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
       readonly secondthing: string = '';
       readonly blarb: Date | undefined = undefined;
     }
-    class MyEntity extends schema.Entity(MyData, {
+    class MyEntity extends EntityMixin(MyData, {
       pk: 'name',
       schema: { blarb: Temporal.Instant.from },
     }) {}
@@ -894,7 +894,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
       readonly secondthing: string = '';
       readonly blarb: Date | null = null;
     }
-    class MyEntity extends schema.Entity(MyData, {
+    class MyEntity extends EntityMixin(MyData, {
       pk: 'name',
       schema: { blarb: Temporal.Instant.from },
     }) {}
@@ -976,14 +976,14 @@ describe(`${schema.Entity.name} denormalization`, () => {
       readonly role = '';
       readonly reports: Report[] = [];
     }
-    class User extends schema.Entity(UserData) {}
+    class User extends EntityMixin(UserData) {}
     class ReportData {
       id = '';
       readonly title: string = '';
       readonly draftedBy: User = User.fromJS();
       readonly publishedBy: User = User.fromJS();
     }
-    class Report extends schema.Entity(ReportData, {
+    class Report extends EntityMixin(ReportData, {
       schema: {
         draftedBy: User,
         publishedBy: User,
@@ -997,7 +997,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
       readonly body: string = '';
       readonly author: User = User.fromJS();
     }
-    class Comment extends schema.Entity(CommentData, {
+    class Comment extends EntityMixin(CommentData, {
       schema: { author: User },
     }) {}
 
@@ -1290,7 +1290,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
 
 describe('Entity.defaults', () => {
   it('should work with inheritance', () => {
-    abstract class DefaultsEntity extends schema.Entity(
+    abstract class DefaultsEntity extends EntityMixin(
       class {
         id = '';
       },

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -112,7 +112,7 @@ return <ReviewForm onSubmit={data => controller.fetch(createReview, data)} />;
 <tbody><tr>
 <td rowSpan="4"><a href="https://en.wikipedia.org/wiki/Object_(computer_science)">Object</a></td>
 <td align="center">✅</td>
-<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/schema.Entity">schema.Entity</a> mixin, <a href="https://dataclient.io/graphql/api/GQLEntity">GQLEntity</a></td>
+<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/EntityMixin">EntityMixin</a> mixin, <a href="https://dataclient.io/graphql/api/GQLEntity">GQLEntity</a></td>
 <td>single <em>unique</em> object</td>
 <td align="center">✅</td>
 </tr>

--- a/packages/normalizr/README.md
+++ b/packages/normalizr/README.md
@@ -244,7 +244,7 @@ Available from [@data-client/endpoint](https://www.npmjs.com/package/@data-clien
 <tbody><tr>
 <td rowSpan="4"><a href="https://en.wikipedia.org/wiki/Object_(computer_science)">Object</a></td>
 <td align="center">✅</td>
-<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/schema.Entity">schema.Entity</a> mixin</td>
+<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/EntityMixin">EntityMixin</a> mixin</td>
 <td>single <em>unique</em> object</td>
 <td align="center">✅</td>
 </tr>

--- a/packages/normalizr/docs/api.md
+++ b/packages/normalizr/docs/api.md
@@ -25,7 +25,7 @@ import { normalize } from '@data-client/normalizr';
 
 const myData = { users: [{ id: 1 }, { id: 2 }] };
 class User { id = 0 }
-const userSchema = new schema.Entity(User);
+const userSchema = new schema.EntityMixin(User);
 const mySchema = { users: [userSchema] };
 const normalizedData = normalize(mySchema, myData);
 ```
@@ -61,7 +61,7 @@ import { schema } from '@data-client/endpoint';
 import { denormalize } from '@data-client/normalizr';
 
 class User { id = 0 }
-const userSchema = new schema.Entity(User);
+const userSchema = new schema.EntityMixin(User);
 const mySchema = { users: [userSchema] };
 const entities = { User: { '1': { id: 1 }, '2': { id: 2 } } };
 const denormalizedData = denormalize(mySchema, { users: [1, 2] }, entities);
@@ -179,7 +179,7 @@ To describe a simple array of a singular entity type:
 import { schema } from '@data-client/endpoint';
 
 const data = [{ id: '123', name: 'Jim' }, { id: '456', name: 'Jane' }];
-const userSchema = new schema.Entity(class User {id='';name='';});
+const userSchema = new schema.EntityMixin(class User {id='';name='';});
 
 const userListSchema = new schema.Array(userSchema);
 // or use shorthand syntax:
@@ -213,8 +213,8 @@ import { schema } from '@data-client/endpoint';
 
 const data = [{ id: 1, type: 'admin' }, { id: 2, type: 'user' }];
 
-const userSchema = new schema.Entity(class User {id='';type='user';});
-const adminSchema = new schema.Entity(class Admin {id='';type='admin';});
+const userSchema = new schema.EntityMixin(class User {id='';type='user';});
+const adminSchema = new schema.EntityMixin(class Admin {id='';type='admin';});
 const myArray = new schema.Array(
   {
     admins: adminSchema,

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -175,7 +175,7 @@ supports inferring argument types from the path templates.
 <tbody><tr>
 <td rowSpan="4"><a href="https://en.wikipedia.org/wiki/Object_(computer_science)">Object</a></td>
 <td align="center">✅</td>
-<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/schema.Entity">schema.Entity</a> mixin</td>
+<td><a href="https://dataclient.io/rest/api/Entity">Entity</a>, <a href="https://dataclient.io/rest/api/EntityMixin">EntityMixin</a> mixin</td>
 <td>single <em>unique</em> object</td>
 <td align="center">✅</td>
 </tr>

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -348,6 +348,10 @@ const config: Config = {
             to: '/docs/getting-started/debugging',
             from: ['/docs/guides/debugging'],
           },
+          {
+            to: '/rest/api/EntityMixin',
+            from: ['/rest/api/schema.Entity'],
+          },
           ...gqlRedirects,
         ],
       },

--- a/website/sidebars-endpoint.json
+++ b/website/sidebars-endpoint.json
@@ -13,7 +13,7 @@
   },
   {
     "type": "doc",
-    "id": "api/schema.Entity"
+    "id": "api/EntityMixin"
   },
   {
     "type": "doc",

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -289,6 +289,10 @@ declare let Endpoint: EndpointConstructor;
 
 declare let ExtendableEndpoint: ExtendableEndpointConstructor;
 
+/**
+ * Entity defines a single (globally) unique object.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
 interface IEntityClass<TBase extends Constructor = any> {
     toJSON(): {
         name: string;
@@ -326,7 +330,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
+     * @see https://dataclient.io/docs/api/Entity#shouldUpdate
      */
     shouldUpdate(existingMeta: {
         date: number;
@@ -337,7 +341,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Determines the order of incoming entity vs entity already in store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldReorder
+     * @see https://dataclient.io/docs/api/Entity#shouldReorder
      * @returns true if incoming entity should be first argument of merge()
      */
     shouldReorder(existingMeta: {
@@ -349,12 +353,12 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Creates new instance copying over defined values of arguments
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#merge
+     * @see https://dataclient.io/docs/api/Entity#merge
      */
     merge(existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -365,7 +369,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeMetaWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeMetaWithStore
      */
     mergeMetaWithStore(existingMeta: {
         expiresAt: number;
@@ -441,6 +445,14 @@ type EntityOptions<TInstance extends {}> = {
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
 }
+
+/**
+ * Turns any class into an Entity.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
+declare function EntityMixin<TBase extends PKClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase;
+declare function EntityMixin<TBase extends IDClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+declare function EntityMixin<TBase extends Constructor>(Base: TBase, opt: RequiredPKOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
 
 /**
  * Marks entity as Invalid.
@@ -582,7 +594,7 @@ interface CollectionInterface<S extends PolymorphicInterface = any, Args extends
     }, existing: any, incoming: any): boolean;
     /** Run when an existing Collection is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Collection#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -1010,27 +1022,6 @@ declare class Collection<
   Parent = any,
 > extends CollectionRoot<S, Args, Parent> {}
 
-/**
- * Entity defines a single (globally) unique object.
- * @see https://dataclient.io/rest/api/schema.Entity
- */
-declare function Entity$1<TBase extends PKClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase;
-
-// id is in Instance, so we default to that as pk
-declare function Entity$1<TBase extends IDClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-// pk was specified in options, so we don't need to redefine
-declare function Entity$1<TBase extends Constructor>(
-  Base: TBase,
-  opt: RequiredPKOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
 type schema_d_EntityMap<T = any> = EntityMap<T>;
 type schema_d_Invalidate<E extends EntityInterface & {
     process: any;
@@ -1040,6 +1031,7 @@ type schema_d_Query<S extends Queryable | {
     [k: string]: Queryable;
 }, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
 declare const schema_d_Query: typeof Query;
+declare const schema_d_EntityMixin: typeof EntityMixin;
 type schema_d_SchemaClass<T = any, Args extends readonly any[] = any> = SchemaClass<T, Args>;
 type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
 declare const schema_d_All: typeof All;
@@ -1073,6 +1065,8 @@ declare namespace schema_d {
     schema_d_EntityMap as EntityMap,
     schema_d_Invalidate as Invalidate,
     schema_d_Query as Query,
+    schema_d_EntityMixin as EntityMixin,
+    EntityMixin as Entity,
     schema_d_SchemaClass as SchemaClass,
     Array$1 as Array,
     schema_d_All as All,
@@ -1085,7 +1079,6 @@ declare namespace schema_d {
     schema_d_CollectionArrayAdder as CollectionArrayAdder,
     schema_d_CollectionRoot as CollectionRoot,
     schema_d_Collection as Collection,
-    Entity$1 as Entity,
     schema_d_EntityInterface as EntityInterface,
     schema_d_CollectionInterface as CollectionInterface,
     schema_d_CollectionFromSchema as CollectionFromSchema,
@@ -1149,4 +1142,4 @@ declare const INVALID: unique symbol;
 /** https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type */
 type NI<T> = NoInfer<T>;
 
-export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, EntityMixin, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -289,6 +289,10 @@ declare let Endpoint: EndpointConstructor;
 
 declare let ExtendableEndpoint: ExtendableEndpointConstructor;
 
+/**
+ * Entity defines a single (globally) unique object.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
 interface IEntityClass<TBase extends Constructor = any> {
     toJSON(): {
         name: string;
@@ -326,7 +330,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
+     * @see https://dataclient.io/docs/api/Entity#shouldUpdate
      */
     shouldUpdate(existingMeta: {
         date: number;
@@ -337,7 +341,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Determines the order of incoming entity vs entity already in store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldReorder
+     * @see https://dataclient.io/docs/api/Entity#shouldReorder
      * @returns true if incoming entity should be first argument of merge()
      */
     shouldReorder(existingMeta: {
@@ -349,12 +353,12 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Creates new instance copying over defined values of arguments
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#merge
+     * @see https://dataclient.io/docs/api/Entity#merge
      */
     merge(existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -365,7 +369,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeMetaWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeMetaWithStore
      */
     mergeMetaWithStore(existingMeta: {
         expiresAt: number;
@@ -441,6 +445,14 @@ type EntityOptions<TInstance extends {}> = {
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
 }
+
+/**
+ * Turns any class into an Entity.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
+declare function EntityMixin<TBase extends PKClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase;
+declare function EntityMixin<TBase extends IDClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+declare function EntityMixin<TBase extends Constructor>(Base: TBase, opt: RequiredPKOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
 
 /**
  * Marks entity as Invalid.
@@ -582,7 +594,7 @@ interface CollectionInterface<S extends PolymorphicInterface = any, Args extends
     }, existing: any, incoming: any): boolean;
     /** Run when an existing Collection is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Collection#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -1010,27 +1022,6 @@ declare class Collection<
   Parent = any,
 > extends CollectionRoot<S, Args, Parent> {}
 
-/**
- * Entity defines a single (globally) unique object.
- * @see https://dataclient.io/rest/api/schema.Entity
- */
-declare function Entity$1<TBase extends PKClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase;
-
-// id is in Instance, so we default to that as pk
-declare function Entity$1<TBase extends IDClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-// pk was specified in options, so we don't need to redefine
-declare function Entity$1<TBase extends Constructor>(
-  Base: TBase,
-  opt: RequiredPKOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
 type schema_d_EntityMap<T = any> = EntityMap<T>;
 type schema_d_Invalidate<E extends EntityInterface & {
     process: any;
@@ -1040,6 +1031,7 @@ type schema_d_Query<S extends Queryable | {
     [k: string]: Queryable;
 }, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
 declare const schema_d_Query: typeof Query;
+declare const schema_d_EntityMixin: typeof EntityMixin;
 type schema_d_SchemaClass<T = any, Args extends readonly any[] = any> = SchemaClass<T, Args>;
 type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
 declare const schema_d_All: typeof All;
@@ -1073,6 +1065,8 @@ declare namespace schema_d {
     schema_d_EntityMap as EntityMap,
     schema_d_Invalidate as Invalidate,
     schema_d_Query as Query,
+    schema_d_EntityMixin as EntityMixin,
+    EntityMixin as Entity,
     schema_d_SchemaClass as SchemaClass,
     Array$1 as Array,
     schema_d_All as All,
@@ -1085,7 +1079,6 @@ declare namespace schema_d {
     schema_d_CollectionArrayAdder as CollectionArrayAdder,
     schema_d_CollectionRoot as CollectionRoot,
     schema_d_Collection as Collection,
-    Entity$1 as Entity,
     schema_d_EntityInterface as EntityInterface,
     schema_d_CollectionInterface as CollectionInterface,
     schema_d_CollectionFromSchema as CollectionFromSchema,
@@ -1190,4 +1183,4 @@ interface GQLError {
     path: (string | number)[];
 }
 
-export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };
+export { AbstractInstanceType, Array$1 as Array, Collection, DefaultArgs, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, EntityMixin, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, FetchFunction, GQLEndpoint, GQLEntity, GQLError, GQLNetworkError, GQLOptions, INVALID, Invalidate, KeyofEndpointInstance, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Schema, SchemaArgs, SchemaClass, SchemaSimple, SnapshotInterface, UnknownError, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -287,6 +287,10 @@ declare let Endpoint: EndpointConstructor;
 
 declare let ExtendableEndpoint: ExtendableEndpointConstructor;
 
+/**
+ * Entity defines a single (globally) unique object.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
 interface IEntityClass<TBase extends Constructor = any> {
     toJSON(): {
         name: string;
@@ -324,7 +328,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
+     * @see https://dataclient.io/docs/api/Entity#shouldUpdate
      */
     shouldUpdate(existingMeta: {
         date: number;
@@ -335,7 +339,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Determines the order of incoming entity vs entity already in store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldReorder
+     * @see https://dataclient.io/docs/api/Entity#shouldReorder
      * @returns true if incoming entity should be first argument of merge()
      */
     shouldReorder(existingMeta: {
@@ -347,12 +351,12 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Creates new instance copying over defined values of arguments
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#merge
+     * @see https://dataclient.io/docs/api/Entity#merge
      */
     merge(existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -363,7 +367,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeMetaWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeMetaWithStore
      */
     mergeMetaWithStore(existingMeta: {
         expiresAt: number;
@@ -439,6 +443,14 @@ type EntityOptions<TInstance extends {}> = {
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
 }
+
+/**
+ * Turns any class into an Entity.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
+declare function EntityMixin<TBase extends PKClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase;
+declare function EntityMixin<TBase extends IDClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+declare function EntityMixin<TBase extends Constructor>(Base: TBase, opt: RequiredPKOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
 
 /**
  * Marks entity as Invalid.
@@ -580,7 +592,7 @@ interface CollectionInterface<S extends PolymorphicInterface = any, Args extends
     }, existing: any, incoming: any): boolean;
     /** Run when an existing Collection is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Collection#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -1008,27 +1020,6 @@ declare class Collection<
   Parent = any,
 > extends CollectionRoot<S, Args, Parent> {}
 
-/**
- * Entity defines a single (globally) unique object.
- * @see https://dataclient.io/rest/api/schema.Entity
- */
-declare function Entity$1<TBase extends PKClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase;
-
-// id is in Instance, so we default to that as pk
-declare function Entity$1<TBase extends IDClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-// pk was specified in options, so we don't need to redefine
-declare function Entity$1<TBase extends Constructor>(
-  Base: TBase,
-  opt: RequiredPKOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
 type schema_d_EntityMap<T = any> = EntityMap<T>;
 type schema_d_Invalidate<E extends EntityInterface & {
     process: any;
@@ -1038,6 +1029,7 @@ type schema_d_Query<S extends Queryable | {
     [k: string]: Queryable;
 }, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
 declare const schema_d_Query: typeof Query;
+declare const schema_d_EntityMixin: typeof EntityMixin;
 type schema_d_SchemaClass<T = any, Args extends readonly any[] = any> = SchemaClass<T, Args>;
 type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
 declare const schema_d_All: typeof All;
@@ -1071,6 +1063,8 @@ declare namespace schema_d {
     schema_d_EntityMap as EntityMap,
     schema_d_Invalidate as Invalidate,
     schema_d_Query as Query,
+    schema_d_EntityMixin as EntityMixin,
+    EntityMixin as Entity,
     schema_d_SchemaClass as SchemaClass,
     Array$1 as Array,
     schema_d_All as All,
@@ -1083,7 +1077,6 @@ declare namespace schema_d {
     schema_d_CollectionArrayAdder as CollectionArrayAdder,
     schema_d_CollectionRoot as CollectionRoot,
     schema_d_Collection as Collection,
-    Entity$1 as Entity,
     schema_d_EntityInterface as EntityInterface,
     schema_d_CollectionInterface as CollectionInterface,
     schema_d_CollectionFromSchema as CollectionFromSchema,
@@ -1748,4 +1741,4 @@ declare class NetworkError extends Error {
     constructor(response: Response);
 }
 
-export { AbstractInstanceType, AddEndpoint, Array$1 as Array, Collection, CustomResource, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceInterface, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };
+export { AbstractInstanceType, AddEndpoint, Array$1 as Array, Collection, CustomResource, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, EntityMixin, ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceInterface, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -291,6 +291,10 @@ declare let Endpoint: EndpointConstructor;
 
 declare let ExtendableEndpoint: ExtendableEndpointConstructor;
 
+/**
+ * Entity defines a single (globally) unique object.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
 interface IEntityClass<TBase extends Constructor = any> {
     toJSON(): {
         name: string;
@@ -328,7 +332,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     pk<T extends (abstract new (...args: any[]) => IEntityInstance & InstanceType<TBase>) & IEntityClass & TBase>(this: T, value: Partial<AbstractInstanceType<T>>, parent?: any, key?: string, args?: any[]): string | number | undefined;
     /** Return true to merge incoming data; false keeps existing entity
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldUpdate
+     * @see https://dataclient.io/docs/api/Entity#shouldUpdate
      */
     shouldUpdate(existingMeta: {
         date: number;
@@ -339,7 +343,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Determines the order of incoming entity vs entity already in store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#shouldReorder
+     * @see https://dataclient.io/docs/api/Entity#shouldReorder
      * @returns true if incoming entity should be first argument of merge()
      */
     shouldReorder(existingMeta: {
@@ -351,12 +355,12 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): boolean;
     /** Creates new instance copying over defined values of arguments
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#merge
+     * @see https://dataclient.io/docs/api/Entity#merge
      */
     merge(existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -367,7 +371,7 @@ interface IEntityClass<TBase extends Constructor = any> {
     }, existing: any, incoming: any): any;
     /** Run when an existing entity is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeMetaWithStore
+     * @see https://dataclient.io/docs/api/Entity#mergeMetaWithStore
      */
     mergeMetaWithStore(existingMeta: {
         expiresAt: number;
@@ -443,6 +447,14 @@ type EntityOptions<TInstance extends {}> = {
 interface RequiredPKOptions<TInstance extends {}> extends EntityOptions<TInstance> {
     readonly pk: ((value: TInstance, parent?: any, key?: string) => string | number | undefined) | keyof TInstance;
 }
+
+/**
+ * Turns any class into an Entity.
+ * @see https://dataclient.io/rest/api/EntityMixin
+ */
+declare function EntityMixin<TBase extends PKClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase;
+declare function EntityMixin<TBase extends IDClass>(Base: TBase, opt?: EntityOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
+declare function EntityMixin<TBase extends Constructor>(Base: TBase, opt: RequiredPKOptions<InstanceType<TBase>>): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
 
 /**
  * Marks entity as Invalid.
@@ -584,7 +596,7 @@ interface CollectionInterface<S extends PolymorphicInterface = any, Args extends
     }, existing: any, incoming: any): boolean;
     /** Run when an existing Collection is found in the store
      *
-     * @see https://dataclient.io/docs/api/schema.Entity#mergeWithStore
+     * @see https://dataclient.io/docs/api/Collection#mergeWithStore
      */
     mergeWithStore(existingMeta: {
         date: number;
@@ -1012,27 +1024,6 @@ declare class Collection<
   Parent = any,
 > extends CollectionRoot<S, Args, Parent> {}
 
-/**
- * Entity defines a single (globally) unique object.
- * @see https://dataclient.io/rest/api/schema.Entity
- */
-declare function Entity$1<TBase extends PKClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase;
-
-// id is in Instance, so we default to that as pk
-declare function Entity$1<TBase extends IDClass>(
-  Base: TBase,
-  opt?: EntityOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
-// pk was specified in options, so we don't need to redefine
-declare function Entity$1<TBase extends Constructor>(
-  Base: TBase,
-  opt: RequiredPKOptions<InstanceType<TBase>>,
-): IEntityClass<TBase> & TBase & (new (...args: any[]) => IEntityInstance);
-
 type schema_d_EntityMap<T = any> = EntityMap<T>;
 type schema_d_Invalidate<E extends EntityInterface & {
     process: any;
@@ -1042,6 +1033,7 @@ type schema_d_Query<S extends Queryable | {
     [k: string]: Queryable;
 }, P extends (entries: Denormalize<S>, ...args: any) => any> = Query<S, P>;
 declare const schema_d_Query: typeof Query;
+declare const schema_d_EntityMixin: typeof EntityMixin;
 type schema_d_SchemaClass<T = any, Args extends readonly any[] = any> = SchemaClass<T, Args>;
 type schema_d_All<S extends EntityMap | EntityInterface = EntityMap | EntityInterface> = All<S>;
 declare const schema_d_All: typeof All;
@@ -1075,6 +1067,8 @@ declare namespace schema_d {
     schema_d_EntityMap as EntityMap,
     schema_d_Invalidate as Invalidate,
     schema_d_Query as Query,
+    schema_d_EntityMixin as EntityMixin,
+    EntityMixin as Entity,
     schema_d_SchemaClass as SchemaClass,
     Array$1 as Array,
     schema_d_All as All,
@@ -1087,7 +1081,6 @@ declare namespace schema_d {
     schema_d_CollectionArrayAdder as CollectionArrayAdder,
     schema_d_CollectionRoot as CollectionRoot,
     schema_d_Collection as Collection,
-    Entity$1 as Entity,
     schema_d_EntityInterface as EntityInterface,
     schema_d_CollectionInterface as CollectionInterface,
     schema_d_CollectionFromSchema as CollectionFromSchema,
@@ -1927,4 +1920,4 @@ declare function useController(): Controller;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
 
-export { AbstractInstanceType, AddEndpoint, Array$1 as Array, _default as AsyncBoundary, Collection, CustomResource, DataProvider, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, ErrorTypes$1 as ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceInterface, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };
+export { AbstractInstanceType, AddEndpoint, Array$1 as Array, _default as AsyncBoundary, Collection, CustomResource, DataProvider, DefaultArgs, Defaults, Denormalize, DenormalizeNullable, DenormalizeNullableObject, DenormalizeObject, Endpoint, EndpointExtendOptions, EndpointExtraOptions, EndpointInstance, EndpointInstanceInterface, EndpointInterface, EndpointOptions, EndpointParam, EndpointToFunction, Entity, EntityFields, EntityMap, EntityMixin, ErrorTypes$1 as ErrorTypes, ExpiryStatusInterface, ExtendableEndpoint, ExtendedResource, FetchFunction, FetchGet, FetchMutate, FromFallBack, GetEndpoint, HookResource, HookableEndpointInterface, INVALID, RestEndpoint$1 as IRestEndpoint, Invalidate, KeyofEndpointInstance, KeyofRestEndpoint, KeysToArgs, MethodToSide, MutateEndpoint, NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, Normalize, NormalizeNullable, NormalizeObject, NormalizedEntity, NormalizedNullableObject, ObjectArgs, OptionsToFunction, PaginationEndpoint, PaginationFieldEndpoint, ParamFetchNoBody, ParamFetchWithBody, ParamToArgs, PartialRestGenerics, PathArgs, PathArgsAndSearch, PathKeys, PolymorphicInterface, Queryable, ReadEndpoint, RecordClass, ResolveType, Resource, ResourceEndpointExtensions, ResourceExtension, ResourceGenerics, ResourceInterface, ResourceOptions, RestEndpoint, RestEndpointConstructor, RestEndpointConstructorOptions, RestEndpointExtendOptions, RestEndpointOptions, RestExtendedEndpoint, RestFetch, RestGenerics, RestInstance, RestInstanceBase, RestType, RestTypeNoBody, RestTypeWithBody, Schema, SchemaArgs, SchemaClass, SchemaSimple, ShortenPath, SnapshotInterface, UnknownError, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Clearer naming

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`schema.Entity` -> [EntityMixin](https://dataclient.io/rest/api/EntityMixin)

```ts
import { EntityMixin } from '@data-client/rest';

export class Article {
  id = '';
  title = '';
  content = '';
  tags: string[] = [];
}

export class ArticleEntity extends EntityMixin(Article) {}
```

We keep `schema.Entity` for legacy, and add schema.EntityMixin and [EntityMixin](https://dataclient.io/rest/api/EntityMixin) as direct export