### PR TITLE
enhance: Add GC counting to useQuery()

### DIFF
--- a/.changeset/shaky-ties-hide.md
+++ b/.changeset/shaky-ties-hide.md
@@ -1,0 +1,5 @@
+---
+'@data-client/core': patch
+---
+
+Add Controller.getQueryMeta and Controller.getResponseMeta

--- a/.changeset/silver-paws-send.md
+++ b/.changeset/silver-paws-send.md
@@ -1,0 +1,5 @@
+---
+'@data-client/core': patch
+---
+
+Controller.snapshot() methods have stronger argument typing

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -452,6 +452,50 @@ export default class Controller<
     expiresAt: number;
     countRef: () => () => void;
   } {
+    // TODO: breaking: only return data
+    return this.getResponseMeta(endpoint, ...rest);
+  }
+
+  /**
+   * Gets the (globally referentially stable) response for a given endpoint/args pair from state given.
+   * @see https://dataclient.io/docs/api/Controller#getResponseMeta
+   */
+  getResponseMeta<E extends EndpointInterface>(
+    endpoint: E,
+    ...rest:
+      | readonly [null, State<unknown>]
+      | readonly [...Parameters<E>, State<unknown>]
+  ): {
+    data: DenormalizeNullable<E['schema']>;
+    expiryStatus: ExpiryStatus;
+    expiresAt: number;
+    countRef: () => () => void;
+  };
+
+  getResponseMeta<
+    E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
+  >(
+    endpoint: E,
+    ...rest: readonly [
+      ...(readonly [...Parameters<E['key']>] | readonly [null]),
+      State<unknown>,
+    ]
+  ): {
+    data: DenormalizeNullable<E['schema']>;
+    expiryStatus: ExpiryStatus;
+    expiresAt: number;
+    countRef: () => () => void;
+  };
+
+  getResponseMeta(
+    endpoint: EndpointInterface,
+    ...rest: readonly [...unknown[], State<unknown>]
+  ): {
+    data: unknown;
+    expiryStatus: ExpiryStatus;
+    expiresAt: number;
+    countRef: () => () => void;
+  } {
     const state = rest[rest.length - 1] as State<unknown>;
     // this is typescript generics breaking
     const args: any = rest
@@ -546,6 +590,52 @@ export default class Controller<
       .map(ensurePojo) as SchemaArgs<S>;
 
     return this.memo.query(schema, args, state.entities as any, state.indexes);
+  }
+
+  /**
+   * Queries the store for a Querable schema; providing related metadata
+   * @see https://dataclient.io/docs/api/Controller#getQueryMeta
+   */
+  getQueryMeta<S extends Queryable>(
+    schema: S,
+    ...rest: readonly [
+      ...SchemaArgs<S>,
+      Pick<State<unknown>, 'entities' | 'entityMeta'>,
+    ]
+  ): {
+    data: DenormalizeNullable<S> | undefined;
+    countRef: () => () => void;
+  } {
+    const state = rest[rest.length - 1] as State<any>;
+    // this is typescript generics breaking
+    const args: any = rest
+      .slice(0, rest.length - 1)
+      .map(ensurePojo) as SchemaArgs<S>;
+
+    // TODO: breaking: Switch back to this.memo.query(schema, args, state.entities as any, state.indexes) to do
+    // this logic
+    const input = this.memo.buildQueryKey(
+      schema,
+      args,
+      state.entities as any,
+      state.indexes,
+      JSON.stringify(args),
+    );
+
+    if (!input) {
+      return { data: undefined, countRef: () => () => undefined };
+    }
+
+    const { data, paths } = this.memo.denormalize(
+      schema,
+      input,
+      state.entities,
+      args,
+    );
+    return {
+      data: typeof data === 'symbol' ? undefined : (data as any),
+      countRef: this.gcPolicy.createCountRef({ paths }),
+    };
   }
 
   private getSchemaResponse<T>(
@@ -689,6 +779,49 @@ class Snapshot<T = unknown> implements SnapshotInterface {
     return this.controller.getResponse(endpoint, ...args, this.state);
   }
 
+  /** @see https://dataclient.io/docs/api/Snapshot#getResponseMeta */
+  getResponseMeta<E extends EndpointInterface>(
+    endpoint: E,
+    ...args: readonly [null]
+  ): {
+    data: DenormalizeNullable<E['schema']>;
+    expiryStatus: ExpiryStatus;
+    expiresAt: number;
+  };
+
+  getResponseMeta<E extends EndpointInterface>(
+    endpoint: E,
+    ...args: readonly [...Parameters<E>]
+  ): {
+    data: DenormalizeNullable<E['schema']>;
+    expiryStatus: ExpiryStatus;
+    expiresAt: number;
+  };
+
+  getResponseMeta<
+    E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
+  >(
+    endpoint: E,
+    ...args: readonly [...Parameters<E['key']>] | readonly [null]
+  ): {
+    data: DenormalizeNullable<E['schema']>;
+    expiryStatus: ExpiryStatus;
+    expiresAt: number;
+  };
+
+  getResponseMeta<
+    E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
+  >(
+    endpoint: E,
+    ...args: readonly [...Parameters<E['key']>] | readonly [null]
+  ): {
+    data: DenormalizeNullable<E['schema']>;
+    expiryStatus: ExpiryStatus;
+    expiresAt: number;
+  } {
+    return this.controller.getResponseMeta(endpoint, ...args, this.state);
+  }
+
   /** @see https://dataclient.io/docs/api/Snapshot#getError */
   getError<E extends EndpointInterface>(
     endpoint: E,
@@ -716,5 +849,19 @@ class Snapshot<T = unknown> implements SnapshotInterface {
     ...args: SchemaArgs<S>
   ): DenormalizeNullable<S> | undefined {
     return this.controller.get(schema, ...args, this.state);
+  }
+
+  /**
+   * Queries the store for a Querable schema; providing related metadata
+   * @see https://dataclient.io/docs/api/Snapshot#getQueryMeta
+   */
+  getQueryMeta<S extends Queryable>(
+    schema: S,
+    ...args: SchemaArgs<S>
+  ): {
+    data: DenormalizeNullable<S> | undefined;
+    countRef: () => () => void;
+  } {
+    return this.controller.getQueryMeta(schema, ...args, this.state);
   }
 }

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -372,7 +372,7 @@ export default class Controller<
    * Gets a snapshot (https://dataclient.io/docs/api/Snapshot)
    * @see https://dataclient.io/docs/api/Controller#snapshot
    */
-  snapshot = (state: State<unknown>, fetchedAt?: number): SnapshotInterface => {
+  snapshot = (state: State<unknown>, fetchedAt?: number): Snapshot<unknown> => {
     return new Snapshot(this, state, fetchedAt);
   };
 

--- a/packages/core/src/controller/__tests__/__snapshots__/get.ts.snap
+++ b/packages/core/src/controller/__tests__/__snapshots__/get.ts.snap
@@ -118,3 +118,10 @@ Tacos {
   "type": "foo",
 }
 `;
+
+exports[`Snapshot.getQueryMeta() query Entity based on pk 1`] = `
+Tacos {
+  "id": "1",
+  "type": "foo",
+}
+`;

--- a/packages/core/src/controller/__tests__/__snapshots__/getResponse.ts.snap
+++ b/packages/core/src/controller/__tests__/__snapshots__/getResponse.ts.snap
@@ -33,3 +33,18 @@ exports[`Controller.getResponse() infers schema with extra members but not set 1
   },
 }
 `;
+
+exports[`Snapshot.getResponseMeta() denormalizes schema with extra members but not set 1`] = `
+{
+  "data": [
+    Tacos {
+      "id": "1",
+      "type": "foo",
+    },
+    Tacos {
+      "id": "2",
+      "type": "bar",
+    },
+  ],
+}
+`;

--- a/packages/core/src/controller/__tests__/get.ts
+++ b/packages/core/src/controller/__tests__/get.ts
@@ -3,24 +3,24 @@ import { Entity, schema } from '@data-client/endpoint';
 import { initialState } from '../../state/reducer/createReducer';
 import Controller from '../Controller';
 
-describe('Controller.get()', () => {
-  class Tacos extends Entity {
-    type = '';
-    id = '';
-  }
-  const TacoList = new schema.Collection([Tacos]);
-  const entities = {
-    Tacos: {
-      1: { id: '1', type: 'foo' },
-      2: { id: '2', type: 'bar' },
-    },
-    [TacoList.key]: {
-      [TacoList.pk(undefined, undefined, '', [{ type: 'foo' }])]: ['1'],
-      [TacoList.pk(undefined, undefined, '', [{ type: 'bar' }])]: ['2'],
-      [TacoList.pk(undefined, undefined, '', [])]: ['1', '2'],
-    },
-  };
+class Tacos extends Entity {
+  type = '';
+  id = '';
+}
+const TacoList = new schema.Collection([Tacos]);
+const entities = {
+  Tacos: {
+    1: { id: '1', type: 'foo' },
+    2: { id: '2', type: 'bar' },
+  },
+  [TacoList.key]: {
+    [TacoList.pk(undefined, undefined, '', [{ type: 'foo' }])]: ['1'],
+    [TacoList.pk(undefined, undefined, '', [{ type: 'bar' }])]: ['2'],
+    [TacoList.pk(undefined, undefined, '', [])]: ['1', '2'],
+  },
+};
 
+describe('Controller.get()', () => {
   it('query Entity based on pk', () => {
     const controller = new Controller();
     const state = {
@@ -271,5 +271,26 @@ describe('Controller.get()', () => {
     () => controller.get(queryPerson, { doesnotexist: 5 }, state);
     // @ts-expect-error
     () => controller.get(queryPerson, { id: '1', doesnotexist: 5 }, state);
+  });
+});
+
+describe('Snapshot.getQueryMeta()', () => {
+  it('query Entity based on pk', () => {
+    const controller = new Controller();
+    const state = {
+      ...initialState,
+      entities,
+    };
+    const snapshot = controller.snapshot(state);
+    const taco = snapshot.getQueryMeta(Tacos, { id: '1' }).data;
+    expect(taco).toBeDefined();
+    expect(taco).toBeInstanceOf(Tacos);
+    expect(taco).toMatchSnapshot();
+    const taco2 = snapshot.getQueryMeta(Tacos, { id: '2' }).data;
+    expect(taco2).toBeDefined();
+    expect(taco2).toBeInstanceOf(Tacos);
+    expect(taco2).not.toEqual(taco);
+    // should maintain referential equality
+    expect(taco).toBe(snapshot.getQueryMeta(Tacos, { id: '1' }).data);
   });
 });

--- a/packages/core/src/controller/__tests__/get.ts
+++ b/packages/core/src/controller/__tests__/get.ts
@@ -292,5 +292,12 @@ describe('Snapshot.getQueryMeta()', () => {
     expect(taco2).not.toEqual(taco);
     // should maintain referential equality
     expect(taco).toBe(snapshot.getQueryMeta(Tacos, { id: '1' }).data);
+
+    // @ts-expect-error
+    () => snapshot.getQueryMeta(Tacos, { id: { bob: 5 } });
+    // @ts-expect-error
+    expect(snapshot.getQueryMeta(Tacos, 5).data).toBeUndefined();
+    // @ts-expect-error
+    () => snapshot.getQueryMeta(Tacos, { doesnotexist: 5 });
   });
 });

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -174,3 +174,49 @@ describe('Controller.getResponse()', () => {
     expect(second.expiresAt).toBe(expiresAt);
   });
 });
+
+describe('Snapshot.getResponseMeta()', () => {
+  it('denormalizes schema with extra members but not set', () => {
+    const controller = new Contoller();
+    class Tacos extends Entity {
+      type = '';
+      id = '';
+    }
+    const ep = new Endpoint(() => Promise.resolve(), {
+      key() {
+        return 'mytest';
+      },
+      schema: {
+        data: [Tacos],
+        extra: '',
+        page: {
+          first: null,
+          second: undefined,
+          third: 0,
+          complex: { complex: true, next: false },
+        },
+      },
+    });
+    const entities = {
+      Tacos: {
+        1: { id: '1', type: 'foo' },
+        2: { id: '2', type: 'bar' },
+      },
+    };
+
+    const state = {
+      ...initialState,
+      entities,
+      endpoints: {
+        [ep.key()]: {
+          data: ['1', '2'],
+        },
+      },
+    };
+    const { data, expiryStatus } = controller
+      .snapshot(state)
+      .getResponseMeta(ep);
+    expect(expiryStatus).toBe(ExpiryStatus.Valid);
+    expect(data).toMatchSnapshot();
+  });
+});

--- a/packages/normalizr/src/endpoint/SnapshotInterface.ts
+++ b/packages/normalizr/src/endpoint/SnapshotInterface.ts
@@ -20,6 +20,21 @@ export interface SnapshotInterface {
     expiresAt: number;
   };
 
+  /**
+   * Gets the (globally referentially stable) response for a given endpoint/args pair from state given.
+   * @see https://dataclient.io/docs/api/Snapshot#getResponseMeta
+   */
+  getResponseMeta<
+    E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
+  >(
+    endpoint: E,
+    ...args: readonly any[]
+  ): {
+    data: DenormalizeNullable<E['schema']>;
+    expiryStatus: ExpiryStatusInterface;
+    expiresAt: number;
+  };
+
   /** @see https://dataclient.io/docs/api/Snapshot#getError */
   getError: <
     E extends Pick<EndpointInterface, 'key'>,
@@ -34,6 +49,18 @@ export interface SnapshotInterface {
    * @see https://dataclient.io/docs/api/Snapshot#get
    */
   get<S extends Queryable>(schema: S, ...args: readonly any[]): any;
+
+  /**
+   * Queries the store for a Querable schema; providing related metadata
+   * @see https://dataclient.io/docs/api/Snapshot#getQueryMeta
+   */
+  getQueryMeta<S extends Queryable>(
+    schema: S,
+    ...args: readonly any[]
+  ): {
+    data: any;
+    countRef: () => () => void;
+  };
 
   readonly fetchedAt: number;
   readonly abort: Error;

--- a/packages/react/src/__tests__/integration-garbage-collection.native.tsx
+++ b/packages/react/src/__tests__/integration-garbage-collection.native.tsx
@@ -86,7 +86,7 @@ const TestComponent = () => {
 
 // Test cases
 describe('Integration Garbage Collection React Native', () => {
-  it('should render list view and detail view correctly', async () => {
+  it('should count properly with useSuspense', async () => {
     jest.useFakeTimers();
 
     mockGetList.mockReturnValue([
@@ -141,7 +141,7 @@ describe('Integration Garbage Collection React Native', () => {
     await act(async () => {
       jest.advanceTimersByTime(
         Math.max(
-          ArticleResource.getList.dataExpiryLength ?? 60000,
+          ArticleResource.getList.dataExpiryLength ?? 60000 + GC_INTERVAL,
           GC_INTERVAL,
         ),
       );

--- a/packages/react/src/__tests__/integration-garbage-collection.web.tsx
+++ b/packages/react/src/__tests__/integration-garbage-collection.web.tsx
@@ -2,6 +2,7 @@ import {
   AsyncBoundary,
   DataProvider,
   GCPolicy,
+  useQuery,
   useSuspense,
 } from '@data-client/react';
 import { MockResolver } from '@data-client/test';
@@ -31,7 +32,9 @@ const ArticleList = ({
     </div>
   );
 };
-const ArticleDetail = ({ article }: { article: Article }) => {
+const ArticleDetail = ({ id }: { id: number }) => {
+  const article = useSuspense(ArticleResource.get, { id });
+
   return (
     <div>
       <h3>{article.title}</h3>
@@ -45,13 +48,30 @@ const ListView = ({ onSelect }: { onSelect: (id: number) => void }) => {
   return <ArticleList articles={articles} onSelect={onSelect} />;
 };
 
-const DetailView = ({ id }: { id: number }) => {
-  const article = useSuspense(ArticleResource.get, { id });
+const QueryArticleList = ({ onSelect }: { onSelect: (id: number) => void }) => {
+  const articles = useQuery(ArticleResource.getList.schema);
+
+  if (articles === undefined) return <div>Articles not found</div>;
+  return <ArticleList articles={articles} onSelect={onSelect} />;
+};
+const ListQueryView = ({ onSelect }: { onSelect: (id: number) => void }) => {
   const [toggle, setToggle] = useState(false);
 
   return (
     <>
-      <ArticleDetail article={article} />{' '}
+      <QueryArticleList key={`${toggle}`} onSelect={onSelect} />{' '}
+      <button onClick={() => setToggle(!toggle)}>Toggle Re-render</button>
+      {toggle && <div>Toggle state: {toggle.toString()}</div>}
+    </>
+  );
+};
+
+const DetailView = ({ id }: { id: number }) => {
+  const [toggle, setToggle] = useState(false);
+
+  return (
+    <>
+      <ArticleDetail key={`${toggle}`} id={id} />{' '}
       <button onClick={() => setToggle(!toggle)}>Toggle Re-render</button>
       {toggle && <div>Toggle state: {toggle.toString()}</div>}
     </>
@@ -59,7 +79,9 @@ const DetailView = ({ id }: { id: number }) => {
 };
 
 const TestComponent = () => {
-  const [view, setView] = useState<'list' | 'detail'>('list');
+  const [view, setView] = useState<'list' | 'detail' | 'querylist' | 'blank'>(
+    'list',
+  );
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   return (
@@ -75,6 +97,16 @@ const TestComponent = () => {
         ]}
       >
         <div onClick={() => setView('list')}>Home</div>
+        <div onClick={() => setView('querylist')}>Query</div>
+        <div onClick={() => setView('blank')}>Blank</div>
+        <div
+          onClick={() => {
+            setSelectedId(1);
+            setView('detail');
+          }}
+        >
+          Try first article
+        </div>
         <AsyncBoundary fallback={<div>Loading...</div>}>
           {view === 'list' ?
             <ListView
@@ -83,6 +115,15 @@ const TestComponent = () => {
                 setView('detail');
               }}
             />
+          : view === 'querylist' ?
+            <ListQueryView
+              onSelect={id => {
+                setSelectedId(id);
+                setView('detail');
+              }}
+            />
+          : view === 'blank' ?
+            <div>This is an empty page</div>
           : selectedId !== null && <DetailView id={selectedId} />}
         </AsyncBoundary>
       </MockResolver>
@@ -91,7 +132,7 @@ const TestComponent = () => {
 };
 
 describe('Integration Garbage Collection Web', () => {
-  it('should render list view and detail view correctly', async () => {
+  it('should count properly with useSuspense', async () => {
     jest.useFakeTimers();
     mockGetList.mockReturnValue([
       { id: 1, title: 'Article 1', content: 'Content 1' },
@@ -104,6 +145,11 @@ describe('Integration Garbage Collection Web', () => {
     });
 
     render(<TestComponent />);
+
+    // only needed for react 17
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
 
     // Initial render, should show list view
     expect(await screen.findByText('Article 1')).toBeInTheDocument();
@@ -137,7 +183,7 @@ describe('Integration Garbage Collection Web', () => {
     // Jest time pass to expiry
     act(() => {
       jest.advanceTimersByTime(
-        ArticleResource.getList.dataExpiryLength ?? 60000,
+        ArticleResource.getList.dataExpiryLength ?? 60000 + GC_INTERVAL,
       );
     });
     expect(await screen.findByText('Content 1')).toBeInTheDocument();
@@ -155,6 +201,88 @@ describe('Integration Garbage Collection Web', () => {
     });
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('should count properly with useQuery', async () => {
+    jest.useFakeTimers();
+    mockGetList.mockReturnValue([
+      { id: 1, title: 'Article 1', content: 'Content 1' },
+      { id: 2, title: 'Article 2', content: 'Content 2' },
+    ]);
+    mockGet.mockReturnValue({
+      id: 1,
+      title: 'Article 1',
+      content: 'Content 1',
+    });
+
+    render(<TestComponent />);
+
+    // only needed for react 17
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
+
+    // Initial render, should show list view
+    expect(await screen.findByText('Article 1')).toBeInTheDocument();
+
+    // Switch to detail view
+    act(() => {
+      screen.getByText('Article 1').click();
+    });
+
+    // Detail view should render
+    expect(await screen.findByText('Content 1')).toBeInTheDocument();
+
+    // Jest time pass to trigger sweep but not expired
+    act(() => {
+      jest.advanceTimersByTime(GC_INTERVAL);
+    });
+
+    // Switch to useQuery() list view
+    act(() => {
+      screen.getByText('Query').click();
+    });
+
+    // List view should instantly render
+    expect(await screen.findByText('Article 1')).toBeInTheDocument();
+
+    // Jest time pass to expiry
+    act(() => {
+      jest.advanceTimersByTime(
+        ArticleResource.getList.dataExpiryLength ?? 60000 + GC_INTERVAL,
+      );
+    });
+    expect(await screen.findByText('Article 1')).toBeInTheDocument();
+
+    // Re-render query list view to make sure it still renders
+    act(() => {
+      screen.getByText('Toggle Re-render').click();
+    });
+    expect(await screen.findByText('Toggle state: true')).toBeInTheDocument();
+    expect(await screen.findByText('Article 1')).toBeInTheDocument();
+
+    act(() => {
+      screen.getByText('Blank').click();
+    });
+    // enough time to GC
+    act(() => {
+      jest.advanceTimersByTime(GC_INTERVAL);
+    });
+
+    // Visit detail view and see suspense fallback
+    act(() => {
+      screen.getByText('Try first article').click();
+    });
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    // Visit useQuery() list view and see query fallback
+    act(() => {
+      screen.getByText('Query').click();
+    });
+
+    expect(screen.getByText('Articles not found')).toBeInTheDocument();
     jest.useRealTimers();
   });
 });

--- a/packages/react/src/hooks/useQuery.ts
+++ b/packages/react/src/hooks/useQuery.ts
@@ -4,7 +4,7 @@ import type {
   Queryable,
   SchemaArgs,
 } from '@data-client/core';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import useCacheState from './useCacheState.js';
 import useController from './useController.js';
@@ -27,8 +27,13 @@ export default function useQuery<S extends Queryable>(
 
   // even though controller.get() is memoized, its memoization is more complex than
   // this so we layer it up to improve rerenders
-  return useMemo(() => {
-    return controller.get(schema, ...args, state);
+  const { data, countRef } = useMemo(() => {
+    return controller.getQueryMeta(schema, ...args, state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.indexes, state.entities, key]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(countRef, [data]);
+
+  return data;
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
useQuery() must also count its references else it might break when others un-mount.

Followup to: #3343

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Introduce Controller.getQueryMeta() so we have a countRef for useQuery.
Similarly, add Controller.getResponseMeta(). This should eventually become what is used instead of getResponse() - so getResponse() can just return data. (useful for getResponse snapshot stuff)