### PR TITLE
enhance: Change NetworkManager bookkeeping data structure for inflight fetches

### DIFF
--- a/.changeset/sour-horses-give.md
+++ b/.changeset/sour-horses-give.md
@@ -1,0 +1,22 @@
+---
+'@data-client/core': minor
+'@data-client/test': minor
+---
+
+Change NetworkManager bookkeeping data structure for inflight fetches
+
+BREAKING CHANGE: NetworkManager.fetched, NetworkManager.rejectors, NetworkManager.resolvers, NetworkManager.fetchedAt
+  -> NetworkManager.fetching
+
+
+#### Before
+
+```ts
+if (action.key in this.fetched)
+```
+
+#### After
+
+```ts
+if (this.fetching.has(action.key))
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export {
   default as NetworkManager,
   ResetError,
 } from './manager/NetworkManager.js';
+export type { FetchingMeta } from './manager/NetworkManager.js';
 export * from './state/GCPolicy.js';
 export {
   default as createReducer,

--- a/packages/test/src/makeRenderDataClient/index.tsx
+++ b/packages/test/src/makeRenderDataClient/index.tsx
@@ -83,9 +83,7 @@ export default function makeRenderDataHook(
     // TODO: move to return value
     renderDataClient.cleanup = () => {
       nm.cleanupDate = Infinity;
-      Object.values(nm['rejectors'] as Record<string, any>).forEach(rej => {
-        rej();
-      });
+      nm['fetching'].forEach(({ reject }) => reject());
       nm['clearAll']();
       managers.forEach(manager => manager.cleanup());
     };

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -889,6 +889,12 @@ declare class ResetError extends Error {
     name: string;
     constructor();
 }
+interface FetchingMeta {
+    promise: Promise<any>;
+    resolve: (value?: any) => void;
+    reject: (value?: any) => void;
+    fetchedAt: number;
+}
 /** Handles all async network dispatches
  *
  * Dedupes concurrent requests by keeping track of all fetches in flight
@@ -899,18 +905,7 @@ declare class ResetError extends Error {
  * @see https://dataclient.io/docs/api/NetworkManager
  */
 declare class NetworkManager implements Manager {
-    protected fetched: {
-        [k: string]: Promise<any>;
-    };
-    protected resolvers: {
-        [k: string]: (value?: any) => void;
-    };
-    protected rejectors: {
-        [k: string]: (value?: any) => void;
-    };
-    protected fetchedAt: {
-        [k: string]: number;
-    };
+    protected fetching: Map<string, FetchingMeta>;
     readonly dataExpiryLength: number;
     readonly errorExpiryLength: number;
     protected controller: Controller;
@@ -1371,4 +1366,4 @@ interface Props {
     shouldLogout?: (error: UnknownError) => boolean;
 }
 
-export { type AbstractInstanceType, type ActionMeta, type ActionTypes, type ConnectionListener, Controller, type CreateCountRef, type DataClientDispatch, DefaultConnectionListener, type Denormalize, type DenormalizeNullable, type DevToolsConfig, DevToolsManager, type Dispatch, type EndpointExtraOptions, type EndpointInterface, type EndpointUpdateFunction, type EntityInterface, type ErrorTypes, type ExpireAllAction, ExpiryStatus, type FetchAction, type FetchFunction, type FetchMeta, type GCAction, type GCInterface, type GCOptions, GCPolicy, type GenericDispatch, type INormalizeDelegate, type IQueryDelegate, ImmortalGCPolicy, type InvalidateAction, type InvalidateAllAction, LogoutManager, type Manager, type Mergeable, type Middleware, type MiddlewareAPI, type NI, type NetworkError, NetworkManager, type Normalize, type NormalizeNullable, type OptimisticAction, type PK, PollingSubscription, type Queryable, type ResetAction, ResetError, type ResolveType, type ResultEntry, type Schema, type SchemaArgs, type SchemaClass, type SetAction, type SetResponseAction, type SetResponseActionBase, type SetResponseActionError, type SetResponseActionSuccess, type State, type SubscribeAction, SubscriptionManager, type UnknownError, type UnsubscribeAction, type UpdateFunction, internal_d as __INTERNAL__, actionTypes_d as actionTypes, index_d as actions, applyManager, createReducer, initManager, initialState };
+export { type AbstractInstanceType, type ActionMeta, type ActionTypes, type ConnectionListener, Controller, type CreateCountRef, type DataClientDispatch, DefaultConnectionListener, type Denormalize, type DenormalizeNullable, type DevToolsConfig, DevToolsManager, type Dispatch, type EndpointExtraOptions, type EndpointInterface, type EndpointUpdateFunction, type EntityInterface, type ErrorTypes, type ExpireAllAction, ExpiryStatus, type FetchAction, type FetchFunction, type FetchMeta, type FetchingMeta, type GCAction, type GCInterface, type GCOptions, GCPolicy, type GenericDispatch, type INormalizeDelegate, type IQueryDelegate, ImmortalGCPolicy, type InvalidateAction, type InvalidateAllAction, LogoutManager, type Manager, type Mergeable, type Middleware, type MiddlewareAPI, type NI, type NetworkError, NetworkManager, type Normalize, type NormalizeNullable, type OptimisticAction, type PK, PollingSubscription, type Queryable, type ResetAction, ResetError, type ResolveType, type ResultEntry, type Schema, type SchemaArgs, type SchemaClass, type SetAction, type SetResponseAction, type SetResponseActionBase, type SetResponseActionError, type SetResponseActionSuccess, type State, type SubscribeAction, SubscriptionManager, type UnknownError, type UnsubscribeAction, type UpdateFunction, internal_d as __INTERNAL__, actionTypes_d as actionTypes, index_d as actions, applyManager, createReducer, initManager, initialState };


### PR DESCRIPTION
BREAKING CHANGE: NetworkManager.fetched, NetworkManager.rejectors, NetworkManager.resolvers, NetworkManager.fetchedAt
  -> NetworkManager.fetching

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Better performance, security, and readability

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```ts
fetching: Map<string, FetchMeta>;
```

```ts
interface FetchingMeta {
  promise: Promise<any>;
  resolve: (value?: any) => void;
  reject: (value?: any) => void;
  fetchedAt: number;
}
```

#### Before

```ts
if (action.key in this.fetched)
```

#### After

```ts
if (this.fetching.has(action.key))
```