### PR TITLE
fix: Collections work with nested args

### DIFF
--- a/.changeset/dirty-lamps-raise.md
+++ b/.changeset/dirty-lamps-raise.md
@@ -1,0 +1,9 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+---
+
+Collections work with nested args
+
+This fixes [integration with qs library](https://dataclient.io/rest/api/RestEndpoint#using-qs-library) and more complex search parameters.

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -136,7 +136,7 @@ export default class CollectionSchema<
     const obj =
       this.argsKey ? this.argsKey(...args) : this.nestKey(parent, key);
     for (const key in obj) {
-      if (typeof obj[key] !== 'string' && obj[key] !== undefined)
+      if (['number', 'boolean'].includes(typeof obj[key]))
         obj[key] = `${obj[key]}`;
     }
     return consistentSerialize(obj);

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -1,7 +1,7 @@
 // eslint-env jest
-import { initialState, State } from '@data-client/core';
+import { initialState } from '@data-client/core';
 import { normalize, denormalize, MemoCache } from '@data-client/normalizr';
-import { IDEntity } from '__tests__/new';
+import { ArticleResource, IDEntity } from '__tests__/new';
 import { Record } from 'immutable';
 
 import SimpleMemoCache from './denormalize';
@@ -12,7 +12,7 @@ import PolymorphicSchema from '../Polymorphic';
 let dateSpy: jest.SpyInstance;
 beforeAll(() => {
   dateSpy = jest
-    // eslint-disable-next-line no-undef
+
     .spyOn(global.Date, 'now')
     .mockImplementation(() => new Date('2019-05-14T11:01:58.135Z').valueOf());
 });
@@ -669,5 +669,24 @@ describe(`${schema.Collection.name} denormalization`, () => {
       {},
     );
     expect(queryKey).toBeUndefined();
+  });
+
+  it('pk should serialize differently with nested args', () => {
+    const filtersA = {
+      search: {
+        type: 'Coupon',
+      },
+    };
+    const filtersB = {
+      search: {
+        type: 'Cashback',
+      },
+    };
+
+    expect(
+      ArticleResource.getList.schema.pk([], undefined, '', [filtersA]),
+    ).not.toEqual(
+      ArticleResource.getList.schema.pk([], undefined, '', [filtersB]),
+    );
   });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -189,7 +189,9 @@
     "@anansi/browserslist-config": "^1.4.2",
     "@react-navigation/native": "^7.0.0",
     "@types/node": "^22.0.0",
+    "@types/qs": "^6",
     "@types/react": "^18.0.30",
+    "qs": "^6.13.1",
     "react-native": "^0.76.0"
   }
 }

--- a/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
+++ b/packages/react/src/__tests__/__snapshots__/integration-collections.tsx.snap
@@ -200,6 +200,32 @@ exports[`CacheProvider RestEndpoint/current should update on get for a paginated
 }
 `;
 
+exports[`CacheProvider RestEndpoint/current should update on get for nested args change 1`] = `
+[
+  Offer {
+    "id": "5",
+    "text": "hi",
+  },
+  Offer {
+    "id": "2",
+    "text": "next",
+  },
+]
+`;
+
+exports[`CacheProvider RestEndpoint/current should update on get for nested args change 2`] = `
+[
+  Offer {
+    "id": "10",
+    "text": "second",
+  },
+  Offer {
+    "id": "11",
+    "text": "page",
+  },
+]
+`;
+
 exports[`CacheProvider RestEndpoint/next endpoint.assign should add to schema.Values Collections 1`] = `
 Article {
   "author": null,
@@ -398,6 +424,32 @@ exports[`CacheProvider RestEndpoint/next should update on get for a paginated re
     },
   ],
 }
+`;
+
+exports[`CacheProvider RestEndpoint/next should update on get for nested args change 1`] = `
+[
+  Offer {
+    "id": "5",
+    "text": "hi",
+  },
+  Offer {
+    "id": "2",
+    "text": "next",
+  },
+]
+`;
+
+exports[`CacheProvider RestEndpoint/next should update on get for nested args change 2`] = `
+[
+  Offer {
+    "id": "10",
+    "text": "second",
+  },
+  Offer {
+    "id": "11",
+    "text": "page",
+  },
+]
 `;
 
 exports[`CacheProvider pagination should ignore undefined values 1`] = `
