### PR TITLE
enhance: Reduce bundle size by removing bloated polyfills

### DIFF
--- a/.changeset/smooth-seals-shake.md
+++ b/.changeset/smooth-seals-shake.md
@@ -1,0 +1,13 @@
+---
+'@data-client/use-enhanced-reducer': patch
+'@data-client/normalizr': patch
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/react': patch
+'@data-client/core': patch
+'@data-client/rest': patch
+'@data-client/test': patch
+'@data-client/img': patch
+---
+
+Reduce bundle sizes by 30% by removing unneeded polyfills

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,13 +9,14 @@ module.exports = function (api) {
       process.env.BROWSERSLIST_ENV +
       process.env.COMPILE_TARGET +
       process.env.POLYFILL_TARGETS +
-      '0',
+      '1',
   );
   return {
     presets: [
       [
         '@anansi',
         {
+          polyfillMethod: false,
           hasJsxRuntime: true,
           loose: true,
           resolver: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -124,9 +124,8 @@
     "url": "https://github.com/reactive/data-client/issues"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
+    "@babel/runtime": "^7.20.0",
     "@data-client/normalizr": "^0.14.20",
-    "core-js-pure": "^3.40.0",
     "flux-standard-action": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -15,7 +15,7 @@ import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies)
   //.concat(Object.keys(pkg.peerDependencies))
-  .filter(dep => ![].includes(dep));
+  .filter(dep => !['@babel/runtime'].includes(dep));
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node', '.jsx'];
 const nativeExtensions = ['.native.ts', ...extensions];

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -133,8 +133,7 @@
     "url": "https://github.com/reactive/data-client/issues"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
-    "core-js-pure": "^3.40.0"
+    "@babel/runtime": "^7.20.0"
   },
   "devDependencies": {
     "@anansi/browserslist-config": "^1.4.2",

--- a/packages/endpoint/rollup.config.mjs
+++ b/packages/endpoint/rollup.config.mjs
@@ -14,7 +14,7 @@ import {
 import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies).filter(
-  dep => ![].includes(dep),
+  dep => !['@babel/runtime'].includes(dep),
 );
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export type {
   EndpointOptions,
   EndpointInstance,

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -106,9 +106,8 @@
   "funding": "https://github.com/sponsors/ntucker",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
-    "@data-client/endpoint": "^0.14.20",
-    "core-js-pure": "^3.40.0"
+    "@babel/runtime": "^7.20.0",
+    "@data-client/endpoint": "^0.14.20"
   },
   "devDependencies": {
     "@anansi/browserslist-config": "^1.4.2",

--- a/packages/graphql/rollup.config.mjs
+++ b/packages/graphql/rollup.config.mjs
@@ -13,7 +13,7 @@ import {
 import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies).filter(
-  dep => ![].includes(dep),
+  dep => !['@babel/runtime'].includes(dep),
 );
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -74,9 +74,8 @@
   "funding": "https://github.com/sponsors/ntucker",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
-    "@data-client/endpoint": "^0.14.20",
-    "core-js-pure": "^3.40.0"
+    "@babel/runtime": "^7.20.0",
+    "@data-client/endpoint": "^0.14.20"
   },
   "peerDependencies": {
     "@data-client/react": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0",

--- a/packages/img/rollup.config.mjs
+++ b/packages/img/rollup.config.mjs
@@ -14,7 +14,7 @@ import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
-  .filter(dep => ![].includes(dep));
+  .filter(dep => !['@babel/runtime'].includes(dep));
 const peers = Object.keys(pkg.peerDependencies);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -118,8 +118,7 @@
     "url": "https://github.com/reactive/data-client/issues"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
-    "core-js-pure": "^3.40.0"
+    "@babel/runtime": "^7.20.0"
   },
   "devDependencies": {
     "@anansi/browserslist-config": "^1.4.2",

--- a/packages/normalizr/rollup.config.mjs
+++ b/packages/normalizr/rollup.config.mjs
@@ -10,7 +10,9 @@ import {
 
 import pkg from './package.json' with { type: 'json' };
 
-const dependencies = Object.keys(pkg.dependencies);
+const dependencies = Object.keys(pkg.dependencies).filter(
+  dep => !['@babel/runtime'].includes(dep),
+);
 
 const name = 'normalizr';
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -168,10 +168,9 @@
   "funding": "https://github.com/sponsors/ntucker",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
+    "@babel/runtime": "^7.20.0",
     "@data-client/core": "^0.14.20",
-    "@data-client/use-enhanced-reducer": "^0.1.13",
-    "core-js-pure": "^3.40.0"
+    "@data-client/use-enhanced-reducer": "^0.1.13"
   },
   "peerDependencies": {
     "@react-navigation/native": "^6.0.0 || ^7.0.0",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -16,7 +16,10 @@ import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
-  .filter(dep => !['@data-client/use-enhanced-reducer'].includes(dep));
+  .filter(
+    dep =>
+      !['@data-client/use-enhanced-reducer', '@babel/runtime'].includes(dep),
+  );
 const peers = Object.keys(pkg.peerDependencies);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node', '.jsx'];

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export { Controller, ExpiryStatus, actionTypes } from '@data-client/core';
 export type {
   EndpointExtraOptions,

--- a/packages/react/src/server/index.ts
+++ b/packages/react/src/server/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export { default as createPersistedStore } from './createPersistedStore.js';
 export * from './getInitialData.js';
 export { default as createServerDataComponent } from './createServerDataComponent.js';

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -134,9 +134,8 @@
   "funding": "https://github.com/sponsors/ntucker",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
+    "@babel/runtime": "^7.20.0",
     "@data-client/endpoint": "^0.14.20",
-    "core-js-pure": "^3.40.0",
     "path-to-regexp": "^6.3.0"
   },
   "devDependencies": {

--- a/packages/rest/rollup.config.mjs
+++ b/packages/rest/rollup.config.mjs
@@ -15,7 +15,7 @@ import {
 import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies).filter(
-  dep => ![].includes(dep),
+  dep => !['@babel/runtime'].includes(dep),
 );
 
 const extensions = ['.ts', '.tsx', '.js', '.mjs', '.json', '.node'];

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -115,11 +115,10 @@
   "funding": "https://github.com/sponsors/ntucker",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.0",
+    "@babel/runtime": "^7.20.0",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^16.0.0",
-    "@testing-library/react-native": "^13.0.0",
-    "core-js-pure": "^3.40.0"
+    "@testing-library/react-native": "^13.0.0"
   },
   "peerDependencies": {
     "@data-client/react": "^0.12.15 || ^0.13.0 || ^0.14.0",

--- a/packages/test/rollup.config.mjs
+++ b/packages/test/rollup.config.mjs
@@ -4,7 +4,7 @@ import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
-  .filter(dep => !['@data-client/normalizr'].includes(dep));
+  .filter(dep => !['@data-client/normalizr', '@babel/runtime'].includes(dep));
 
 const extensions = [
   '.js',

--- a/packages/test/src/MockController.ts
+++ b/packages/test/src/MockController.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 import {
   actionTypes,
   Controller,

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -94,7 +94,6 @@
     "rollup-plugins": "workspace:*"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.26.7",
-    "core-js-pure": "^3.40.0"
+    "@babel/runtime": "^7.20.0"
   }
 }

--- a/packages/use-enhanced-reducer/rollup.config.mjs
+++ b/packages/use-enhanced-reducer/rollup.config.mjs
@@ -14,7 +14,7 @@ import pkg from './package.json' with { type: 'json' };
 
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
-  .filter(dep => ![].includes(dep));
+  .filter(dep => !['@babel/runtime'].includes(dep));
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 process.env.NODE_ENV = 'production';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2198,12 +2198,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
-  version: 7.26.0
-  resolution: "@babel/runtime@npm:7.26.0"
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+  version: 7.26.9
+  resolution: "@babel/runtime@npm:7.26.9"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
-  checksum: 10c0/12c01357e0345f89f4f7e8c0e81921f2a3e3e101f06e8eaa18a382b517376520cd2fa8c237726eb094dab25532855df28a7baaf1c26342b52782f6936b07c287
+  checksum: 10c0/e8517131110a6ec3a7360881438b85060e49824e007f4a64b5dfa9192cf2bb5c01e84bfc109f02d822c7edb0db926928dd6b991e3ee460b483fb0fac43152d9b
   languageName: node
   linkType: hard
 
@@ -3080,12 +3080,11 @@ __metadata:
   resolution: "@data-client/core@workspace:packages/core"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/endpoint": "workspace:*"
     "@data-client/normalizr": "npm:^0.14.20"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.0.0"
-    core-js-pure: "npm:^3.40.0"
     flux-standard-action: "npm:^2.1.1"
     rollup-plugins: "workspace:*"
   languageName: unknown
@@ -3096,13 +3095,12 @@ __metadata:
   resolution: "@data-client/endpoint@workspace:packages/endpoint"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/core": "workspace:*"
     "@data-client/normalizr": "workspace:*"
     "@js-temporal/polyfill": "npm:^0.4.4"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.0.0"
-    core-js-pure: "npm:^3.40.0"
     immutable: "npm:4.2.2"
     nock: "npm:13.3.1"
     rollup-plugins: "workspace:*"
@@ -3114,11 +3112,10 @@ __metadata:
   resolution: "@data-client/graphql@workspace:packages/graphql"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/endpoint": "npm:^0.14.20"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.0.0"
-    core-js-pure: "npm:^3.40.0"
     nock: "npm:13.3.1"
     rollup-plugins: "workspace:*"
   languageName: unknown
@@ -3129,14 +3126,13 @@ __metadata:
   resolution: "@data-client/img@workspace:packages/img"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/endpoint": "npm:^0.14.20"
     "@data-client/react": "workspace:*"
     "@testing-library/react": "npm:^16.1.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.0.0"
     "@types/react": "npm:19.0.10"
-    core-js-pure: "npm:^3.40.0"
     react: "npm:^19.0.0"
     rollup-plugins: "workspace:*"
   peerDependencies:
@@ -3154,12 +3150,11 @@ __metadata:
   resolution: "@data-client/normalizr@workspace:packages/normalizr"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/endpoint": "workspace:*"
     "@js-temporal/polyfill": "npm:^0.4.4"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.0.0"
-    core-js-pure: "npm:^3.40.0"
     immutable: "npm:4.2.2"
     rollup-plugins: "workspace:*"
   languageName: unknown
@@ -3170,7 +3165,7 @@ __metadata:
   resolution: "@data-client/react@workspace:packages/react"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/core": "npm:^0.14.20"
     "@data-client/rest": "workspace:*"
     "@data-client/test": "workspace:*"
@@ -3187,7 +3182,6 @@ __metadata:
     "@types/qs": "npm:^6"
     "@types/react": "npm:19.0.10"
     "@types/react-dom": "npm:*"
-    core-js-pure: "npm:^3.40.0"
     jest-mock: "npm:^29.7.0"
     nock: "npm:13.3.1"
     qs: "npm:^6.13.1"
@@ -3215,13 +3209,12 @@ __metadata:
   resolution: "@data-client/rest@workspace:packages/rest"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/endpoint": "npm:^0.14.20"
     "@data-client/react": "workspace:*"
     "@data-client/test": "workspace:*"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.0.0"
-    core-js-pure: "npm:^3.40.0"
     nock: "npm:13.3.1"
     path-to-regexp: "npm:^6.3.0"
     rollup-plugins: "workspace:*"
@@ -3233,7 +3226,7 @@ __metadata:
   resolution: "@data-client/test@workspace:packages/test"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@data-client/react": "workspace:*"
     "@testing-library/dom": "npm:^10.1.0"
     "@testing-library/react": "npm:^16.0.0"
@@ -3243,7 +3236,6 @@ __metadata:
     "@types/react": "npm:19.0.10"
     "@types/react-dom": "npm:19.0.4"
     "@types/react-test-renderer": "npm:19.0.0"
-    core-js-pure: "npm:^3.40.0"
     jest: "npm:^29.5.0"
     react: "npm:19.0.0"
     react-dom: "npm:19.0.0"
@@ -3283,11 +3275,10 @@ __metadata:
   resolution: "@data-client/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
     "@anansi/browserslist-config": "npm:^1.4.2"
-    "@babel/runtime-corejs3": "npm:^7.26.7"
+    "@babel/runtime": "npm:^7.20.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.0.0"
     "@types/react": "npm:19.0.10"
-    core-js-pure: "npm:^3.40.0"
     react: "npm:^19.0.0"
     rollup-plugins: "workspace:*"
   peerDependencies:


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In https://github.com/reactive/data-client/commit/165afed083c0c63e9356bc8d1ee30dee8b916ed6#diff-9a40c6a3ef28df92dce0c4b8ab76fd7a4912103d2e767254ed4d93100e532bb0 we tried focusing on bundling polyfills as a robust approach.

Unfortunately, the current way polyfill packages work even including just one polyfill for Object.hasOwn includes around 40 other polyfills that are not needed; increasing all bundle sizes by 30%.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Go back to the old approach of using @babel/runtime only 