### PR TITLE
enhance: state.entityMeta -> state.entitiesMeta

### DIFF
--- a/.changeset/sixty-monkeys-open.md
+++ b/.changeset/sixty-monkeys-open.md
@@ -1,0 +1,7 @@
+---
+'@data-client/normalizr': minor
+'@data-client/react': minor
+'@data-client/core': minor
+---
+
+state.entityMeta -> state.entitiesMeta

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -25,12 +25,12 @@ export function mockEventHandlers() {
 export function createEntityMeta(
   entities: Record<string, Record<string, any>>,
 ) {
-  const entityMeta: any = {};
+  const entitiesMeta: any = {};
   for (const k in entities) {
-    entityMeta[k] = {};
+    entitiesMeta[k] = {};
     for (const pk in entities[k]) {
-      entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+      entitiesMeta[k][pk] = { date: 0, expiresAt: 0 };
     }
   }
-  return entityMeta;
+  return entitiesMeta;
 }

--- a/docs/core/api/DataProvider.md
+++ b/docs/core/api/DataProvider.md
@@ -54,7 +54,7 @@ export interface State<T> {
       readonly errorPolicy?: 'hard' | 'soft' | undefined;
     };
   };
-  readonly entityMeta: {
+  readonly entitiesMeta: {
     readonly [entityKey: string]: {
       readonly [pk: string]: {
         readonly date: number;

--- a/docs/core/api/types.md
+++ b/docs/core/api/types.md
@@ -57,7 +57,7 @@ interface State<T> {
       readonly errorPolicy?: 'hard' | 'soft' | undefined;
     };
   };
-  readonly entityMeta: {
+  readonly entitiesMeta: {
     readonly [entityKey: string]: {
       readonly [pk: string]: {
         readonly date: number;

--- a/docs/rest/api/schema.md
+++ b/docs/rest/api/schema.md
@@ -142,7 +142,7 @@ Now, `normalizedData` will create a single serializable source of truth for all 
   },
   // contents excluded for brevity
   indexes,
-  entityMeta,
+  entitiesMeta,
 }
 ```
 

--- a/examples/normalizr-relationships/output.json
+++ b/examples/normalizr-relationships/output.json
@@ -81,7 +81,7 @@
     "1",
     "2"
   ],
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "123": {
         "expiresAt": null,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,7 +48,7 @@ function useSuspense(endpoint, ...args)
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -563,7 +563,7 @@ export default class Controller<
       // note: isInvalid can only be true if shouldQuery is true
       if (isInvalid) expiresAt = 1;
       // fallback to entity expiry time
-      else expiresAt = entityExpiresAt(paths, state.entityMeta);
+      else expiresAt = entityExpiresAt(paths, state.entitiesMeta);
     }
 
     return {
@@ -664,7 +664,7 @@ export default class Controller<
 // earliest expiry dictates age
 function entityExpiresAt(
   paths: EntityPath[],
-  entityMeta: {
+  entitiesMeta: {
     readonly [entityKey: string]: {
       readonly [pk: string]: {
         readonly date: number;
@@ -676,7 +676,7 @@ function entityExpiresAt(
 ) {
   let expiresAt = Infinity;
   for (const { pk, key } of paths) {
-    const entityExpiry = entityMeta[key]?.[pk]?.expiresAt;
+    const entityExpiry = entitiesMeta[key]?.[pk]?.expiresAt;
     // expiresAt will always resolve to false with any comparison
     if (entityExpiry < expiresAt) expiresAt = entityExpiry;
   }

--- a/packages/core/src/controller/__tests__/Controller.ts
+++ b/packages/core/src/controller/__tests__/Controller.ts
@@ -46,7 +46,7 @@ describe('Controller', () => {
         endpoints: {
           [fetchKey]: result,
         },
-        entityMeta: createEntityMeta(entities),
+        entitiesMeta: createEntityMeta(entities),
         meta: {
           [fetchKey]: {
             date: Date.now(),
@@ -85,7 +85,7 @@ describe('Controller', () => {
         endpoints: {
           [fetchKey]: result,
         },
-        entityMeta: createEntityMeta(entities),
+        entitiesMeta: createEntityMeta(entities),
         meta: {
           [fetchKey]: {
             date: 0,

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -152,7 +152,7 @@ describe('Controller.getResponse()', () => {
     const state = {
       ...initialState,
       entities,
-      entityMeta: {
+      entitiesMeta: {
         Tacos: {
           1: { date: 1000000, expiresAt: 1100000, fetchedAt: 1000000 },
           2: { date: 2000000, expiresAt: 2100000, fetchedAt: 2000000 },

--- a/packages/core/src/state/GCPolicy.ts
+++ b/packages/core/src/state/GCPolicy.ts
@@ -133,7 +133,7 @@ export class GCPolicy implements GCInterface {
       if (
         !this.entityCount.get(path.key)?.has(path.pk) &&
         this.expiresAt(
-          state.entityMeta[path.key]?.[path.pk] ?? {
+          state.entitiesMeta[path.key]?.[path.pk] ?? {
             fetchedAt: 0,
             date: 0,
             expiresAt: 0,

--- a/packages/core/src/state/__tests__/GCPolicy.test.ts
+++ b/packages/core/src/state/__tests__/GCPolicy.test.ts
@@ -48,7 +48,7 @@ describe('GCPolicy', () => {
           expiresAt: 0,
         },
       },
-      entityMeta: {
+      entitiesMeta: {
         testEntity: {
           '1': {
             date: 0,
@@ -90,7 +90,7 @@ describe('GCPolicy', () => {
           expiresAt: 0,
         },
       },
-      entityMeta: {
+      entitiesMeta: {
         testEntity: {
           '1': {
             date: 0,
@@ -127,7 +127,7 @@ describe('GCPolicy', () => {
     const paths: EntityPath[] = [{ key: 'testEntity', pk: '1' }];
     const state = {
       meta: {},
-      entityMeta: {},
+      entitiesMeta: {},
     };
     (controller.getState as jest.Mock).mockReturnValue(state);
 
@@ -163,7 +163,7 @@ describe('GCPolicy', () => {
           expiresAt: futureTime,
         },
       },
-      entityMeta: {
+      entitiesMeta: {
         testEntity: {
           '1': {
             date: futureTime - 100,
@@ -196,7 +196,7 @@ describe('GCPolicy', () => {
           expiresAt: 0,
         },
       },
-      entityMeta: {
+      entitiesMeta: {
         testEntity: {
           '1': {
             date: 0,
@@ -233,7 +233,7 @@ describe('GCPolicy', () => {
           expiresAt: futureTime,
         },
       },
-      entityMeta: {
+      entitiesMeta: {
         testEntity: {
           '1': {
             date: futureTime - 100,

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -4,7 +4,7 @@ exports[`reducer should set error in meta for "set" 1`] = `
 {
   "endpoints": {},
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "lastReset": 0,
   "meta": {
@@ -34,7 +34,7 @@ exports[`reducer singles should update state correctly 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Article": {
       "20": {
         "date": 5000000000,

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -84,10 +84,10 @@ describe('reducer', () => {
       expect(nextEntity.content).not.toBe(undefined);
 
       expect(
-        nextState.entityMeta[Article.key][`${Article.pk(action.response)}`],
+        nextState.entitiesMeta[Article.key][`${Article.pk(action.response)}`],
       ).toBeDefined();
       expect(
-        nextState.entityMeta[Article.key][`${Article.pk(action.response)}`]
+        nextState.entitiesMeta[Article.key][`${Article.pk(action.response)}`]
           .date,
       ).toBe(action.meta.date);
     });
@@ -102,7 +102,7 @@ describe('reducer', () => {
         },
       };
       const getMeta = (state: any): { expiresAt: number } =>
-        state.entityMeta[Article.key][`${Article.pk(action.response)}`];
+        state.entitiesMeta[Article.key][`${Article.pk(action.response)}`];
       const prevMeta = getMeta(newState);
       expect(prevMeta).toBeDefined();
       const nextState = reducer(newState, localAction);
@@ -123,7 +123,7 @@ describe('reducer', () => {
         },
       };
       const getMeta = (state: any): { date: number } =>
-        state.entityMeta[Article.key][`${Article.pk(action.response)}`];
+        state.entitiesMeta[Article.key][`${Article.pk(action.response)}`];
       const getEntity = (state: any): Article =>
         state.entities[Article.key][`${Article.pk(action.response)}`];
       const prevEntity = getEntity(newState);
@@ -182,7 +182,9 @@ describe('reducer', () => {
         },
       };
       const getMeta = (state: any): { date: number; expiresAt: number } =>
-        state.entityMeta[ExpiresSoon.key][`${ExpiresSoon.pk(action.response)}`];
+        state.entitiesMeta[ExpiresSoon.key][
+          `${ExpiresSoon.pk(action.response)}`
+        ];
       const getEntity = (state: any): ExpiresSoon =>
         state.entities[ExpiresSoon.key][`${ExpiresSoon.pk(action.response)}`];
 
@@ -259,7 +261,7 @@ describe('reducer', () => {
           [id]: { id, counter: 5 },
         },
       },
-      entityMeta: {
+      entitiesMeta: {
         [Counter.key]: {
           [id]: { date: 0, fetchedAt: 0, expiresAt: 0 },
         },
@@ -688,7 +690,7 @@ describe('reducer', () => {
           },
           '5': undefined,
         },
-        entityMeta: {
+        entitiesMeta: {
           [Article.key]: {
             '10': { date: 0, expiresAt: 10000, fetchedAt: 0 },
             '20': { date: 0, expiresAt: 10000, fetchedAt: 0 },
@@ -726,7 +728,7 @@ describe('reducer', () => {
       const newState = reducer(iniState, action);
       expect(newState).toBe(iniState);
       expect(Object.keys(newState.entities[Article.key] ?? {}).length).toBe(2);
-      expect(Object.keys(newState.entityMeta[Article.key] ?? {}).length).toBe(
+      expect(Object.keys(newState.entitiesMeta[Article.key] ?? {}).length).toBe(
         2,
       );
       expect(Object.keys(newState.endpoints).length).toBe(0);

--- a/packages/core/src/state/reducer/createReducer.ts
+++ b/packages/core/src/state/reducer/createReducer.ts
@@ -28,7 +28,7 @@ export default function createReducer(controller: Controller): ReducerType {
         // inline deletes are fine as these should have 0 refcounts
         action.entities.forEach(({ key, pk }) => {
           delete (state as any).entities[key]?.[pk];
-          delete (state as any).entityMeta[key]?.[pk];
+          delete (state as any).entitiesMeta[key]?.[pk];
         });
         action.endpoints.forEach(fetchKey => {
           delete (state as any).endpoints[fetchKey];
@@ -69,7 +69,7 @@ export const initialState: State<unknown> = {
   endpoints: {},
   indexes: {},
   meta: {},
-  entityMeta: {},
+  entitiesMeta: {},
   optimistic: [],
   lastReset: 0,
 };

--- a/packages/core/src/state/reducer/setReducer.ts
+++ b/packages/core/src/state/reducer/setReducer.ts
@@ -17,7 +17,7 @@ export function setReducer(
     value = action.value;
   }
   try {
-    const { entities, indexes, entityMeta } = normalize(
+    const { entities, indexes, entitiesMeta } = normalize(
       action.schema,
       value,
       action.args,
@@ -29,7 +29,7 @@ export function setReducer(
       endpoints: state.endpoints,
       indexes,
       meta: state.meta,
-      entityMeta,
+      entitiesMeta,
       optimistic: state.optimistic,
       lastReset: state.lastReset,
     };

--- a/packages/core/src/state/reducer/setResponseReducer.ts
+++ b/packages/core/src/state/reducer/setResponseReducer.ts
@@ -41,7 +41,7 @@ export function setResponseReducer(
     } else {
       response = action.response;
     }
-    const { result, entities, indexes, entityMeta } = normalize(
+    const { result, entities, indexes, entitiesMeta } = normalize(
       action.endpoint.schema,
       response,
       action.args,
@@ -80,7 +80,7 @@ export function setResponseReducer(
           prevExpiresAt: state.meta[action.key]?.expiresAt,
         },
       },
-      entityMeta,
+      entitiesMeta,
       optimistic: filterOptimistic(state, action),
       lastReset: state.lastReset,
     };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,7 +41,7 @@ export interface State<T> {
       readonly errorPolicy?: 'hard' | 'soft' | undefined;
     };
   };
-  readonly entityMeta: {
+  readonly entitiesMeta: {
     readonly [entityKey: string]: {
       readonly [pk: string]: {
         readonly fetchedAt: number;

--- a/packages/endpoint/src/normal.ts
+++ b/packages/endpoint/src/normal.ts
@@ -106,7 +106,7 @@ export type NormalizedSchema<E, R> = {
   entities: E;
   result: R;
   indexes: NormalizedIndex;
-  entityMeta: {
+  entitiesMeta: {
     readonly [entityKey: string]: {
       readonly [pk: string]: {
         readonly date: number;

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -249,7 +249,7 @@ describe(`${schema.Collection.name} normalization`, () => {
           },
         },
       },
-      entityMeta: {
+      entitiesMeta: {
         [User.schema.todos.key]: {
           '{"userId":"1"}': {
             date: 1557831718135,
@@ -456,7 +456,7 @@ describe(`${schema.Collection.name} denormalization`, () => {
         },
       },
     },
-    entityMeta: {
+    entitiesMeta: {
       [userTodos.key]: {
         '{"userId":"1"}': {
           date: 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -95,7 +95,7 @@ describe(`${Entity.name} normalization`, () => {
       }
     }
 
-    const { entities, entityMeta } = normalize(MyEntity, {
+    const { entities, entitiesMeta } = normalize(MyEntity, {
       id: '1',
       title: 'hi',
     });
@@ -103,7 +103,7 @@ describe(`${Entity.name} normalization`, () => {
       MyEntity,
       { id: '1', title: 'second' },
       [],
-      { entities, entityMeta, indexes: {} },
+      { entities, entitiesMeta, indexes: {} },
     ).entities;
     expect(entities.MyEntity['1']).toBeDefined();
     expect(entities.MyEntity['1']).toBe(secondEntities.MyEntity['1']);
@@ -184,7 +184,7 @@ describe(`${Entity.name} normalization`, () => {
             },
           },
         },
-        "entityMeta": {
+        "entitiesMeta": {
           "MyEntity": {
             "bob": {
               "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/EntityMixin.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/EntityMixin.test.ts
@@ -343,7 +343,7 @@ describe(`${schema.Entity.name} normalization`, () => {
         return false;
       }
     }
-    const { entities, entityMeta } = normalize(MyEntity, {
+    const { entities, entitiesMeta } = normalize(MyEntity, {
       id: '1',
       title: 'hi',
     });
@@ -351,7 +351,7 @@ describe(`${schema.Entity.name} normalization`, () => {
       MyEntity,
       { id: '1', title: 'second' },
       [],
-      { entities, entityMeta, indexes: {} },
+      { entities, entitiesMeta, indexes: {} },
     ).entities;
     expect(entities.MyEntity['1']).toBeDefined();
     expect(entities.MyEntity['1']).toBe(secondEntities.MyEntity['1']);
@@ -415,7 +415,7 @@ describe(`${schema.Entity.name} normalization`, () => {
             },
           },
         },
-        "entityMeta": {
+        "entitiesMeta": {
           "MyEntity": {
             "bob": {
               "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -9,7 +9,7 @@ exports[`ArraySchema normalization (plain) Class does not filter out undefined a
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "123": {
         "date": 1557831718135,
@@ -39,7 +39,7 @@ exports[`ArraySchema normalization (plain) Class normalizes Objects using their 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -73,7 +73,7 @@ exports[`ArraySchema normalization (plain) Class normalizes a single entity 1`] 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cats": {
       "1": {
         "date": 1557831718135,
@@ -115,7 +115,7 @@ exports[`ArraySchema normalization (plain) Class normalizes multiple entities 1`
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cats": {
       "123": {
         "date": 1557831718135,
@@ -375,7 +375,7 @@ exports[`ArraySchema normalization (plain) Object normalizes Objects using their
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -416,7 +416,7 @@ exports[`ArraySchema normalization (plain) Object passes its parent to its child
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Child": {
       "4": {
         "date": 1557831718135,
@@ -474,7 +474,7 @@ exports[`ArraySchema normalization (schema) Class does not filter out undefined 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "123": {
         "date": 1557831718135,
@@ -504,7 +504,7 @@ exports[`ArraySchema normalization (schema) Class normalizes Objects using their
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -538,7 +538,7 @@ exports[`ArraySchema normalization (schema) Class normalizes a single entity 1`]
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cats": {
       "1": {
         "date": 1557831718135,
@@ -580,7 +580,7 @@ exports[`ArraySchema normalization (schema) Class normalizes multiple entities 1
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cats": {
       "123": {
         "date": 1557831718135,
@@ -840,7 +840,7 @@ exports[`ArraySchema normalization (schema) Object normalizes Objects using thei
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -881,7 +881,7 @@ exports[`ArraySchema normalization (schema) Object passes its parent to its chil
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Child": {
       "4": {
         "date": 1557831718135,
@@ -1122,7 +1122,7 @@ exports[`input (direct) ArraySchema denormalization (class) does not assume mapp
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cat": {
       "1": {
         "date": 1557831718135,
@@ -1349,7 +1349,7 @@ exports[`input (direct) ArraySchema denormalization (object, direct) does not as
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cat": {
       "1": {
         "date": 1557831718135,
@@ -1614,7 +1614,7 @@ exports[`input (immutable) ArraySchema denormalization (class) does not assume m
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cat": {
       "1": {
         "date": 1557831718135,
@@ -1841,7 +1841,7 @@ exports[`input (immutable) ArraySchema denormalization (object, direct) does not
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cat": {
       "1": {
         "date": 1557831718135,
@@ -1926,7 +1926,7 @@ exports[`normalizes plain arrays as shorthand for ArraySchema 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
@@ -45,7 +45,7 @@ exports[`CollectionSchema normalization normalizes already processed entities 1`
       ],
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -88,7 +88,7 @@ exports[`CollectionSchema normalization normalizes nested collections 1`] = `
       ],
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Todo": {
       "5": {
         "date": 1557831718135,
@@ -143,7 +143,7 @@ exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
       ],
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Todo": {
       "10": {
         "date": 1557831718135,
@@ -193,7 +193,7 @@ exports[`CollectionSchema normalization normalizes top level collections (no arg
       ],
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Todo": {
       "5": {
         "date": 1557831718135,
@@ -229,7 +229,7 @@ exports[`CollectionSchema normalization normalizes top level collections 1`] = `
       ],
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Todo": {
       "5": {
         "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
@@ -159,7 +159,7 @@ exports[`Entity normalization mergeStrategy can use a custom merging strategy 1`
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MergeTaco": {
       "1": {
         "date": 1557831718135,
@@ -187,7 +187,7 @@ exports[`Entity normalization mergeStrategy defaults to plain merging 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Tacos": {
       "1": {
         "date": 1557831718135,
@@ -220,7 +220,7 @@ exports[`Entity normalization normalize throws error when id missing with no pk 
 exports[`Entity normalization normalizes already processed entities 1`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": [
     "1",
@@ -231,7 +231,7 @@ exports[`Entity normalization normalizes already processed entities 1`] = `
 exports[`Entity normalization normalizes already processed entities 2`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": {
     "data": "1",
@@ -250,7 +250,7 @@ exports[`Entity normalization normalizes already processed entities 3`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Nested": {
       "5": {
         "date": 1557831718135,
@@ -273,7 +273,7 @@ exports[`Entity normalization normalizes an entity 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyEntity": {
       "1": {
         "date": 1557831718135,
@@ -297,7 +297,7 @@ exports[`Entity normalization pk() can build the entity's ID from the parent obj
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "tacos-user-4": {
         "date": 1557831718135,
@@ -326,7 +326,7 @@ exports[`Entity normalization pk() can normalize entity IDs based on their objec
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "4": {
         "date": 1557831718135,
@@ -364,7 +364,7 @@ exports[`Entity normalization pk() can use a custom pk() string 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "134351": {
         "date": 1557831718135,
@@ -442,7 +442,7 @@ exports[`Entity normalization should allow many unexpected as long as none are m
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyEntity": {
       "hi": {
         "date": 1557831718135,
@@ -466,7 +466,7 @@ exports[`Entity normalization should not throw if schema key is missing from Ent
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyEntity": {
       "bob": {
         "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/EntityMixin.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/EntityMixin.test.ts.snap
@@ -174,7 +174,7 @@ exports[`EntityMixin normalization mergeStrategy can use a custom merging strate
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MergeTaco": {
       "1": {
         "date": 1557831718135,
@@ -202,7 +202,7 @@ exports[`EntityMixin normalization mergeStrategy defaults to plain merging 1`] =
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Tacos": {
       "1": {
         "date": 1557831718135,
@@ -222,7 +222,7 @@ exports[`EntityMixin normalization mergeStrategy defaults to plain merging 1`] =
 exports[`EntityMixin normalization normalizes already processed entities 1`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": [
     "1",
@@ -233,7 +233,7 @@ exports[`EntityMixin normalization normalizes already processed entities 1`] = `
 exports[`EntityMixin normalization normalizes already processed entities 2`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": {
     "data": "1",
@@ -252,7 +252,7 @@ exports[`EntityMixin normalization normalizes already processed entities 3`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Nested": {
       "5": {
         "date": 1557831718135,
@@ -275,7 +275,7 @@ exports[`EntityMixin normalization normalizes an entity 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyEntity": {
       "1": {
         "date": 1557831718135,
@@ -299,7 +299,7 @@ exports[`EntityMixin normalization pk() can build the entity's ID from the paren
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "tacos-user-4": {
         "date": 1557831718135,
@@ -328,7 +328,7 @@ exports[`EntityMixin normalization pk() can normalize entity IDs based on their 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "4": {
         "date": 1557831718135,
@@ -366,7 +366,7 @@ exports[`EntityMixin normalization pk() can use a custom pk() string 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "134351": {
         "date": 1557831718135,
@@ -456,7 +456,7 @@ exports[`EntityMixin normalization should allow many unexpected as long as none 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyEntity": {
       "hi": {
         "date": 1557831718135,
@@ -495,7 +495,7 @@ exports[`EntityMixin normalization should not throw if schema key is missing fro
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyData": {
       "bob": {
         "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Invalidate.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Invalidate.test.ts.snap
@@ -107,7 +107,7 @@ Immutable.Map {
 exports[`Invalidate normalization normalizes already processed entities 1`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": "1",
 }
@@ -116,7 +116,7 @@ exports[`Invalidate normalization normalizes already processed entities 1`] = `
 exports[`Invalidate normalization normalizes already processed entities 2`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": [
     "1",
@@ -132,7 +132,7 @@ exports[`Invalidate normalization normalizes an object 1`] = `
       "1": Symbol(INVALID),
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -165,7 +165,7 @@ exports[`ObjectSchema normalization filters out undefined and null values 1`] = 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -190,7 +190,7 @@ exports[`ObjectSchema normalization normalizes an object 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -215,7 +215,7 @@ exports[`ObjectSchema normalization normalizes plain objects as shorthand for Ob
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -240,7 +240,7 @@ exports[`ObjectSchema normalization should deserialize Date 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "5": {
         "date": 1557831718135,
@@ -267,7 +267,7 @@ exports[`ObjectSchema normalization should pass over when Date not provided 1`] 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "5": {
         "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
@@ -41,7 +41,7 @@ exports[`Serializable normalization normalizes date and custom as passthrough 1`
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -61,4 +61,4 @@ exports[`Serializable normalization normalizes date and custom as passthrough 1`
 }
 `;
 
-exports[`Serializable normalization normalizes date and custom as passthrough 2`] = `"{"result":{"user":"1","anotherItem":{"thing":500},"time":"2020-06-07T02:00:15+0000"},"entities":{"User":{"1":{"id":"1","name":"Nacho","createdAt":"2020-06-07T02:00:15+0000"}}},"indexes":{},"entityMeta":{"User":{"1":{"fetchedAt":0,"date":1557831718135,"expiresAt":null}}}}"`;
+exports[`Serializable normalization normalizes date and custom as passthrough 2`] = `"{"result":{"user":"1","anotherItem":{"thing":500},"time":"2020-06-07T02:00:15+0000"},"entities":{"User":{"1":{"id":"1","name":"Nacho","createdAt":"2020-06-07T02:00:15+0000"}}},"indexes":{},"entitiesMeta":{"User":{"1":{"fetchedAt":0,"date":1557831718135,"expiresAt":null}}}}"`;

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -10,7 +10,7 @@ exports[`UnionSchema normalization normalizes an array of multiple entities usin
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -37,7 +37,7 @@ exports[`UnionSchema normalization normalizes an array of multiple entities usin
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Group": {
       "2": {
         "date": 1557831718135,
@@ -57,7 +57,7 @@ exports[`UnionSchema normalization normalizes an array of multiple entities usin
 exports[`UnionSchema normalization normalizes an array of multiple entities using a function to infer the schemaAttribute 3`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": {
     "id": "3",
@@ -90,7 +90,7 @@ exports[`UnionSchema normalization normalizes an object using string schemaAttri
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "1": {
         "date": 1557831718135,
@@ -117,7 +117,7 @@ exports[`UnionSchema normalization normalizes an object using string schemaAttri
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Group": {
       "2": {
         "date": 1557831718135,
@@ -307,7 +307,7 @@ exports[`complex case works with undefined 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "ContinuousSequence": {
       "22": {
         "date": 1557831718135,

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -16,7 +16,7 @@ exports[`ValuesSchema normalization can use a function to determine the schema w
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cat": {
       "1": {
         "date": 1557831718135,
@@ -74,7 +74,7 @@ exports[`ValuesSchema normalization filters out null and undefined values 1`] = 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cat": {
       "1": {
         "date": 1557831718135,
@@ -109,7 +109,7 @@ exports[`ValuesSchema normalization normalizes the values of an object with the 
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Cat": {
       "1": {
         "date": 1557831718135,
@@ -153,7 +153,7 @@ exports[`ValuesSchema normalization normalizes without schemaAttribute 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyEntity": {
       "1": {
         "date": 1557831718135,
@@ -249,7 +249,7 @@ exports[`ValuesSchema normalization works on complex object 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Estimate": {
       "BTC": {
         "date": 1557831718135,

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -401,7 +401,7 @@ exports[`normalize can use fully custom entity classes 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Children": {
       "4": {
         "date": 1557831718135,
@@ -446,7 +446,7 @@ exports[`normalize handles number ids when nesting 1`] = `
 exports[`normalize ignores null values 1`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": [
     null,
@@ -457,7 +457,7 @@ exports[`normalize ignores null values 1`] = `
 exports[`normalize ignores null values 2`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": [
     undefined,
@@ -468,7 +468,7 @@ exports[`normalize ignores null values 2`] = `
 exports[`normalize ignores null values 3`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": [
     false,
@@ -490,7 +490,7 @@ exports[`normalize normalizes entities 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Tacos": {
       "1": {
         "date": 1557831718135,
@@ -524,7 +524,7 @@ exports[`normalize normalizes entities with circular references 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "User": {
       "123": {
         "date": 1557831718135,
@@ -572,7 +572,7 @@ exports[`normalize normalizes nested entities 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Article": {
       "123": {
         "date": 1557831718135,
@@ -619,7 +619,7 @@ exports[`normalize normalizes schema with extra members 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Tacos": {
       "1": {
         "date": 1557831718135,
@@ -669,7 +669,7 @@ exports[`normalize normalizes schema with extra members but not set 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Tacos": {
       "1": {
         "date": 1557831718135,
@@ -707,7 +707,7 @@ exports[`normalize normalizes schema with indexes 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyTaco": {
       "1": {
         "date": 1557831718135,
@@ -754,7 +754,7 @@ exports[`normalize normalizes warns on schemas with unfound indexes 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "MyTaco": {
       "1": {
         "date": 1557831718135,
@@ -794,7 +794,7 @@ exports[`normalize passes over pre-normalized values 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Article": {
       "123": {
         "date": 1557831718135,
@@ -811,7 +811,7 @@ exports[`normalize passes over pre-normalized values 1`] = `
 exports[`normalize passes over pre-normalized values 2`] = `
 {
   "entities": {},
-  "entityMeta": {},
+  "entitiesMeta": {},
   "indexes": {},
   "result": {
     "user": "1",
@@ -833,7 +833,7 @@ exports[`normalize uses the non-normalized input when getting the ID for an enti
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "Recommendations": {
       "456": {
         "date": 1557831718135,

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -80,7 +80,7 @@ describe('normalize', () => {
     expect(normalize(mySchema, 'bob')).toMatchInlineSnapshot(`
       {
         "entities": {},
-        "entityMeta": {},
+        "entitiesMeta": {},
         "indexes": {},
         "result": "bob",
       }

--- a/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
+++ b/packages/normalizr/src/__tests__/normalizerMerge.test.tsx
@@ -8,7 +8,7 @@ describe('normalizer() merging', () => {
   describe('with instance.constructor.merge()', () => {
     it('should merge two Resource instances', () => {
       const id = 20;
-      const { entities: first, entityMeta: firstEM } = normalize(Article, {
+      const { entities: first, entitiesMeta: firstEM } = normalize(Article, {
         id,
         title: 'hi',
         content: 'this is the content',
@@ -18,7 +18,7 @@ describe('normalizer() merging', () => {
         Article,
         { id, title: 'hello' },
         [],
-        { entities: first, entityMeta: firstEM, indexes: {} },
+        { entities: first, entitiesMeta: firstEM, indexes: {} },
       );
 
       const merged = denormalize(Article, result, entities);
@@ -59,7 +59,7 @@ describe('normalizer() merging', () => {
         Article,
         { id, title: 'hi', content: 'this is the content' },
         [],
-        { entities: entitiesA, indexes: {}, entityMeta: entitiesMetaA },
+        { entities: entitiesA, indexes: {}, entitiesMeta: entitiesMetaA },
       );
 
       expect(entities[Article.key][42]).toBe(entitiesA[Article.key][42]);
@@ -69,7 +69,7 @@ describe('normalizer() merging', () => {
   describe('basics', function () {
     it('should assign `null` values', () => {
       const id = 20;
-      const { entities: first, entityMeta: firstEM } = normalize(Article, {
+      const { entities: first, entitiesMeta: firstEM } = normalize(Article, {
         id,
         title: 'hi',
         content: 'this is the content',
@@ -77,7 +77,7 @@ describe('normalizer() merging', () => {
 
       const { result, entities } = normalize(Article, { id, title: null }, [], {
         entities: first,
-        entityMeta: firstEM,
+        entitiesMeta: firstEM,
         indexes: {},
       });
 
@@ -94,7 +94,7 @@ describe('normalizer() merging', () => {
 
     it('should not augment source objects', () => {
       const id = 20;
-      const { entities: first, entityMeta: firstMeta } = normalize(Article, {
+      const { entities: first, entitiesMeta: firstMeta } = normalize(Article, {
         id,
         title: 'hi',
         content: 'this is the content',
@@ -103,7 +103,7 @@ describe('normalizer() merging', () => {
       normalize(Article, { id, title: 'hello' }, [], {
         entities: first,
         indexes: {},
-        entityMeta: firstMeta,
+        entitiesMeta: firstMeta,
       });
 
       const merged = denormalize(Article, id, first);
@@ -119,7 +119,7 @@ describe('normalizer() merging', () => {
 
     it('should still clone even when overwriting', () => {
       const id = 20;
-      const { entities: first, entityMeta: firstMeta } = normalize(
+      const { entities: first, entitiesMeta: firstMeta } = normalize(
         new schema.Invalidate(Article),
         {
           id,
@@ -130,7 +130,7 @@ describe('normalizer() merging', () => {
       const { entities } = normalize(Article, nested, [], {
         entities: first,
         indexes: {},
-        entityMeta: firstMeta,
+        entitiesMeta: firstMeta,
       });
 
       expect(entities).toMatchInlineSnapshot(`

--- a/packages/normalizr/src/normalize/NormalizeDelegate.ts
+++ b/packages/normalizr/src/normalize/NormalizeDelegate.ts
@@ -12,7 +12,7 @@ export class NormalizeDelegate
   extends BaseDelegate
   implements INormalizeDelegate
 {
-  declare readonly entityMeta: {
+  declare readonly entitiesMeta: {
     [entityKey: string]: {
       [pk: string]: {
         date: number;
@@ -32,11 +32,11 @@ export class NormalizeDelegate
     {
       entities,
       indexes,
-      entityMeta,
+      entitiesMeta,
     }: {
       entities: EntityTable;
       indexes: NormalizedIndex;
-      entityMeta: {
+      entitiesMeta: {
         [entityKey: string]: {
           [pk: string]: {
             date: number;
@@ -49,7 +49,7 @@ export class NormalizeDelegate
     actionMeta: { fetchedAt: number; date: number; expiresAt: number },
   ) {
     super(entities, indexes);
-    this.entityMeta = entityMeta;
+    this.entitiesMeta = entitiesMeta;
     this.meta = actionMeta;
     this.checkLoop = getCheckLoop();
   }
@@ -66,8 +66,8 @@ export class NormalizeDelegate
       this.entities[key] = {
         ...this.entities[key],
       };
-      this.entityMeta[key] = {
-        ...this.entityMeta[key],
+      this.entitiesMeta[key] = {
+        ...this.entitiesMeta[key],
       };
     }
 
@@ -161,11 +161,11 @@ export class NormalizeDelegate
     pk: string,
     meta: { fetchedAt: number; date: number; expiresAt: number },
   ) {
-    this.entityMeta[key][pk] = meta;
+    this.entitiesMeta[key][pk] = meta;
   }
 
   getMeta(key: string, pk: string) {
-    return this.entityMeta[key][pk];
+    return this.entitiesMeta[key][pk];
   }
 }
 

--- a/packages/normalizr/src/normalize/normalize.ts
+++ b/packages/normalizr/src/normalize/normalize.ts
@@ -19,7 +19,7 @@ export const normalize = <
   schema: S | undefined,
   input: any,
   args: readonly any[] = [],
-  { entities, indexes, entityMeta }: StoreData<E> = emptyStore,
+  { entities, indexes, entitiesMeta }: StoreData<E> = emptyStore,
   meta: NormalizeMeta = { fetchedAt: 0, date: Date.now(), expiresAt: Infinity },
 ): NormalizedSchema<E, R> => {
   // no schema means we don't process at all
@@ -28,7 +28,7 @@ export const normalize = <
       result: input,
       entities,
       indexes,
-      entityMeta,
+      entitiesMeta,
     };
 
   const schemaType = expectedSchemaType(schema);
@@ -83,7 +83,7 @@ See https://dataclient.io/rest/api/RestEndpoint#parseResponse for more informati
     result: '' as any,
     entities: { ...entities },
     indexes: { ...indexes },
-    entityMeta: { ...entityMeta },
+    entitiesMeta: { ...entitiesMeta },
   };
   const visit = getVisit(new NormalizeDelegate(ret, meta));
   ret.result = visit(schema, input, input, undefined, args);
@@ -99,5 +99,5 @@ function expectedSchemaType(schema: Schema) {
 const emptyStore: StoreData<any> = {
   entities: {},
   indexes: {},
-  entityMeta: {},
+  entitiesMeta: {},
 };

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -114,7 +114,7 @@ export type NormalizedSchema<
   entities: E;
   result: R;
   indexes: NormalizedIndex;
-  entityMeta: EntitiesToMeta<E>;
+  entitiesMeta: EntitiesToMeta<E>;
 };
 
 export interface StoreData<
@@ -122,7 +122,7 @@ export interface StoreData<
 > {
   entities: Readonly<E>;
   indexes: Readonly<NormalizedIndex>;
-  entityMeta: EntitiesToMeta<E>;
+  entitiesMeta: EntitiesToMeta<E>;
 }
 
 export type EntitiesToMeta<

--- a/packages/react/src/components/__tests__/__snapshots__/provider.native.tsx.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/provider.native.tsx.snap
@@ -14,7 +14,7 @@ exports[`<DataProvider /> should change state 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "CoolerArticle": {
       "5": {
         "date": 50,

--- a/packages/react/src/components/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/provider.tsx.snap
@@ -14,7 +14,7 @@ exports[`<DataProvider /> should change state 1`] = `
       },
     },
   },
-  "entityMeta": {
+  "entitiesMeta": {
     "CoolerArticle": {
       "5": {
         "date": 50,

--- a/packages/react/src/hooks/__tests__/useDLE.native.tsx
+++ b/packages/react/src/hooks/__tests__/useDLE.native.tsx
@@ -215,7 +215,7 @@ describe('useDLE', () => {
     const state = {
       ...initialState,
       entities,
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       results: {
         [fetchKey]: result,
       },
@@ -309,7 +309,7 @@ describe('useDLE', () => {
       results: {
         [fetchKey]: payload,
       },
-      entityMeta: {},
+      entitiesMeta: {},
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/react/src/hooks/__tests__/useFetch.native.tsx
+++ b/packages/react/src/hooks/__tests__/useFetch.native.tsx
@@ -201,7 +201,7 @@ describe('useFetch', () => {
     const state = {
       ...initialState,
       entities,
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       results: {
         [fetchKey]: result,
       },

--- a/packages/react/src/hooks/__tests__/useSuspense.native.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.native.tsx
@@ -210,7 +210,7 @@ describe('useSuspense()', () => {
     const state = {
       ...initialState,
       entities,
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       results: {
         [fetchKey]: result,
       },
@@ -299,7 +299,7 @@ describe('useSuspense()', () => {
       results: {
         [fetchKey]: result,
       },
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: Infinity,
@@ -330,7 +330,7 @@ describe('useSuspense()', () => {
       results: {
         [fetchKey]: result,
       },
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: 0,
@@ -364,7 +364,7 @@ describe('useSuspense()', () => {
       results: {
         [fetchKey]: payload,
       },
-      entityMeta: {},
+      entitiesMeta: {},
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/react/src/hooks/__tests__/useSuspense.web.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.web.tsx
@@ -204,7 +204,7 @@ describe('useSuspense()', () => {
     const state = {
       ...initialState,
       entities,
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       results: {
         [fetchKey]: result,
       },
@@ -241,7 +241,7 @@ describe('useSuspense()', () => {
       results: {
         [fetchKey]: result,
       },
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: Infinity,
@@ -273,7 +273,7 @@ describe('useSuspense()', () => {
       results: {
         [fetchKey]: result,
       },
-      entityMeta: createEntityMeta(entities),
+      entitiesMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: 0,
@@ -307,7 +307,7 @@ describe('useSuspense()', () => {
       results: {
         [fetchKey]: payload,
       },
-      entityMeta: {},
+      entitiesMeta: {},
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -46,7 +46,7 @@ export default function useCache<
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/packages/react/src/hooks/useDLE.native.ts
+++ b/packages/react/src/hooks/useDLE.native.ts
@@ -88,7 +88,7 @@ export default function useDLE<
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/packages/react/src/hooks/useDLE.ts
+++ b/packages/react/src/hooks/useDLE.ts
@@ -86,7 +86,7 @@ export default function useDLE<
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/packages/react/src/hooks/useFetch.native.ts
+++ b/packages/react/src/hooks/useFetch.native.ts
@@ -65,7 +65,7 @@ export default function useFetch<
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/packages/react/src/hooks/useFetch.ts
+++ b/packages/react/src/hooks/useFetch.ts
@@ -63,7 +63,7 @@ export default function useFetch<
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/packages/react/src/hooks/useSuspense.native.ts
+++ b/packages/react/src/hooks/useSuspense.native.ts
@@ -70,7 +70,7 @@ export default function useSuspense<
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/packages/react/src/hooks/useSuspense.ts
+++ b/packages/react/src/hooks/useSuspense.ts
@@ -67,7 +67,7 @@ export default function useSuspense<
     cacheResults,
     state.indexes,
     state.entities,
-    state.entityMeta,
+    state.entitiesMeta,
     meta,
     key,
   ]);

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -515,7 +515,7 @@ interface State<T> {
             readonly errorPolicy?: 'hard' | 'soft' | undefined;
         };
     };
-    readonly entityMeta: {
+    readonly entitiesMeta: {
         readonly [entityKey: string]: {
             readonly [pk: string]: {
                 readonly fetchedAt: number;

--- a/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
@@ -200,12 +200,12 @@ type NormalizedSchema<E extends Record<string, Record<string, any> | undefined>,
     entities: E;
     result: R;
     indexes: NormalizedIndex;
-    entityMeta: EntitiesToMeta<E>;
+    entitiesMeta: EntitiesToMeta<E>;
 };
 interface StoreData<E extends Record<string, Record<string, any> | undefined>> {
     entities: Readonly<E>;
     indexes: Readonly<NormalizedIndex>;
-    entityMeta: EntitiesToMeta<E>;
+    entitiesMeta: EntitiesToMeta<E>;
 }
 type EntitiesToMeta<E extends Record<string, Record<string, any> | undefined>> = {
     readonly [entityKey in keyof E]: {
@@ -241,7 +241,7 @@ interface Dep<Path, K = object> {
     entity: K;
 }
 
-declare const normalize: <S extends Schema = Schema, E extends Record<string, Record<string, any> | undefined> = Record<string, Record<string, any>>, R = NormalizeNullable<S>>(schema: S | undefined, input: any, args?: readonly any[], { entities, indexes, entityMeta }?: StoreData<E>, meta?: NormalizeMeta) => NormalizedSchema<E, R>;
+declare const normalize: <S extends Schema = Schema, E extends Record<string, Record<string, any> | undefined> = Record<string, Record<string, any>>, R = NormalizeNullable<S>>(schema: S | undefined, input: any, args?: readonly any[], { entities, indexes, entitiesMeta }?: StoreData<E>, meta?: NormalizeMeta) => NormalizedSchema<E, R>;
 
 interface EntityCache extends Map<string, Map<string, WeakMap<EntityInterface, WeakDependencyMap<EntityPath, object, any>>>> {
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Predictable names. Consistency with state.entities

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since this is a lookup table of all meta for every entity, we should make entity plural - just like we did for the entity table.
