### PR TITLE
enhance: ImmutableJS always denormalizes to normal JS

### DIFF
--- a/.changeset/brave-bats-itch.md
+++ b/.changeset/brave-bats-itch.md
@@ -1,0 +1,9 @@
+---
+'@data-client/normalizr': minor
+---
+
+BREAKING CHANGE: Denormalize always transforms immutablejs entities into the class
+
+Previously using ImmutableJS structures when calling denormalize() would maintain
+nested schemas as immutablejs structures still. Now everything is converted to normal JS.
+This is how the types have always been specified.

--- a/docs/core/concepts/normalization.md
+++ b/docs/core/concepts/normalization.md
@@ -392,7 +392,7 @@ xychart-beta
     title "Denormalize Single Entity"
     x-axis [normalizr, "Data Client", "Data Client (cached)"]
     y-axis "Operations per second" 0 --> 5618500
-    bar [212500, 1288500, 5618500]
+    bar [212500, 1341000, 5618500]
 ```
 
 ```mermaid
@@ -400,7 +400,7 @@ xychart-beta
     title "Denormalize Large List"
     x-axis [normalizr, "Data Client", "Data Client (cached)"]
     y-axis "Operations per second" 0 --> 12962
-    bar [1151, 1807, 13182]
+    bar [1151, 1986, 13182]
 ```
 
 </Grid>

--- a/examples/benchmark/old-normalizr/normalizr.js
+++ b/examples/benchmark/old-normalizr/normalizr.js
@@ -46,8 +46,6 @@ function mergeWithStore({ entities, result }, storeState) {
 
 let curState = state;
 export default function addNormlizrSuite(suite) {
-  %OptimizeFunctionOnNextCall(normalize);
-  %OptimizeFunctionOnNextCall(denormalize);
   return suite
     .add('normalizeLong', () => {
       return mergeWithStore(normalize(data, ProjectSchema), state);
@@ -63,7 +61,7 @@ export default function addNormlizrSuite(suite) {
     })
     .add('denormalizeShort donotcache 500x', () => {
       for (let i = 0; i < 500; ++i) {
-        const user = denormalize('gnoff', User, githubState.entities);
+        var user = denormalize('gnoff', User, githubState.entities);
         // legacy normalizr doesn't convert this for us, so we must do manually afterward.
         user.createdAt = new Date(user.createdAt);
         user.updatedAt = new Date(user.updatedAt);

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -812,10 +812,8 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
 
-    expect(denormalize(Menu, '1', entities)).toMatchSnapshot();
     expect(denormalize(Menu, '1', fromJS(entities))).toMatchSnapshot();
 
-    expect(denormalize(Menu, '2', entities)).toMatchSnapshot();
     expect(denormalize(Menu, '2', fromJS(entities))).toMatchSnapshot();
   });
 

--- a/packages/endpoint/src/schemas/__tests__/EntityMixin.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntityMixin.test.ts
@@ -948,10 +948,8 @@ describe(`${schema.Entity.name} denormalization`, () => {
       },
     };
 
-    expect(denormalize(Menu, '1', entities)).toMatchSnapshot();
     expect(denormalize(Menu, '1', fromJS(entities))).toMatchSnapshot();
 
-    expect(denormalize(Menu, '2', entities)).toMatchSnapshot();
     expect(denormalize(Menu, '2', fromJS(entities))).toMatchSnapshot();
   });
 

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
@@ -61,22 +61,6 @@ Menu {
 
 exports[`Entity denormalization denormalizes deep entities with records 2`] = `
 Menu {
-  "food": Food {
-    "id": "1",
-  },
-  "id": "1",
-}
-`;
-
-exports[`Entity denormalization denormalizes deep entities with records 3`] = `
-Menu {
-  "food": null,
-  "id": "2",
-}
-`;
-
-exports[`Entity denormalization denormalizes deep entities with records 4`] = `
-Menu {
   "food": null,
   "id": "2",
 }