@@ -759,6 +811,32 @@ exports[`ExternalDataProvider RestEndpoint/current should update on get for a pa
 }
 `;
 
+exports[`ExternalDataProvider RestEndpoint/current should update on get for nested args change 1`] = `
+[
+  Offer {
+    "id": "5",
+    "text": "hi",
+  },
+  Offer {
+    "id": "2",
+    "text": "next",
+  },
+]
+`;
+
+exports[`ExternalDataProvider RestEndpoint/current should update on get for nested args change 2`] = `
+[
+  Offer {
+    "id": "10",
+    "text": "second",
+  },
+  Offer {
+    "id": "11",
+    "text": "page",
+  },
+]
+`;
+
 exports[`ExternalDataProvider RestEndpoint/next endpoint.assign should add to schema.Values Collections 1`] = `
 Article {
   "author": null,
@@ -957,6 +1035,32 @@ exports[`ExternalDataProvider RestEndpoint/next should update on get for a pagin
     },
   ],
 }
+`;
+
+exports[`ExternalDataProvider RestEndpoint/next should update on get for nested args change 1`] = `
+[
+  Offer {
+    "id": "5",
+    "text": "hi",
+  },
+  Offer {
+    "id": "2",
+    "text": "next",
+  },
+]
+`;
+
+exports[`ExternalDataProvider RestEndpoint/next should update on get for nested args change 2`] = `
+[
+  Offer {
+    "id": "10",
+    "text": "second",
+  },
+  Offer {
+    "id": "11",
+    "text": "page",
+  },
+]
 `;
 
 exports[`ExternalDataProvider pagination should ignore undefined values 1`] = `

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,7 +3189,9 @@ __metadata:
     "@data-client/use-enhanced-reducer": "npm:^0.1.10"
     "@react-navigation/native": "npm:^7.0.0"
     "@types/node": "npm:^22.0.0"
+    "@types/qs": "npm:^6"
     "@types/react": "npm:^18.0.30"
+    qs: "npm:^6.13.1"
     react-native: "npm:^0.76.0"
   peerDependencies:
     "@react-navigation/native": ^6.0.0 || ^7.0.0
@@ -7488,6 +7490,13 @@ __metadata:
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 10c0/157eb05f4c75790b0ebdcf7b0547ff117feabc8cda03c3cac3d3ea82bb19a1912e76a411df3eb0bdd01026a9770f07bc0e7e3fbe39ebb31c1be4564c16be35f1
+  languageName: node
+  linkType: hard
+
+"@types/qs@npm:^6":
+  version: 6.9.17
+  resolution: "@types/qs@npm:6.9.17"
+  checksum: 10c0/a183fa0b3464267f8f421e2d66d960815080e8aab12b9aadab60479ba84183b1cdba8f4eff3c06f76675a8e42fe6a3b1313ea76c74f2885c3e25d32499c17d1b
   languageName: node
   linkType: hard
 
@@ -25016,12 +25025,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.13.0, qs@npm:^6.12.3":
+"qs@npm:6.13.0":
   version: 6.13.0
   resolution: "qs@npm:6.13.0"
   dependencies:
     side-channel: "npm:^1.0.6"
   checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.12.3, qs@npm:^6.13.1":
+  version: 6.13.1
+  resolution: "qs@npm:6.13.1"
+  dependencies:
+    side-channel: "npm:^1.0.6"
+  checksum: 10c0/5ef527c0d62ffca5501322f0832d800ddc78eeb00da3b906f1b260ca0492721f8cdc13ee4b8fd8ac314a6ec37b948798c7b603ccc167e954088df392092f160c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #3280 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Handle nested object args when using Collections.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Stop strinigfying all values in Collection.pk() - only do this for number and booleans.

Originally this was added in https://github.com/reactive/data-client/commit/ca249b5dda2ae40f5aca0777d560b4218608705d#diff-92c9afa78291c2d6c55ee59b03d774c70f8ff00d4a93120c494d6f5498b50b59R107 to normalize serialization even when strings are substituted for numbers, etc. However, this doesn't make sense for other types like objects.