### PR TITLE
internal: Test React Native with distinct react version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,9 @@ jobs:
             yarn workspace @data-client/test add --dev @testing-library/react-hooks 
             elif [ "<< parameters.react-version >>" == "^18" ]; then
             yarn up react@<< parameters.react-version >> react-dom@<< parameters.react-version >> react-test-renderer@<< parameters.react-version >>
-            yarn workspace @data-client/test add --dev @testing-library/react-hooks 
+            yarn workspace @data-client/test add --dev @testing-library/react-hooks
+            elif [ "<< parameters.react-version >>" == "native" ]; then
+            yarn up react@19.0.0 react-dom@19.0.0 react-test-renderer@19.0.0
             fi
       - run:
           name: Running Jest
@@ -121,10 +123,12 @@ jobs:
               yarn test:ci --maxWorkers=3 --selectProjects ReactDOM --testPathPattern packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "^18" ]; then
               yarn test:ci --maxWorkers=4 --selectProjects ReactDOM --testPathPattern packages/react packages/use-enhanced-reducer packages/img
+            elif [ "<< parameters.react-version >>" == "native" ]; then
+              yarn test:ci --maxWorkers=4 --selectProjects ReactNative
             else
               curl -Os https://uploader.codecov.io/latest/linux/codecov;
               chmod +x codecov;
-              yarn run test:coverage --ci --maxWorkers=3 --coverageReporters=text-lcov > ./lcov.info;
+              yarn run test:coverage --ci --maxWorkers=3 --selectProjects ReactDOM Node --coverageReporters=text-lcov > ./lcov.info;
               if [ "$CODECOV_TOKEN" != "" ]; then
                 ./codecov -t ${CODECOV_TOKEN} < ./lcov.info || true;
               else
@@ -246,7 +250,7 @@ workflows:
       - unit_tests:
           matrix:
             parameters:
-              react-version: ["^17", "^18", "latest"]
+              react-version: ["^17", "^18", "native", "latest"]
           requires:
             - setup
       - node_matrix:


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
React Native always needs a very specific version; so running the RN tests with the current version keeps breaking and not allowing us to test or develop against the latest releases.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Instead of constantly changing where RN gets tested with each release, we will maintain a distinct CI job for react native tests so it can be independently adjusted from all other react version tests.