@@ -107,7 +91,7 @@ exports[`Entity denormalization denormalizes recursive dependencies 2`] = `
 Report {
   "draftedBy": User {
     "id": "456",
-    "reports": Immutable.List [
+    "reports": [
       [Circular],
     ],
     "role": "manager",
@@ -115,7 +99,7 @@ Report {
   "id": "123",
   "publishedBy": User {
     "id": "456",
-    "reports": Immutable.List [
+    "reports": [
       [Circular],
     ],
     "role": "manager",
@@ -142,7 +126,7 @@ User {
 exports[`Entity denormalization denormalizes recursive dependencies 4`] = `
 User {
   "id": "456",
-  "reports": Immutable.List [
+  "reports": [
     Report {
       "draftedBy": [Circular],
       "id": "123",

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/EntityMixin.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/EntityMixin.test.ts.snap
@@ -76,22 +76,6 @@ Menu {
 
 exports[`EntityMixin denormalization denormalizes deep entities with records 2`] = `
 Menu {
-  "food": Food {
-    "id": "1",
-  },
-  "id": "1",
-}
-`;
-
-exports[`EntityMixin denormalization denormalizes deep entities with records 3`] = `
-Menu {
-  "food": null,
-  "id": "2",
-}
-`;
-
-exports[`EntityMixin denormalization denormalizes deep entities with records 4`] = `
-Menu {
   "food": null,
   "id": "2",
 }
@@ -148,7 +132,7 @@ exports[`EntityMixin denormalization nesting denormalizes recursive dependencies
 Report {
   "draftedBy": User {
     "id": "456",
-    "reports": Immutable.List [
+    "reports": [
       [Circular],
     ],
     "role": "manager",
@@ -156,7 +140,7 @@ Report {
   "id": "123",
   "publishedBy": User {
     "id": "456",
-    "reports": Immutable.List [
+    "reports": [
       [Circular],
     ],
     "role": "manager",
@@ -183,7 +167,7 @@ User {
 exports[`EntityMixin denormalization nesting denormalizes recursive dependencies 4`] = `
 User {
   "id": "456",
-  "reports": Immutable.List [
+  "reports": [
     Report {
       "draftedBy": [Circular],
       "id": "123",

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -461,69 +461,69 @@ exports[`input (immutable) ValuesSchema denormalization (current) works on compl
   "data": {
     "estimates": {
       "BTC": Estimate {
-        "coinbase_fees": Immutable.Map {
+        "coinbase_fees": {
           "amount": "0.00002270",
           "currency": "BTC",
         },
         "confirmation_duration": 900,
-        "exchange": Immutable.Map {
-          "rate": "6820.07",
+        "exchange": {
+          "crypto": "BTC",
           "local": "USD",
-          "crypto": "BTC",
-        },
-        "exchange_to_proceeds": Immutable.Map {
           "rate": "6820.07",
-          "local": "EUR",
-          "crypto": "BTC",
         },
-        "fee": Immutable.Map {
+        "exchange_to_proceeds": {
+          "crypto": "BTC",
+          "local": "EUR",
+          "rate": "6820.07",
+        },
+        "fee": {
           "amount": "0.00002270",
           "currency": "BTC",
         },
-        "fee_per_kb": Immutable.Map {
+        "fee_per_kb": {
           "amount": "0.00016566",
           "currency": "BTC",
         },
-        "min_order_size": Immutable.Map {
+        "min_order_size": {
           "amount": "0.001",
           "currency": "BTC",
         },
         "priority": "fast",
-        "recipient_value": Immutable.Map {
+        "recipient_value": {
           "amount": "0.00054147",
           "currency": "BTC",
         },
       },
       "ETH": Estimate {
-        "coinbase_fees": Immutable.Map {
+        "coinbase_fees": {
           "amount": "0.00002270",
           "currency": "BTC",
         },
         "confirmation_duration": 900,
-        "exchange": Immutable.Map {
-          "rate": "197.07",
-          "local": "USD",
+        "exchange": {
           "crypto": "ETH",
+          "local": "USD",
+          "rate": "197.07",
         },
-        "exchange_to_proceeds": Immutable.Map {
-          "rate": "6820.07",
-          "local": "EUR",
+        "exchange_to_proceeds": {
           "crypto": "BTC",
+          "local": "EUR",
+          "rate": "6820.07",
         },
-        "fee": Immutable.Map {
+        "fee": {
           "amount": "0.03795",
           "currency": "ETH",
         },
-        "fee_per_kb": Immutable.Map {
+        "fee_per_kb": {
           "amount": "0.00086",
           "currency": "ETH",
         },
-        "min_order_size": Immutable.Map {
+        "min_order_size": {
           "amount": "0.001",
           "currency": "BTC",
         },
         "priority": "fast",
-        "recipient_value": Immutable.Map {
+        "recipient_value": {
           "amount": "2.53",
           "currency": "ETH",
         },

--- a/packages/normalizr/src/denormalize/denormalize.ts
+++ b/packages/normalizr/src/denormalize/denormalize.ts
@@ -2,6 +2,7 @@ import { getEntities } from './getEntities.js';
 import LocalCache from './localCache.js';
 import getUnvisit from './unvisit.js';
 import type { Schema } from '../interface.js';
+import { isImmutable } from '../schemas/ImmutableUtils.js';
 import type { DenormalizeNullable } from '../types.js';
 
 export function denormalize<S extends Schema>(
@@ -19,5 +20,6 @@ export function denormalize<S extends Schema>(
     getEntities(entities),
     new LocalCache(),
     args,
+    isImmutable(entities),
   )(schema, input).data;
 }

--- a/packages/normalizr/src/memo/MemoCache.ts
+++ b/packages/normalizr/src/memo/MemoCache.ts
@@ -50,6 +50,7 @@ export default class MemoCache {
       getEntity,
       new GlobalCache(getEntity, this.entities, this.endpoints),
       args,
+      isImmutable(entities),
     )(schema, input);
   }
 


### PR DESCRIPTION
BREAKING CHANGE: Denormalize always transforms immutablejs entities into the class

Previously using ImmutableJS structures when calling denormalize() would maintain
nested schemas as immutablejs structures still. Now everything is converted to normal JS.
This is how the types have always been specified.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Think through use of immutablejs. Maximize performance and compatibility.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Don't check objects are immutable everywhere.

### Next Work

ideal case:
- immutablejs used for lookup table. but normalize does not turn entitys or such into immutablejs themselves
- then when denormalizing on normal path, no conversion needs to be done
- collections should normalize to immutablelist as they like to be mutated and potentially are long

also support immutablejs at entity level
- have special immutablejsentity (maybe RecordEntity or such) that will keep immutable structures in normalization and denormalization stages. this will have special code
- since this will assume records, we don't even need to convert it to js to call on the lifecycles as they expect immutablejs structures


*then we can remove all immutable checks beyond getEntity*
