### PR TITLE
enhance: Improve performance by using Map

### DIFF
--- a/.changeset/evil-beans-attack.md
+++ b/.changeset/evil-beans-attack.md
@@ -1,0 +1,7 @@
+---
+'@data-client/normalizr': patch
+'@data-client/core': patch
+'@data-client/rest': patch
+---
+
+Improve performance by using Map() instead of Object for unbounded keys

--- a/.changeset/evil-beans-attack.md
+++ b/.changeset/evil-beans-attack.md
@@ -1,6 +1,5 @@
 ---
 '@data-client/normalizr': patch
-'@data-client/core': patch
 '@data-client/rest': patch
 '@data-client/test': patch
 ---

--- a/.changeset/evil-beans-attack.md
+++ b/.changeset/evil-beans-attack.md
@@ -2,6 +2,7 @@
 '@data-client/normalizr': patch
 '@data-client/core': patch
 '@data-client/rest': patch
+'@data-client/test': patch
 ---
 
 Improve performance by using Map() instead of Object for unbounded keys

--- a/.changeset/loud-rice-fry.md
+++ b/.changeset/loud-rice-fry.md
@@ -1,0 +1,22 @@
+---
+'@data-client/test': patch
+---
+
+Interceptors that have args specified will still work, and warn about args.
+
+Example:
+
+```typescript
+{
+  endpoint: TodoResource.getList.push,
+  args: [{ userId: '5' }, {}],
+  response({ userId }, body) {
+    return { id: Math.random(), userId, ...ensurePojo(body) };
+  },
+}
+```
+
+This is clearly an interceptor, but args were accidentally specified. Before
+this would make it not register, and TypeScript couldn't detect the issue.
+
+Now this is treated as an interceptor (args ignored); and there is a console warning

