### PR TITLE
feat: Add hasExpired and expiryMultiplier options to GCPolicy

### DIFF
--- a/.changeset/silly-hotels-shout.md
+++ b/.changeset/silly-hotels-shout.md
@@ -20,7 +20,7 @@ const { store, selector, controller } = prepareStore(
 );
 ```
 
-Use `ImmortalGCPolicy` to never GC (to maintain existing behavior):
+To maintain existing behavior, use `ImmortalGCPolicy`:
 
 ```tsx
 import { ImmortalGCPolicy, DataProvider } from '@data-client/react';

--- a/.changeset/silly-hotels-shout.md
+++ b/.changeset/silly-hotels-shout.md
@@ -2,4 +2,28 @@
 '@data-client/react': patch
 ---
 
-Add gcPolicy option to DataProvider and prepareStore
+Add gcPolicy option to [DataProvider](https://dataclient.io/docs/api/DataProvider) and [prepareStore](https://dataclient.io/docs/guides/redux)
+
+```tsx
+// run GC sweep every 10min
+<DataProvider gcPolicy={new GCPolicy({ intervalMS: 60 * 1000 * 10 })}>{children}</DataProvider>
+```
+
+```ts
+const { store, selector, controller } = prepareStore(
+  initialState,
+  managers,
+  Controller,
+  otherReducers,
+  extraMiddlewares,
+  gcPolicy: new GCPolicy({ intervalMS: 60 * 1000 * 10 }),
+);
+```
+
+Use `ImmortalGCPolicy` to never GC (to maintain existing behavior):
+
+```tsx
+import { ImmortalGCPolicy, DataProvider } from '@data-client/react';
+
+<DataProvider gcPolicy={new ImmortalGCPolicy()}>{children}</DataProvider>
+```

--- a/.changeset/strange-buckets-clean.md
+++ b/.changeset/strange-buckets-clean.md
@@ -3,4 +3,47 @@
 '@data-client/core': patch
 ---
 
-Add GCPolicy
+Add GCPolicy to control Garbage Collection of data in the store.
+
+This can be configured with constructor options, or custom GCPolicies implemented by extending
+or simply building your own. Use `ImmortalGCPolicy` to never GC (to maintain existing behavior).
+
+### constructor
+
+#### intervalMS = 60 * 1000 * 5
+
+How long between low priority GC sweeps.
+
+Longer values may result in more memory usage, but less performance impact.
+
+#### expiryMultiplier = 2
+
+Used in the default `hasExpired` policy.
+
+Represents how many 'stale' lifetimes data should persist before being
+garbage collected.
+
+#### hasExpired
+
+```typescript
+protected hasExpired({
+  fetchedAt,
+  expiresAt,
+  now,
+}: {
+  expiresAt: number;
+  date: number;
+  fetchedAt: number;
+  now: number;
+}): boolean {
+  return (
+    Math.max(
+      (expiresAt - fetchedAt) * this.options.expiryMultiplier,
+      120000,
+    ) +
+      fetchedAt <
+    now
+  );
+}
+```
+

--- a/.changeset/strange-buckets-clean.md
+++ b/.changeset/strange-buckets-clean.md
@@ -23,27 +23,29 @@ Used in the default `hasExpired` policy.
 Represents how many 'stale' lifetimes data should persist before being
 garbage collected.
 
-#### hasExpired
+#### expiresAt
 
 ```typescript
-protected hasExpired({
-  fetchedAt,
-  expiresAt,
-  now,
+expiresAt({
+    fetchedAt,
+    expiresAt,
 }: {
   expiresAt: number;
   date: number;
   fetchedAt: number;
-  now: number;
-}): boolean {
+}): number {
   return (
     Math.max(
       (expiresAt - fetchedAt) * this.options.expiryMultiplier,
       120000,
-    ) +
-      fetchedAt <
-    now
+    ) + fetchedAt
   );
 }
 ```
 
+Indicates at what timestamp it is acceptable to remove unused data from the store.
+
+Data not currently rendered in any components is considered unused. However, unused
+data may be used again in the future (as a cache).
+
+This results in a tradeoff between memory usage and cache hit rate (and thus performance).

--- a/packages/core/src/controller/__tests__/Controller.ts
+++ b/packages/core/src/controller/__tests__/Controller.ts
@@ -50,6 +50,7 @@ describe('Controller', () => {
         meta: {
           [fetchKey]: {
             date: Date.now(),
+            fetchedAt: Date.now(),
             expiresAt: Date.now() + 10000,
           },
         },
@@ -88,6 +89,7 @@ describe('Controller', () => {
         meta: {
           [fetchKey]: {
             date: 0,
+            fetchedAt: 0,
             expiresAt: 0,
           },
         },

--- a/packages/core/src/state/__tests__/GCPolicy.test.ts
+++ b/packages/core/src/state/__tests__/GCPolicy.test.ts
@@ -220,7 +220,7 @@ describe('GCPolicy', () => {
 
   it('should support custom hasExpired', () => {
     jest.useFakeTimers();
-    gcPolicy = new GCPolicy({ hasExpired: () => true });
+    gcPolicy = new GCPolicy({ expiresAt: () => 0 });
     gcPolicy.init(controller);
     const key = 'testEndpoint';
     const paths: EntityPath[] = [{ key: 'testEntity', pk: '1' }];

--- a/packages/core/src/state/__tests__/GCPolicy.test.ts
+++ b/packages/core/src/state/__tests__/GCPolicy.test.ts
@@ -1,5 +1,6 @@
 import type { EntityPath } from '@data-client/normalizr';
 import { jest } from '@jest/globals';
+import { has } from 'benchmark';
 
 import { GC } from '../../actionTypes';
 import Controller from '../../controller/Controller';
@@ -40,8 +41,22 @@ describe('GCPolicy', () => {
     const key = 'testEndpoint';
     const paths: EntityPath[] = [{ key: 'testEntity', pk: '1' }];
     const state = {
-      meta: { testEndpoint: { expiresAt: Date.now() - 1000 } },
-      entityMeta: { testEntity: { '1': { expiresAt: Date.now() - 1000 } } },
+      meta: {
+        testEndpoint: {
+          date: 0,
+          fetchedAt: 0,
+          expiresAt: 0,
+        },
+      },
+      entityMeta: {
+        testEntity: {
+          '1': {
+            date: 0,
+            fetchedAt: 0,
+            expiresAt: 0,
+          },
+        },
+      },
     };
     (controller.getState as jest.Mock).mockReturnValue(state);
 
@@ -68,8 +83,22 @@ describe('GCPolicy', () => {
     const key = 'testEndpoint';
     const paths: EntityPath[] = [{ key: 'testEntity', pk: '1' }];
     const state = {
-      meta: { testEndpoint: { expiresAt: Date.now() - 1000 } },
-      entityMeta: { testEntity: { '1': { expiresAt: Date.now() - 1000 } } },
+      meta: {
+        testEndpoint: {
+          date: 0,
+          fetchedAt: 0,
+          expiresAt: 0,
+        },
+      },
+      entityMeta: {
+        testEntity: {
+          '1': {
+            date: 0,
+            fetchedAt: 0,
+            expiresAt: 0,
+          },
+        },
+      },
     };
     (controller.getState as jest.Mock).mockReturnValue(state);
 
@@ -127,8 +156,22 @@ describe('GCPolicy', () => {
     const paths: EntityPath[] = [{ key: 'testEntity', pk: '1' }];
     const futureTime = Date.now() + 1000;
     const state = {
-      meta: { testEndpoint: { expiresAt: futureTime } },
-      entityMeta: { testEntity: { '1': { expiresAt: futureTime } } },
+      meta: {
+        testEndpoint: {
+          date: futureTime - 100,
+          fetchAt: futureTime - 100,
+          expiresAt: futureTime,
+        },
+      },
+      entityMeta: {
+        testEntity: {
+          '1': {
+            date: futureTime - 100,
+            fetchAt: futureTime - 100,
+            expiresAt: futureTime,
+          },
+        },
+      },
     };
     (controller.getState as jest.Mock).mockReturnValue(state);
 
@@ -146,8 +189,22 @@ describe('GCPolicy', () => {
     // Fast forward time to past the futureTime
     jest.advanceTimersByTime(2000);
     (controller.getState as jest.Mock).mockReturnValue({
-      meta: { testEndpoint: { expiresAt: Date.now() - 1000 } },
-      entityMeta: { testEntity: { '1': { expiresAt: Date.now() - 1000 } } },
+      meta: {
+        testEndpoint: {
+          date: 0,
+          fetchedAt: 0,
+          expiresAt: 0,
+        },
+      },
+      entityMeta: {
+        testEntity: {
+          '1': {
+            date: 0,
+            fetchedAt: 0,
+            expiresAt: 0,
+          },
+        },
+      },
     });
 
     gcPolicy['runSweep']();
@@ -159,5 +216,43 @@ describe('GCPolicy', () => {
     });
 
     jest.useRealTimers();
+  });
+
+  it('should support custom hasExpired', () => {
+    jest.useFakeTimers();
+    gcPolicy = new GCPolicy({ hasExpired: () => true });
+    gcPolicy.init(controller);
+    const key = 'testEndpoint';
+    const paths: EntityPath[] = [{ key: 'testEntity', pk: '1' }];
+    const futureTime = Date.now() + 1000;
+    const state = {
+      meta: {
+        testEndpoint: {
+          date: futureTime - 100,
+          fetchAt: futureTime - 100,
+          expiresAt: futureTime,
+        },
+      },
+      entityMeta: {
+        testEntity: {
+          '1': {
+            date: futureTime - 100,
+            fetchAt: futureTime - 100,
+            expiresAt: futureTime,
+          },
+        },
+      },
+    };
+    (controller.getState as jest.Mock).mockReturnValue(state);
+
+    const countRef = gcPolicy.createCountRef({ key, paths });
+
+    const decrement = countRef();
+    countRef(); // Increment again
+    decrement();
+    decrement(); // Decrement twice
+
+    gcPolicy['runSweep']();
+    expect(controller.dispatch).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -13,6 +13,7 @@ exports[`reducer should set error in meta for "set" 1`] = `
       "error": [Error: hi],
       "errorPolicy": undefined,
       "expiresAt": 5000500000,
+      "fetchedAt": 5000000000,
     },
   },
   "optimistic": [],
@@ -48,6 +49,7 @@ exports[`reducer singles should update state correctly 1`] = `
     "http://test.com/article/20": {
       "date": 5000000000,
       "expiresAt": 5000500000,
+      "fetchedAt": 5000000000,
       "prevExpiresAt": undefined,
     },
   },

--- a/packages/core/src/state/reducer/setResponseReducer.ts
+++ b/packages/core/src/state/reducer/setResponseReducer.ts
@@ -75,6 +75,7 @@ export function setResponseReducer(
         ...state.meta,
         [action.key]: {
           date: action.meta.date,
+          fetchedAt: action.meta.fetchedAt,
           expiresAt: action.meta.expiresAt,
           prevExpiresAt: state.meta[action.key]?.expiresAt,
         },
@@ -126,8 +127,9 @@ function reduceError(
       ...state.meta,
       [action.key]: {
         date: action.meta.date,
-        error,
+        fetchedAt: action.meta.fetchedAt,
         expiresAt: action.meta.expiresAt,
+        error,
         errorPolicy: action.endpoint.errorPolicy?.(error),
       },
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,6 +33,7 @@ export interface State<T> {
   readonly meta: {
     readonly [key: string]: {
       readonly date: number;
+      readonly fetchedAt: number;
       readonly expiresAt: number;
       readonly prevExpiresAt?: number;
       readonly error?: ErrorTypes;

--- a/packages/react/src/__tests__/integration-garbage-collection.native.tsx
+++ b/packages/react/src/__tests__/integration-garbage-collection.native.tsx
@@ -141,7 +141,7 @@ describe('Integration Garbage Collection React Native', () => {
     await act(async () => {
       jest.advanceTimersByTime(
         Math.max(
-          ArticleResource.getList.dataExpiryLength ?? 60000 + GC_INTERVAL,
+          (ArticleResource.getList.dataExpiryLength ?? 60000) * 2,
           GC_INTERVAL,
         ),
       );

--- a/packages/react/src/components/__tests__/__snapshots__/provider.native.tsx.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/provider.native.tsx.snap
@@ -29,6 +29,7 @@ exports[`<DataProvider /> should change state 1`] = `
     "GET http://test.com/article-cooler/5": {
       "date": 50,
       "expiresAt": 55,
+      "fetchedAt": 50,
       "prevExpiresAt": undefined,
     },
   },

--- a/packages/react/src/components/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/provider.tsx.snap
@@ -29,6 +29,7 @@ exports[`<DataProvider /> should change state 1`] = `
     "GET http://test.com/article-cooler/5": {
       "date": 50,
       "expiresAt": 60050,
+      "fetchedAt": 50,
       "prevExpiresAt": undefined,
     },
   },

--- a/packages/react/src/hooks/__tests__/useDLE.native.tsx
+++ b/packages/react/src/hooks/__tests__/useDLE.native.tsx
@@ -222,6 +222,7 @@ describe('useDLE', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },
@@ -312,6 +313,7 @@ describe('useDLE', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },

--- a/packages/react/src/hooks/__tests__/useFetch.native.tsx
+++ b/packages/react/src/hooks/__tests__/useFetch.native.tsx
@@ -208,6 +208,7 @@ describe('useFetch', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },

--- a/packages/react/src/hooks/__tests__/useSuspense.native.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.native.tsx
@@ -217,6 +217,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },
@@ -302,6 +303,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: Infinity,
+          fetchedAt: Infinity,
           expiresAt: Infinity,
         },
       },
@@ -332,6 +334,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },
@@ -365,6 +368,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },

--- a/packages/react/src/hooks/__tests__/useSuspense.web.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.web.tsx
@@ -211,6 +211,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },
@@ -244,6 +245,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: Infinity,
+          fetchedAt: Infinity,
           expiresAt: Infinity,
         },
       },
@@ -275,6 +277,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },
@@ -308,6 +311,7 @@ describe('useSuspense()', () => {
       meta: {
         [fetchKey]: {
           date: 0,
+          fetchedAt: 0,
           expiresAt: 0,
         },
       },


### PR DESCRIPTION
Followup: #3343

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

There is a tradeoff of memory vs cpu/time. Keeping data around longer, means a potentially higher cache hit rate. However, at the sacrifice of memory usage.

These policy configurations allow customization of these tradeoffs to suite the needs of a given application.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### expiryMultiplier = 2

Used in the default `hasExpired` policy.

Represents how many 'stale' lifetimes data should persist before being
garbage collected.

#### expiresAt

```typescript
expiresAt({
    fetchedAt,
    expiresAt,
}: {
  expiresAt: number;
  date: number;
  fetchedAt: number;
}): number {
  return (
    Math.max(
      (expiresAt - fetchedAt) * this.options.expiryMultiplier,
      120000,
    ) + fetchedAt
  );
}
```

Indicates at what timestamp it is acceptable to remove unused data from the store.

Data not currently rendered in any components is considered unused. However, unused
data may be used again in the future (as a cache).

This results in a tradeoff between memory usage and cache hit rate (and thus performance).