### PR TITLE
internal: Run full typescript tests again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,13 +87,12 @@ jobs:
 
   typecheck:
     executor: node
-    resource_class: small
     steps:
       - attach_workspace:
           at: ~/
       - run:
           command: |
-            yarn workspaces foreach -A --include @data-client/endpoint --include @data-client/rest run typecheck
+            yarn run tsc --project tsconfig.test.json --noEmit
 
   unit_tests:
     parameters:
@@ -117,7 +116,7 @@ jobs:
           name: Running Jest
           command: |
             if [ "<< parameters.react-version >>" == "^17.0.0" ]; then
-              ANANSI_JEST_TYPECHECK=false yarn test:ci --maxWorkers=3 --selectProjects ReactDOM ReactNative --testPathPattern packages/react packages/use-enhanced-reducer packages/img
+              yarn test:ci --maxWorkers=3 --selectProjects ReactDOM ReactNative --testPathPattern packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "^18" ]; then
               curl -Os https://uploader.codecov.io/latest/linux/codecov;
               chmod +x codecov;

--- a/examples/coin-app/package.json
+++ b/examples/coin-app/package.json
@@ -36,7 +36,7 @@
     "@types/react": "*",
     "@types/react-dom": "*",
     "react-refresh": "*",
-    "typescript": "^5.4.5",
+    "typescript": "5.6",
     "webpack": "*",
     "webpack-cli": "*"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:copy:ambient": "mkdirp ./packages/endpoint/lib && copyfiles --flat ./packages/endpoint/src/schema.d.ts ./packages/endpoint/lib/ && copyfiles --flat ./packages/endpoint/src/endpoint.d.ts ./packages/endpoint/lib/ && mkdirp ./packages/rest/lib && copyfiles --flat ./packages/rest/src/RestEndpoint.d.ts ./packages/rest/lib && copyfiles --flat ./packages/rest/src/next/RestEndpoint.d.ts ./packages/rest/lib/next && mkdirp ./packages/react/lib && copyfiles --flat ./packages/react/src/server/redux/redux.d.ts ./packages/react/lib/server/redux",
     "copy:websitetypes": "./scripts/copywebsitetypes.sh",
     "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:ci": "yarn test --ci",
+    "test:ci": "ANANSI_JEST_TYPECHECK=false yarn test --ci",
     "test:coverage": "ANANSI_JEST_TYPECHECK=false yarn test --coverage",
     "prepare": "yarn build:copy:ambient && tsc --build",
     "prepack": "yarn prepare",
@@ -109,7 +109,7 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "10.9.2",
-    "typescript": "5.7.2",
+    "typescript": "5.6",
     "whatwg-fetch": "3.0.0"
   },
   "resolutions": {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
     "sourceMap": true,
     "noImplicitAny": false   // this is for normalizr
   },
-  "include": ["packages/*/src", "__tests__"]
+  "include": ["packages/*/src", "packages/*/typescript-tests", "__tests__"]
 }

--- a/website/package.json
+++ b/website/package.json
@@ -56,7 +56,7 @@
     "react-dom": "^19.0.0",
     "react-json-tree": "0.19.0",
     "react-live": "^4.0.0",
-    "typescript": "^5.5.2",
+    "typescript": "5.6",
     "uuid": "^11.0.0"
   },
   "browserslist": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11038,7 +11038,7 @@ __metadata:
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     react-refresh: "npm:*"
-    typescript: "npm:^5.4.5"
+    typescript: "npm:5.6"
     webpack: "npm:*"
     webpack-cli: "npm:*"
   languageName: unknown
@@ -25467,7 +25467,7 @@ __metadata:
     react-json-tree: "npm:0.19.0"
     react-live: "npm:^4.0.0"
     serve: "npm:14.2.4"
-    typescript: "npm:^5.5.2"
+    typescript: "npm:5.6"
     uuid: "npm:^11.0.0"
     webpack: "npm:^5.76.0"
   languageName: unknown
@@ -27065,7 +27065,7 @@ __metadata:
     rollup-plugin-replace: "npm:^2.2.0"
     rollup-plugin-terser: "npm:^7.0.2"
     ts-node: "npm:10.9.2"
-    typescript: "npm:5.7.2"
+    typescript: "npm:5.6"
     whatwg-fetch: "npm:3.0.0"
   languageName: unknown
   linkType: soft
@@ -29749,13 +29749,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.7.2, typescript@npm:^5.4.5, typescript@npm:^5.5.2":
-  version: 5.7.2
-  resolution: "typescript@npm:5.7.2"
+"typescript@npm:5.6":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/a873118b5201b2ef332127ef5c63fb9d9c155e6fdbe211cbd9d8e65877283797cca76546bad742eea36ed7efbe3424a30376818f79c7318512064e8625d61622
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
   languageName: node
   linkType: hard
 
@@ -29769,13 +29769,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.5.2#optional!builtin<compat/typescript>":
-  version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.6#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/f3b8082c9d1d1629a215245c9087df56cb784f9fb6f27b5d55577a20e68afe2a889c040aacff6d27e35be165ecf9dca66e694c42eb9a50b3b2c451b36b5675cb
+  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Ensure full type-test coverage
- Don't slow down CI by repeating typechecks over same files

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- No longer do typecheck in CI jest; extract to typecheck CI stage