--- a/docs/core/concepts/normalization.md
+++ b/docs/core/concepts/normalization.md
@@ -391,8 +391,8 @@ and up to 20x performance even after [mutation operations](../getting-started/mu
 xychart-beta
     title "Denormalize Single Entity"
     x-axis [normalizr, "Data Client", "Data Client (cached)"]
-    y-axis "Operations per second" 0 --> 4875500
-    bar [218500, 1079500, 4875500]
+    y-axis "Operations per second" 0 --> 5618500
+    bar [212500, 1288500, 5618500]
 ```
 
 ```mermaid
@@ -400,7 +400,7 @@ xychart-beta
     title "Denormalize Large List"
     x-axis [normalizr, "Data Client", "Data Client (cached)"]
     y-axis "Operations per second" 0 --> 12962
-    bar [1165, 1807, 13168]
+    bar [1151, 1807, 13182]
 ```
 
 </Grid>

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -23,10 +23,10 @@ Performance compared to normalizr package (higher is better):
 
 |                     | no cache | with cache |
 | ------------------- | -------- | ---------- |
-| normalize (long)    | 121%     | 121%       |
-| denormalize (long)  | 158%     | 1,262%     |
-| denormalize (short) | 676%     | 2,367%     |
+| normalize (long)    | 120%     | 120%       |
+| denormalize (long)  | 158%     | 1,250%     |
+| denormalize (short) | 676%     | 2,650%     |
 
-[Comparison done on a Ryzen 7950x; Ubuntu; Node 20.10.0]
+[Comparison done on a Ryzen 7950x; Ubuntu; Node 22.14.0]
 
 Not only is denormalize faster, but it is more feature-rich as well.

--- a/packages/normalizr/README.md
+++ b/packages/normalizr/README.md
@@ -313,9 +313,9 @@ Available from [@data-client/endpoint](https://www.npmjs.com/package/@data-clien
 
 |                     | no cache | with cache |
 | ------------------- | -------- | ---------- |
-| normalize (long)    | 121%     | 121%       |
-| denormalize (long)  | 158%     | 1,262%     |
-| denormalize (short) | 676%     | 2,367%     |
+| normalize (long)    | 120%     | 120%       |
+| denormalize (long)  | 158%     | 1,250%     |
+| denormalize (short) | 676%     | 2,650%     |
 
 [View benchmark](https://github.com/reactive/data-client/blob/master/examples/benchmark)
 

--- a/packages/normalizr/src/denormalize/cache.ts
+++ b/packages/normalizr/src/denormalize/cache.ts
@@ -6,7 +6,7 @@ export default interface Cache {
     pk: string,
     schema: EntityInterface,
     entity: any,
-    computeValue: (localCacheKey: Record<string, any>) => void,
+    computeValue: (localCacheKey: Map<string, any>) => void,
   ): object | undefined | symbol;
   getResults(
     input: any,

--- a/packages/normalizr/src/denormalize/localCache.ts
+++ b/packages/normalizr/src/denormalize/localCache.ts
@@ -3,24 +3,24 @@ import type { EntityInterface } from '../interface.js';
 import type { EntityPath } from '../types.js';
 
 export default class LocalCache implements Cache {
-  private localCache: Record<string, Record<string, any>> = {};
+  private localCache = new Map<string, Map<string, any>>();
 
   getEntity(
     pk: string,
     schema: EntityInterface,
     entity: any,
-    computeValue: (localCacheKey: Record<string, any>) => void,
+    computeValue: (localCacheKey: Map<string, any>) => void,
   ): object | undefined | symbol {
     const key = schema.key;
-    if (!(key in this.localCache)) {
-      this.localCache[key] = Object.create(null);
+    if (!this.localCache.has(key)) {
+      this.localCache.set(key, new Map<string, any>());
     }
-    const localCacheKey = this.localCache[key];
+    const localCacheKey = this.localCache.get(key) as Map<string, any>;
 
-    if (!localCacheKey[pk]) {
+    if (!localCacheKey.get(pk)) {
       computeValue(localCacheKey);
     }
-    return localCacheKey[pk];
+    return localCacheKey.get(pk);
   }
 
   getResults(

--- a/packages/normalizr/src/memo/MemoCache.ts
+++ b/packages/normalizr/src/memo/MemoCache.ts
@@ -21,7 +21,7 @@ export default class MemoCache {
   /** Caches the final denormalized form based on input, entities */
   protected endpoints: EndpointsCache = new WeakDependencyMap<EntityPath>();
   /** Caches the queryKey based on schema, args, and any used entities or indexes */
-  protected queryKeys: Record<string, WeakDependencyMap<QueryPath>> = {};
+  protected queryKeys: Map<string, WeakDependencyMap<QueryPath>> = new Map();
 
   /** Compute denormalized form maintaining referential equality for same inputs */
   denormalize<S extends Schema>(
@@ -107,10 +107,14 @@ export default class MemoCache {
       return schema as any;
 
     // cache lookup: argsKey -> schema -> ...touched indexes or entities
-    if (!this.queryKeys[argsKey]) {
-      this.queryKeys[argsKey] = new WeakDependencyMap<QueryPath>();
+    if (!this.queryKeys.get(argsKey)) {
+      this.queryKeys.set(argsKey, new WeakDependencyMap<QueryPath>());
     }
-    const queryCache = this.queryKeys[argsKey];
+    const queryCache = this.queryKeys.get(argsKey) as WeakDependencyMap<
+      QueryPath,
+      object,
+      any
+    >;
     const getEntity = createGetEntity(entities);
     const getIndex = createGetIndex(indexes);
     // eslint-disable-next-line prefer-const

--- a/packages/normalizr/src/memo/MemoCache.ts
+++ b/packages/normalizr/src/memo/MemoCache.ts
@@ -17,7 +17,7 @@ import type {
 /** Singleton to store the memoization cache for denormalization methods */
 export default class MemoCache {
   /** Cache for every entity based on its dependencies and its own input */
-  protected entities: EntityCache = {};
+  protected entities: EntityCache = new Map();
   /** Caches the final denormalized form based on input, entities */
   protected endpoints: EndpointsCache = new WeakDependencyMap<EntityPath>();
   /** Caches the queryKey based on schema, args, and any used entities or indexes */

--- a/packages/normalizr/src/memo/types.ts
+++ b/packages/normalizr/src/memo/types.ts
@@ -2,12 +2,12 @@ import WeakDependencyMap from './WeakDependencyMap.js';
 import { EntityInterface } from '../interface.js';
 import { EntityPath } from '../types.js';
 
-export interface EntityCache {
-  [key: string]: {
-    [pk: string]: WeakMap<
-      EntityInterface,
-      WeakDependencyMap<EntityPath, object, any>
-    >;
-  };
-}
+export interface EntityCache
+  extends Map<
+    string,
+    Map<
+      string,
+      WeakMap<EntityInterface, WeakDependencyMap<EntityPath, object, any>>
+    >
+  > {}
 export type EndpointsCache = WeakDependencyMap<EntityPath, object, any>;

--- a/packages/normalizr/src/normalizr/getCheckLoop.ts
+++ b/packages/normalizr/src/normalizr/getCheckLoop.ts
@@ -1,19 +1,23 @@
 export function getCheckLoop() {
-  const visitedEntities = {};
+  const visitedEntities = new Map<string, Map<string, object[]>>();
   /* Returns true if a circular reference is found */
   return function checkLoop(entityKey: string, pk: string, input: object) {
-    if (!(entityKey in visitedEntities)) {
-      visitedEntities[entityKey] = {};
+    if (!visitedEntities.has(entityKey)) {
+      visitedEntities.set(entityKey, new Map<string, object[]>());
     }
-    if (!(pk in visitedEntities[entityKey])) {
-      visitedEntities[entityKey][pk] = [];
+    // we have to tell typescript this can't be undefined (due to line above)
+    const entitiesOneType: Map<string, object[]> = visitedEntities.get(
+      entityKey,
+    ) as Map<string, object[]>;
+
+    if (!entitiesOneType.has(pk)) {
+      entitiesOneType.set(pk, []);
     }
-    if (
-      visitedEntities[entityKey][pk].some((entity: any) => entity === input)
-    ) {
+    const visitedEntityList = entitiesOneType.get(pk) as object[];
+    if (visitedEntityList.some((entity: any) => entity === input)) {
       return true;
     }
-    visitedEntities[entityKey][pk].push(input);
+    visitedEntityList.push(input);
     return false;
   };
 }

--- a/packages/normalizr/src/normalizr/normalize.ts
+++ b/packages/normalizr/src/normalizr/normalize.ts
@@ -80,8 +80,8 @@ See https://dataclient.io/rest/api/RestEndpoint#parseResponse for more informati
     }
   }
 
-  const newEntities: E = {} as any;
-  const newIndexes: NormalizedIndex = {} as any;
+  const newEntities = new Map<string, Map<string, any>>();
+  const newIndexes = new Map<string, Map<string, any>>();
   const ret: NormalizedSchema<E, R> = {
     result: '' as any,
     entities: { ...entities },

--- a/packages/react/src/__tests__/integration-collections.tsx
+++ b/packages/react/src/__tests__/integration-collections.tsx
@@ -190,7 +190,6 @@ describe.each([
         resolverFixtures: [
           {
             endpoint: UnionResource.getList.push,
-            args: [],
             response(body) {
               return body;
             },
@@ -517,7 +516,6 @@ describe.each([
             resolverFixtures: [
               {
                 endpoint: TodoResource.getList.push,
-                args: [{ userId: '5' }, {}],
                 response({ userId }, body) {
                   return { id: Math.random(), userId, ...ensurePojo(body) };
                 },

--- a/packages/react/src/hooks/__tests__/useQuery.tsx
+++ b/packages/react/src/hooks/__tests__/useQuery.tsx
@@ -297,7 +297,6 @@ describe('useQuery()', () => {
         resolverFixtures: [
           {
             endpoint: UnionResource.getList.push,
-            args: [],
             response(body) {
               return body;
             },

--- a/packages/rest/src/RestHelpers.ts
+++ b/packages/rest/src/RestHelpers.ts
@@ -2,25 +2,31 @@ import { compile, PathFunction, parse } from 'path-to-regexp';
 
 import { ShortenPath } from './pathTypes.js';
 
-const urlBaseCache: Record<string, PathFunction<object>> = Object.create(null);
+const urlBaseCache: Map<string, PathFunction<object>> = new Map();
 export function getUrlBase(path: string): PathFunction {
-  if (!(path in urlBaseCache)) {
-    urlBaseCache[path] = compile(path, {
-      encode: encodeURIComponent,
-      validate: false,
-    });
-  }
-  return urlBaseCache[path];
-}
-
-const urlTokensCache: Record<string, Set<string>> = Object.create(null);
-export function getUrlTokens(path: string): Set<string> {
-  if (!(path in urlTokensCache)) {
-    urlTokensCache[path] = new Set(
-      parse(path).map(t => (typeof t === 'string' ? t : `${t['name']}`)),
+  if (!urlBaseCache.has(path)) {
+    urlBaseCache.set(
+      path,
+      compile(path, {
+        encode: encodeURIComponent,
+        validate: false,
+      }),
     );
   }
-  return urlTokensCache[path];
+  return urlBaseCache.get(path) as PathFunction;
+}
+
+const urlTokensCache: Map<string, Set<string>> = new Map();
+export function getUrlTokens(path: string): Set<string> {
+  if (!urlTokensCache.has(path)) {
+    urlTokensCache.set(
+      path,
+      new Set(
+        parse(path).map(t => (typeof t === 'string' ? t : `${t['name']}`)),
+      ),
+    );
+  }
+  return urlTokensCache.get(path) as Set<string>;
 }
 
 const proto = Object.prototype;

--- a/packages/test/src/MockController.ts
+++ b/packages/test/src/MockController.ts
@@ -1,8 +1,3 @@
-Object.hasOwn =
-  Object.hasOwn ||
-  /* istanbul ignore next */ function hasOwn(it, key) {
-    return Object.prototype.hasOwnProperty.call(it, key);
-  };
 import {
   actionTypes,
   Controller,
@@ -33,7 +28,7 @@ export function MockController<TBase extends typeof Controller, T>(
     // TODO: drop when drop support for destructuring (0.14 and below)
     declare protected _dispatch: D;
 
-    fixtureMap: Record<string, Fixture> = fixtureMap;
+    fixtureMap: Map<string, Fixture> = fixtureMap;
     interceptors: Interceptor<any>[] = interceptors;
     interceptorData: T = getInitialInterceptorData();
 
@@ -62,8 +57,8 @@ export function MockController<TBase extends typeof Controller, T>(
           // eslint-disable-next-line prefer-const
           let { key, args } = action;
           let fixture: Fixture | Interceptor | undefined;
-          if (Object.hasOwn(this.fixtureMap, key)) {
-            fixture = this.fixtureMap[key];
+          if (this.fixtureMap.has(key)) {
+            fixture = this.fixtureMap.get(key) as Fixture;
             if (!args) args = fixture.args;
             // exact matches take priority; now test ComputedFixture
           } else {

--- a/packages/test/src/createFixtureMap.tsx
+++ b/packages/test/src/createFixtureMap.tsx
@@ -1,12 +1,23 @@
 import type { Fixture, Interceptor } from './fixtureTypes.js';
 
 export function createFixtureMap(fixtures: (Fixture | Interceptor)[] = []) {
-  const map: Record<string, Fixture> = {};
+  const map: Map<string, Fixture> = new Map();
   const computed: Interceptor[] = [];
   for (const fixture of fixtures) {
     if ('args' in fixture) {
-      const key = fixture.endpoint.key(...fixture.args);
-      map[key] = fixture;
+      if (typeof fixture.response !== 'function') {
+        const key = fixture.endpoint.key(...fixture.args);
+        map.set(key, fixture);
+      } else {
+        // this has to be a typo. probably needs to remove args
+        console.warn(
+          `Fixture found with function response, and explicit args. Interceptors should not specify args.
+${fixture.endpoint.name}: ${JSON.stringify(fixture.args)}
+
+Treating as Interceptor`,
+        );
+        computed.push(fixture as any);
+      }
     } else {
       computed.push(fixture);
     }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#objects_vs._maps

Objects are intended to be used for...Objects. In other words, things with statically known keys. Map was developed to handle the hashmap function, even though in legacy javascript Objects were used for both.

Maps don't have the security problems, and not only are they faster base, they don't cause deopt thrashing which slows performance both for doing JITs as well as causing JIT misses, and not being able to JIT as many functions.

See MDN article for a full list of benefits.

We already require WeakMap, which was made after so this does not introduce any more support. (And Map is super old now!)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Up to 32% performance increase (getResponse for long)


### Followups

Experiment with State itself as a Map. This would also need an extra step for JSON serialization/deserialization.
