### PR TITLE
enhance: Consolidate controller expiry logic in private getExpiryStatus()

### DIFF
--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -807,7 +807,7 @@ declare class Controller<D extends GenericDispatch = DataClientDispatch> {
         data: DenormalizeNullable<S> | undefined;
         countRef: () => () => void;
     };
-    private getSchemaResponse;
+    private getExpiryStatus;
 }
 
 declare class Snapshot<T = unknown> implements SnapshotInterface {

--- a/website/src/components/Playground/editor-types/bignumber.d.ts
+++ b/website/src/components/Playground/editor-types/bignumber.d.ts
@@ -5,9 +5,7 @@
 
 // Documentation: http://mikemcl.github.io/bignumber.js/
 //
-// Exports:
-//
-//   class     BigNumber (default export)
+//   class     BigNumber
 //   type      BigNumber.Constructor
 //   type      BigNumber.ModuloMode
 //   type      BigNumber.RoundingMode
@@ -31,9 +29,7 @@
 //
 // The use of compiler option `--strictNullChecks` is recommended.
 
-export default BigNumber;
-
-export namespace BigNumber {
+declare namespace BigNumber {
 
   /** See `BigNumber.config` (alias `BigNumber.set`) and `BigNumber.clone`. */
   interface Config {
@@ -324,10 +320,10 @@ export namespace BigNumber {
   type Constructor = typeof BigNumber;
   type ModuloMode = 0 | 1 | 3 | 6 | 9;
   type RoundingMode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-  type Value = string | number | Instance;
+  type Value = string | number | bigint | Instance;
 }
 
-export declare class BigNumber implements BigNumber.Instance {
+declare class BigNumber implements BigNumber.Instance {
 
   /** Used internally to identify a BigNumber instance. */
   private readonly _isBigNumber: true;
@@ -343,7 +339,7 @@ export declare class BigNumber implements BigNumber.Instance {
 
   /**
    * Returns a new instance of a BigNumber object with value `n`, where `n` is a numeric value in
-   * the specified `base`, or base 10 if `base` is omitted or is `null` or `undefined`.
+   * the specified `base`, or base 10 if `base` is omitted.
    *
    * ```ts
    * x = new BigNumber(123.4567)              // '123.4567'
@@ -485,17 +481,16 @@ export declare class BigNumber implements BigNumber.Instance {
    * @param n A numeric value.
    * @param [base] The base of n.
    */
-  comparedTo(n: BigNumber.Value, base?: number): number;
+  comparedTo(n: BigNumber.Value, base?: number): 1 | -1 | 0 | null;
 
   /**
    * Returns a BigNumber whose value is the value of this BigNumber rounded by rounding mode
    * `roundingMode` to a maximum of `decimalPlaces` decimal places.
    *
-   * If `decimalPlaces` is omitted, or is `null` or `undefined`, the return value is the number of
-   * decimal places of the value of this BigNumber, or `null` if the value of this BigNumber is
-   * ±`Infinity` or `NaN`.
+   * If `decimalPlaces` is omitted, the return value is the number of decimal places of the value of
+   * this BigNumber, or `null` if the value of this BigNumber is ±`Infinity` or `NaN`.
    *
-   * If `roundingMode` is omitted, or is `null` or `undefined`, `ROUNDING_MODE` is used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` is used.
    *
    * Throws if `decimalPlaces` or `roundingMode` is invalid.
    *
@@ -524,11 +519,10 @@ export declare class BigNumber implements BigNumber.Instance {
    * Returns a BigNumber whose value is the value of this BigNumber rounded by rounding mode
    * `roundingMode` to a maximum of `decimalPlaces` decimal places.
    *
-   * If `decimalPlaces` is omitted, or is `null` or `undefined`, the return value is the number of
-   * decimal places of the value of this BigNumber, or `null` if the value of this BigNumber is
-   * ±`Infinity` or `NaN`.
+   * If `decimalPlaces` is omitted, the return value is the number of decimal places of the value of
+   * this BigNumber, or `null` if the value of this BigNumber is ±`Infinity` or `NaN`.
    *
-   * If `roundingMode` is omitted, or is `null` or `undefined`, `ROUNDING_MODE` is used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` is used.
    *
    * Throws if `decimalPlaces` or `roundingMode` is invalid.
    *
@@ -693,7 +687,7 @@ export declare class BigNumber implements BigNumber.Instance {
    * Returns a BigNumber whose value is the value of this BigNumber rounded to an integer using
    * rounding mode `rm`.
    *
-   * If `rm` is omitted, or is `null` or `undefined`, `ROUNDING_MODE` is used.
+   * If `rm` is omitted, `ROUNDING_MODE` is used.
    *
    * Throws if `rm` is invalid.
    *
@@ -790,7 +784,7 @@ export declare class BigNumber implements BigNumber.Instance {
    * returns `false`.
    *
    * ```ts
-   * 0.1 > (0.3 - 0                     // true
+   * 0.1 > (0.3 - 0.2)                  // true
    * x = new BigNumber(0.1)
    * x.gt(BigNumber(0.3).minus(0.2))    // false
    * BigNumber(0).gt(x)                 // false
@@ -1122,7 +1116,7 @@ export declare class BigNumber implements BigNumber.Instance {
    * Returns a BigNumber whose value is the value of this BigNumber rounded to a precision of
    * `significantDigits` significant digits using rounding mode `roundingMode`.
    *
-   * If `roundingMode` is omitted or is `null` or `undefined`, `ROUNDING_MODE` will be used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` will be used.
    *
    * Throws if `significantDigits` or `roundingMode` is invalid.
    *
@@ -1166,7 +1160,7 @@ export declare class BigNumber implements BigNumber.Instance {
    * Returns a BigNumber whose value is the value of this BigNumber rounded to a precision of
    * `significantDigits` significant digits using rounding mode `roundingMode`.
    *
-   * If `roundingMode` is omitted or is `null` or `undefined`, `ROUNDING_MODE` will be used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` will be used.
    *
    * Throws if `significantDigits` or `roundingMode` is invalid.
    *
@@ -1244,11 +1238,10 @@ export declare class BigNumber implements BigNumber.Instance {
    * If the value of this BigNumber in exponential notation has fewer than `decimalPlaces` fraction
    * digits, the return value will be appended with zeros accordingly.
    *
-   * If `decimalPlaces` is omitted, or is `null` or `undefined`, the number of digits after the
-   * decimal point defaults to the minimum number of digits necessary to represent the value
-   * exactly.
+   * If `decimalPlaces` is omitted, the number of digits after the decimal point defaults to the
+   * minimum number of digits necessary to represent the value exactly.
    *
-   * If `roundingMode` is omitted or is `null` or `undefined`, `ROUNDING_MODE` is used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` is used.
    *
    * Throws if `decimalPlaces` or `roundingMode` is invalid.
    *
@@ -1282,12 +1275,12 @@ export declare class BigNumber implements BigNumber.Instance {
    * Unlike `Number.prototype.toFixed`, which returns exponential notation if a number is greater or
    * equal to 10**21, this method will always return normal notation.
    *
-   * If `decimalPlaces` is omitted or is `null` or `undefined`, the return value will be unrounded
-   * and in normal notation. This is also unlike `Number.prototype.toFixed`, which returns the value
-   * to zero decimal places. It is useful when normal notation is required and the current
-   * `EXPONENTIAL_AT` setting causes `toString` to return exponential notation.
+   * If `decimalPlaces` is omitted, the return value will be unrounded and in normal notation.
+   * This is also unlike `Number.prototype.toFixed`, which returns the value to zero decimal places.
+   * It is useful when normal notation is required and the current `EXPONENTIAL_AT` setting causes
+   * `toString` to return exponential notation.
    *
-   * If `roundingMode` is omitted or is `null` or `undefined`, `ROUNDING_MODE` is used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` is used.
    *
    * Throws if `decimalPlaces` or `roundingMode` is invalid.
    *
@@ -1317,12 +1310,12 @@ export declare class BigNumber implements BigNumber.Instance {
    *
    * The formatting object may contain some or all of the properties shown in the examples below.
    *
-   * If `decimalPlaces` is omitted or is `null` or `undefined`, then the return value is not
-   * rounded to a fixed number of decimal places.
+   * If `decimalPlaces` is omitted, then the return value is not rounded to a fixed number of
+   * decimal places.
    *
-   * If `roundingMode` is omitted or is `null` or `undefined`, `ROUNDING_MODE` is used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` is used.
    *
-   * If `format` is omitted or is `null` or `undefined`, `FORMAT` is used.
+   * If `format` is omitted, `FORMAT` is used.
    *
    * Throws if `decimalPlaces`, `roundingMode`, or `format` is invalid.
    *
@@ -1378,8 +1371,8 @@ export declare class BigNumber implements BigNumber.Instance {
    * Returns an array of two BigNumbers representing the value of this BigNumber as a simple
    * fraction with an integer numerator and an integer denominator.
    * The denominator will be a positive non-zero value less than or equal to `max_denominator`.
-   * If a maximum denominator, `max_denominator`, is not specified, or is `null` or `undefined`, the
-   * denominator will be the lowest value necessary to represent the number exactly.
+   * If a maximum denominator, `max_denominator`, is not specified, the denominator will be the
+   * lowest value necessary to represent the number exactly.
    *
    * Throws if `max_denominator` is invalid.
    *
@@ -1430,10 +1423,9 @@ export declare class BigNumber implements BigNumber.Instance {
    * If `significantDigits` is less than the number of digits necessary to represent the integer
    * part of the value in normal (fixed-point) notation, then exponential notation is used.
    *
-   * If `significantDigits` is omitted, or is `null` or `undefined`, then the return value is the
-   * same as `n.toString()`.
+   * If `significantDigits` is omitted, then the return value is the same as `n.toString()`.
    *
-   * If `roundingMode` is omitted or is `null` or `undefined`, `ROUNDING_MODE` is used.
+   * If `roundingMode` is omitted, `ROUNDING_MODE` is used.
    *
    * Throws if `significantDigits` or `roundingMode` is invalid.
    *
@@ -1458,7 +1450,7 @@ export declare class BigNumber implements BigNumber.Instance {
 
   /**
    * Returns a string representing the value of this BigNumber in base `base`, or base 10 if `base`
-   * is omitted or is `null` or `undefined`.
+   * is omitted.
    *
    * For bases above 10, and using the default base conversion alphabet (see `ALPHABET`), values
    * from 10 to 35 are represented by a-z (the same as `Number.prototype.toString`).
@@ -1470,8 +1462,6 @@ export declare class BigNumber implements BigNumber.Instance {
    * greater than the positive component of the current `EXPONENTIAL_AT` setting, or a negative
    * exponent equal to or less than the negative component of the setting, then exponential notation
    * is returned.
-   *
-   * If `base` is `null` or `undefined` it is ignored.
    *
    * Throws if `base` is invalid.
    *
@@ -1592,7 +1582,7 @@ export declare class BigNumber implements BigNumber.Instance {
 
   /**
    * Returns a new independent BigNumber constructor with configuration as described by `object`, or
-   * with the default configuration if object is `null` or `undefined`.
+   * with the default configuration if object is omitted.
    *
    * Throws if `object` is not an object.
    *
@@ -1828,4 +1818,4 @@ export declare class BigNumber implements BigNumber.Instance {
   static set(object?: BigNumber.Config): BigNumber.Config;
 }
 
-export function BigNumber(n: BigNumber.Value, base?: number): BigNumber;
+declare function BigNumber(n: BigNumber.Value, base?: number): BigNumber;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Cleaner abstraction boundary; shared code path

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

```ts
  private getExpiryStatus(
    invalidDenormalize: boolean,
    invalidIfStale: boolean,
    meta: { error?: unknown; invalidated?: unknown } = {},
  ) {
    // https://dataclient.io/docs/concepts/expiry-policy#expiry-status
    // we don't track the difference between stale or fresh because that is tied to triggering
    // conditions
    return (
      meta.invalidated || (invalidDenormalize && !meta.error) ?
        ExpiryStatus.Invalid
      : invalidDenormalize || invalidIfStale ? ExpiryStatus.InvalidIfStale
      : ExpiryStatus.Valid
    );
  }
```

