### PR TITLE
enhance: Add react-native entry to package.json exports

### DIFF
--- a/.changeset/three-needles-brake.md
+++ b/.changeset/three-needles-brake.md
@@ -1,0 +1,11 @@
+---
+'@data-client/normalizr': patch
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/react': patch
+'@data-client/core': patch
+'@data-client/rest': patch
+'@data-client/test': patch
+---
+
+Add react-native entry to package.json exports

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,11 @@ const path = require('path');
 
 module.exports = function (api) {
   api.cache.using(
-    () => process.env.NODE_ENV + process.env.BROWSERSLIST_ENV + '0',
+    () =>
+      process.env.NODE_ENV +
+      process.env.BROWSERSLIST_ENV +
+      process.env.COMPILE_TARGET +
+      '0',
   );
   return {
     presets: [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,11 +37,15 @@
       "module": "./lib/index.js",
       "import": "./node.mjs",
       "require": "./dist/index.js",
+      "browser": "./lib/index.js",
+      "react-native": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./next": {
       "types": "./lib/next/index.d.ts",
       "require": "./dist/next.js",
+      "browser": "./lib/next/index.js",
+      "react-native": "./lib/next/index.js",
       "default": "./lib/next/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -83,6 +83,8 @@
       "module": "./lib/index.js",
       "import": "./node.mjs",
       "require": "./dist/index.js",
+      "browser": "./lib/index.js",
+      "react-native": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -69,6 +69,8 @@
       "module": "./lib/index.js",
       "import": "./node.mjs",
       "require": "./dist/index.js",
+      "browser": "./lib/index.js",
+      "react-native": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -68,6 +68,8 @@
       "module": "./lib/index.js",
       "import": "./node.mjs",
       "require": "./dist/normalizr.js",
+      "browser": "./lib/index.js",
+      "react-native": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -153,7 +153,7 @@
   "scripts": {
     "build:lib": "NODE_ENV=production BROWSERSLIST_ENV='2020' yarn g:babel --out-dir lib",
     "build:legacy:lib": "NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir legacy",
-    "build:native:lib": "COMPILE_TARGET=native NODE_ENV=production BROWSERSLIST_ENV='2018' yarn g:babel --out-dir native",
+    "build:native:lib": "COMPILE_TARGET=native NODE_ENV=production BROWSERSLIST_ENV='hermes12' yarn g:babel --out-dir native",
     "build:js:node": "BROWSERSLIST_ENV=node12 yarn g:rollup",
     "build:js:browser": "BROWSERSLIST_ENV=legacy yarn g:rollup",
     "build:bundle": "yarn g:runs build:js:\\* && echo '{\"type\":\"commonjs\"}' > dist/package.json",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -87,11 +87,15 @@
       "module": "./lib/index.js",
       "import": "./node.mjs",
       "require": "./dist/index.js",
+      "browser": "./lib/index.js",
+      "react-native": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./next": {
       "types": "./lib/next/index.d.ts",
       "require": "./dist/next.js",
+      "browser": "./lib/next/index.js",
+      "react-native": "./lib/next/index.js",
       "default": "./lib/next/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/test/.gitignore
+++ b/packages/test/.gitignore
@@ -1,3 +1,4 @@
 /lib
 /dist
 /legacy
+/native

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -71,6 +71,8 @@
       "module": "./lib/browser.js",
       "import": "./node.mjs",
       "require": "./dist/index.js",
+      "browser": "./lib/browser.js",
+      "react-native": "./native/browser.js",
       "default": "./lib/index.js"
     },
     "./browser": {
@@ -89,6 +91,7 @@
     "ts3.4",
     "node.mjs",
     "legacy",
+    "native",
     "LICENSE",
     "README.md"
   ],
@@ -96,13 +99,14 @@
     "build:lib": "run build:lib:esm && run build:lib:cjs",
     "build:lib:esm": "NODE_ENV=production BROWSERSLIST_ENV=2020 yarn g:babel-lite --out-dir lib --extensions '.ts,.tsx,.js'",
     "build:lib:cjs": "BROWSERSLIST_ENV=node12 BABEL_MODULES=cjs yarn g:babel-lite --out-dir lib --extensions '.cts' && mv ./lib/makeRenderDataClient/renderHook.js ./lib/makeRenderDataClient/renderHook.cjs && mv ./lib/makeRenderDataClient/use18.js ./lib/makeRenderDataClient/use18.cjs && mv ./lib/makeRenderDataClient/use18.native.js ./lib/makeRenderDataClient/use18.native.cjs",
+    "build:native:esm": "COMPILE_TARGET=native NODE_ENV=production BROWSERSLIST_ENV='hermes12' yarn g:babel --out-dir native --extensions '.ts,.tsx,.js'",
     "build:legacy:lib": "run build:legacy:lib:esm && run build:legacy:lib:cjs",
     "build:legacy:lib:esm": "NODE_ENV=production BROWSERSLIST_ENV=2018 yarn g:babel-lite --out-dir legacy --extensions '.ts,.tsx,.js'",
     "build:legacy:lib:cjs": "BABEL_MODULES=cjs BROWSERSLIST_ENV=2018 yarn g:babel-lite --out-dir legacy --extensions '.cts' && mv ./legacy/makeRenderDataClient/renderHook.js ./legacy/makeRenderDataClient/renderHook.cjs && mv ./legacy/makeRenderDataClient/use18.js ./legacy/makeRenderDataClient/use18.cjs && mv ./legacy/makeRenderDataClient/use18.native.js ./legacy/makeRenderDataClient/use18.native.cjs",
-    "build:bundle": "BROWSERSLIST_ENV=node12 yarn g:rollup && COMPILE_TARGET=native BROWSERSLIST_ENV=node12 yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
-    "build:clean": "yarn g:clean",
+    "build:bundle": "BROWSERSLIST_ENV=node12 yarn g:rollup && COMPILE_TARGET=native BROWSERSLIST_ENV=hermes12 yarn g:rollup && echo '{\"type\":\"commonjs\"}' > dist/package.json",
+    "build:clean": "yarn g:clean native",
     "build:legacy-types": "yarn g:downtypes lib ts3.4",
-    "build": "run build:lib && run build:legacy:lib && run build:bundle",
+    "build": "run build:lib && run build:legacy:lib && run build:native:esm && run build:bundle",
     "dev": "run build:lib:esm -w & run build:lib:cjs -w && fg",
     "prepare": "run build:lib",
     "prepack": "echo 'run prepack' && run prepare && run build:bundle && run build:legacy:lib"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Consolidate react native build and package.json across packages.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
exports support was added in 0.72, with hermes 0.12. Therefore we target hermes 0.12 for exports + react-native condition.
For "react-native" top-level entry in package.json we use legacy as to support older versions of react native.

For packages without a specific RN build, we simply use the 'lib' dir as that targets 2020, which is approximately the same as hermes 0.12. (though potentially with more legacy support). We do this simply to reduce package download size and build time.
