### PR TITLE
enhance: MemoCache.query() and MemoCache.buildQueryKey() take state as one argument

### DIFF
--- a/.changeset/poor-jobs-turn.md
+++ b/.changeset/poor-jobs-turn.md
@@ -1,0 +1,41 @@
+---
+'@data-client/normalizr': minor
+---
+
+BREAKING CHANGE: MemoCache.query() and MemoCache.buildQueryKey() take state as one argument
+
+#### Before
+
+```ts
+this.memo.buildQueryKey(
+  schema,
+  args,
+  state.entities,
+  state.indexes,
+  key,
+);
+```
+
+
+#### After
+
+```ts
+this.memo.buildQueryKey(
+  schema,
+  args,
+  state,
+  key,
+);
+```
+
+#### Before
+
+```ts
+this.memo.query(schema, args, state.entities, state.indexes);
+```
+
+#### After
+
+```ts
+this.memo.query(schema, args, state);
+```

--- a/examples/benchmark/normalizr.js
+++ b/examples/benchmark/normalizr.js
@@ -21,18 +21,8 @@ import userData from './user.json' with { type: 'json' };
 const { result, entities } = normalize(ProjectSchema, data);
 const queryState = normalize(AllProjects, data);
 const queryMemo = new MemoCache();
-queryState.result = queryMemo.buildQueryKey(
-  AllProjects,
-  [],
-  queryState.entities,
-  queryState.indexes,
-);
-const queryInfer = queryMemo.buildQueryKey(
-  getSortedProjects,
-  [],
-  queryState.entities,
-  queryState.indexes,
-);
+queryState.result = queryMemo.buildQueryKey(AllProjects, [], queryState);
+const queryInfer = queryMemo.buildQueryKey(getSortedProjects, [], queryState);
 
 let githubState = normalize(User, userData);
 
@@ -56,12 +46,7 @@ export default function addNormlizrSuite(suite) {
       curState = { ...initialState, entities: {}, endpoints: {} };
     })
     .add('infer All', () => {
-      return new MemoCache().buildQueryKey(
-        AllProjects,
-        [],
-        queryState.entities,
-        queryState.indexes,
-      );
+      return new MemoCache().buildQueryKey(AllProjects, [], queryState);
     })
     .add('denormalizeLong', () => {
       return new MemoCache().denormalize(ProjectSchema, result, entities);
@@ -86,12 +71,7 @@ export default function addNormlizrSuite(suite) {
     })
     .add('queryShort 500x withCache', () => {
       for (let i = 0; i < 500; ++i) {
-        memo.query(
-          User,
-          [{ login: 'gnoff' }],
-          githubState.entities,
-          githubState.indexes,
-        );
+        memo.query(User, [{ login: 'gnoff' }], githubState);
       }
     })
     .add('denormalizeLong with mixin Entity', () => {

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -514,13 +514,7 @@ export default class Controller<
     const input =
       shouldQuery ?
         // nothing in endpoints cache, so try querying if we have a schema to do so
-        this.memo.buildQueryKey(
-          schema,
-          args,
-          state.entities as any,
-          state.indexes,
-          key,
-        )
+        this.memo.buildQueryKey(schema, args, state, key)
       : cacheEndpoints;
 
     if (!isActive) {
@@ -595,7 +589,7 @@ export default class Controller<
       .slice(0, rest.length - 1)
       .map(ensurePojo) as SchemaArgs<S>;
 
-    return this.memo.query(schema, args, state.entities as any, state.indexes);
+    return this.memo.query(schema, args, state);
   }
 
   /**
@@ -623,8 +617,7 @@ export default class Controller<
     const input = this.memo.buildQueryKey(
       schema,
       args,
-      state.entities as any,
-      state.indexes,
+      state,
       JSON.stringify(args),
     );
 

--- a/packages/endpoint/src/schemas/__tests__/All.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/All.test.ts
@@ -135,9 +135,7 @@ describe.each([
         indexes: {},
       });
       // use memocache because we don't support 'object' schemas in controller yet
-      expect(
-        new MemoCache().query(catSchema, [], state.entities, state.indexes),
-      ).toMatchSnapshot();
+      expect(new MemoCache().query(catSchema, [], state)).toMatchSnapshot();
     });
 
     test('denormalizes nested in object with primitive', () => {
@@ -152,12 +150,7 @@ describe.each([
         },
         indexes: {},
       });
-      const value = new MemoCache().query(
-        catSchema,
-        [],
-        state.entities,
-        state.indexes,
-      );
+      const value = new MemoCache().query(catSchema, [], state);
       expect(value).not.toEqual(expect.any(Symbol));
       if (typeof value === 'symbol' || value === undefined) return;
       expect(createOutput(value.results)).toMatchSnapshot();
@@ -178,12 +171,7 @@ describe.each([
         },
         indexes: {},
       });
-      const value = new MemoCache().query(
-        catSchema,
-        [],
-        state.entities,
-        state.indexes,
-      );
+      const value = new MemoCache().query(catSchema, [], state);
       expect(value).not.toEqual(expect.any(Symbol));
       if (typeof value === 'symbol' || value === undefined) return;
       expect(createOutput(value.results).length).toBe(2);
@@ -206,11 +194,11 @@ describe.each([
         indexes: {},
       };
       const memo = new MemoCache();
-      const value = memo.query(catSchema, [], state.entities, state.indexes);
+      const value = memo.query(catSchema, [], state);
 
       expect(createOutput(value).results?.length).toBe(2);
       expect(createOutput(value).results).toMatchSnapshot();
-      const value2 = memo.query(catSchema, [], state.entities, state.indexes);
+      const value2 = memo.query(catSchema, [], state);
       expect(createOutput(value).results[0]).toBe(
         createOutput(value2).results[0],
       );
@@ -226,7 +214,7 @@ describe.each([
           },
         },
       };
-      const value3 = memo.query(catSchema, [], state.entities, state.indexes);
+      const value3 = memo.query(catSchema, [], state);
       expect(createOutput(value3).results?.length).toBe(3);
       expect(createOutput(value3).results).toMatchSnapshot();
       expect(createOutput(value).results[0]).toBe(
@@ -250,12 +238,7 @@ describe.each([
         },
         indexes: {},
       });
-      const value = new MemoCache().query(
-        catSchema,
-        [],
-        state.entities,
-        state.indexes,
-      );
+      const value = new MemoCache().query(catSchema, [], state);
       expect(createOutput(value)).toBeUndefined();
     });
 
@@ -287,12 +270,7 @@ describe.each([
         },
         indexes: {},
       });
-      const value = new MemoCache().query(
-        listSchema,
-        [],
-        state.entities,
-        state.indexes,
-      );
+      const value = new MemoCache().query(listSchema, [], state);
       expect(createOutput(value)).toBeUndefined();
     });
 
@@ -355,12 +333,7 @@ describe.each([
         },
         indexes: {},
       });
-      const value = new MemoCache().query(
-        listSchema,
-        [],
-        state.entities,
-        state.indexes,
-      );
+      const value = new MemoCache().query(listSchema, [], state);
       expect(value).not.toEqual(expect.any(Symbol));
       if (typeof value === 'symbol') return;
       expect(value).toMatchSnapshot();

--- a/packages/endpoint/src/schemas/__tests__/Collection.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Collection.test.ts
@@ -620,8 +620,7 @@ describe(`${schema.Collection.name} denormalization`, () => {
     const queryKey = memo.buildQueryKey(
       userTodos,
       [{ userId: '1' }],
-      normalizeNested.entities,
-      normalizeNested.indexes,
+      normalizeNested,
     );
     expect(queryKey).toBeDefined();
     // now ensure our queryKey is usable
@@ -644,8 +643,7 @@ describe(`${schema.Collection.name} denormalization`, () => {
     const queryKey = memo.buildQueryKey(
       userTodos,
       [{ userId: '100' }],
-      normalizeNested.entities,
-      normalizeNested.indexes,
+      normalizeNested,
     );
     expect(queryKey).toBeUndefined();
   });
@@ -655,8 +653,7 @@ describe(`${schema.Collection.name} denormalization`, () => {
     const queryKey = memo.buildQueryKey(
       User.schema.todos,
       [{ userId: '1' }],
-      normalizeNested.entities,
-      normalizeNested.indexes,
+      normalizeNested,
     );
     expect(queryKey).toBeUndefined();
   });

--- a/packages/endpoint/src/schemas/__tests__/Query.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Query.test.ts
@@ -76,7 +76,7 @@ describe.each([
           },
         });
         const users: DenormalizeNullable<typeof sortedUsers> | symbol =
-          new MemoCache().query(sortedUsers, [], state.entities, state.indexes);
+          new MemoCache().query(sortedUsers, [], state);
         expect(users).not.toEqual(expect.any(Symbol));
         if (typeof users === 'symbol') return;
         expect(users && users[0].name).toBe('Zeta');
@@ -101,12 +101,7 @@ describe.each([
           },
         });
         expect(
-          new MemoCache().query(
-            sortedUsers,
-            [{ asc: true }],
-            state.entities,
-            state.indexes,
-          ),
+          new MemoCache().query(sortedUsers, [{ asc: true }], state),
         ).toMatchSnapshot();
       });
 
@@ -120,12 +115,7 @@ describe.each([
             },
           },
         };
-        const data = new MemoCache().query(
-          sortedUsers,
-          [],
-          state.entities,
-          state.indexes,
-        );
+        const data = new MemoCache().query(sortedUsers, [], state);
 
         expect(createOutput(data)).toEqual(undefined);
       });
@@ -162,12 +152,7 @@ describe.each([
         });
         const totalCount:
           | DenormalizeNullable<typeof userCountByAdmin>
-          | symbol = new MemoCache().query(
-          userCountByAdmin,
-          [],
-          state.entities,
-          state.indexes,
-        );
+          | symbol = new MemoCache().query(userCountByAdmin, [], state);
 
         expect(totalCount).toBe(4);
         const nonAdminCount:
@@ -175,8 +160,7 @@ describe.each([
           | symbol = new MemoCache().query(
           userCountByAdmin,
           [{ isAdmin: false }],
-          state.entities,
-          state.indexes,
+          state,
         );
         expect(nonAdminCount).toBe(3);
         const adminCount:
@@ -184,8 +168,7 @@ describe.each([
           | symbol = new MemoCache().query(
           userCountByAdmin,
           [{ isAdmin: true }],
-          state.entities,
-          state.indexes,
+          state,
         );
         expect(adminCount).toBe(1);
         if (typeof totalCount === 'symbol') return;
@@ -226,12 +209,7 @@ describe('top level schema', () => {
         },
       },
     };
-    const users = new MemoCache().query(
-      sortedUsers,
-      [],
-      state.entities,
-      state.indexes,
-    );
+    const users = new MemoCache().query(sortedUsers, [], state);
     expect(users).not.toEqual(expect.any(Symbol));
     if (typeof users === 'symbol') return;
     expect(users && users[0].name).toBe('Zeta');
@@ -250,12 +228,7 @@ describe('top level schema', () => {
         },
       },
     };
-    const users = new MemoCache().query(
-      sortedUsers,
-      [],
-      state.entities,
-      state.indexes,
-    );
+    const users = new MemoCache().query(sortedUsers, [], state);
     expect(users).toBeUndefined();
   });
 
@@ -270,12 +243,7 @@ describe('top level schema', () => {
         return sorted.reverse();
       },
     );
-    const users = new MemoCache().query(
-      allSortedUsers,
-      [],
-      initialState.entities,
-      initialState.indexes,
-    );
+    const users = new MemoCache().query(allSortedUsers, [], initialState);
     expect(users).toBeUndefined();
   });
 
@@ -290,12 +258,7 @@ describe('top level schema', () => {
         return sorted.reverse();
       },
     );
-    const users = new MemoCache().query(
-      allSortedUsers,
-      [],
-      initialState.entities,
-      initialState.indexes,
-    );
+    const users = new MemoCache().query(allSortedUsers, [], initialState);
     expect(users).toBeUndefined();
   });
 
@@ -310,12 +273,7 @@ describe('top level schema', () => {
       },
     };
 
-    const value = new MemoCache().query(
-      sortedUsers,
-      [],
-      state.entities,
-      state.indexes,
-    );
+    const value = new MemoCache().query(sortedUsers, [], state);
 
     expect(value).toEqual(undefined);
   });

--- a/packages/normalizr/src/__tests__/MemoCache.ts
+++ b/packages/normalizr/src/__tests__/MemoCache.ts
@@ -625,14 +625,12 @@ describe('MemoCache', () => {
         }),
       });
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ id: 5 }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ id: 5 }], {
+          entities: {
             [CoolerArticle.key]: { '5': {} },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toEqual({
         data: { article: 5 },
       });
@@ -645,14 +643,12 @@ describe('MemoCache', () => {
         }),
       });
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [5],
-          {
+        new MemoCache().buildQueryKey(schema, [5], {
+          entities: {
             [CoolerArticle.key]: { '5': {} },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toEqual({
         data: { article: '5' },
       });
@@ -665,14 +661,12 @@ describe('MemoCache', () => {
         }),
       });
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          ['5'],
-          {
+        new MemoCache().buildQueryKey(schema, ['5'], {
+          entities: {
             [CoolerArticle.key]: { '5': {} },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toEqual({
         data: { article: '5' },
       });
@@ -683,14 +677,12 @@ describe('MemoCache', () => {
         data: new schemas.Array(CoolerArticle),
       };
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ id: 5 }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ id: 5 }], {
+          entities: {
             [CoolerArticle.key]: { '5': {} },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toStrictEqual({
         data: undefined,
       });
@@ -699,14 +691,12 @@ describe('MemoCache', () => {
         data: [CoolerArticle],
       };
       expect(
-        new MemoCache().buildQueryKey(
-          schema2,
-          [{ id: 5 }],
-          {
+        new MemoCache().buildQueryKey(schema2, [{ id: 5 }], {
+          entities: {
             [CoolerArticle.key]: { '5': {} },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toStrictEqual({
         data: undefined,
       });
@@ -717,14 +707,12 @@ describe('MemoCache', () => {
         data: new schemas.Values(CoolerArticle),
       };
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ id: 5 }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ id: 5 }], {
+          entities: {
             [CoolerArticle.key]: { '5': {} },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toStrictEqual({
         data: undefined,
       });
@@ -733,32 +721,28 @@ describe('MemoCache', () => {
     it('should be undefined with Union and type', () => {
       const schema = UnionResource.get.schema;
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ id: 5 }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ id: 5 }], {
+          entities: {
             [CoolerArticle.key]: {
               '5': {},
             },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toBe(undefined);
     });
 
     it('should work with Union', () => {
       const schema = UnionResource.get.schema;
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ id: 5, type: 'first' }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ id: 5, type: 'first' }], {
+          entities: {
             [FirstUnion.key]: {
               '5': {},
             },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toMatchInlineSnapshot(`
         {
           "id": 5,
@@ -773,16 +757,14 @@ describe('MemoCache', () => {
         data: CoolerArticle,
       };
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ id: 5 }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ id: 5 }], {
+          entities: {
             [CoolerArticle.key]: {
               '5': {},
             },
           },
-          {},
-        ),
+          indexes: {},
+        }),
       ).toEqual({
         pagination: { next: '', previous: '' },
         data: 5,
@@ -795,22 +777,20 @@ describe('MemoCache', () => {
         data: IndexedUser,
       };
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ username: 'bob' }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ username: 'bob' }], {
+          entities: {
             [IndexedUser.key]: {
               '5': {},
             },
           },
-          {
+          indexes: {
             [IndexedUser.key]: {
               username: {
                 bob: '5',
               },
             },
           },
-        ),
+        }),
       ).toEqual({
         pagination: { next: '', previous: '' },
         data: '5',
@@ -820,14 +800,16 @@ describe('MemoCache', () => {
           schema,
           [{ username: 'bob', mary: 'five' }],
           {
-            [IndexedUser.key]: {
-              '5': {},
+            entities: {
+              [IndexedUser.key]: {
+                '5': {},
+              },
             },
-          },
-          {
-            [IndexedUser.key]: {
-              username: {
-                bob: '5',
+            indexes: {
+              [IndexedUser.key]: {
+                username: {
+                  bob: '5',
+                },
               },
             },
           },
@@ -844,43 +826,39 @@ describe('MemoCache', () => {
         data: IndexedUser,
       };
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ username: 'bob' }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ username: 'bob' }], {
+          entities: {
             [IndexedUser.key]: {
               '5': {},
             },
           },
-          {
+          indexes: {
             [IndexedUser.key]: {
               username: {
                 charles: '5',
               },
             },
           },
-        ),
+        }),
       ).toEqual({
         pagination: { next: '', previous: '' },
         data: undefined,
       });
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ hover: 'bob' }],
-          {
+        new MemoCache().buildQueryKey(schema, [{ hover: 'bob' }], {
+          entities: {
             [IndexedUser.key]: {
               '5': {},
             },
           },
-          {
+          indexes: {
             [IndexedUser.key]: {
               username: {
                 charles: '5',
               },
             },
           },
-        ),
+        }),
       ).toEqual({
         pagination: { next: '', previous: '' },
         data: undefined,
@@ -893,27 +871,19 @@ describe('MemoCache', () => {
         data: IndexedUser,
       };
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ username: 'bob' }],
-          {
-            [IndexedUser.key]: { '5': {} },
-          },
-          {},
-        ),
+        new MemoCache().buildQueryKey(schema, [{ username: 'bob' }], {
+          entities: { [IndexedUser.key]: { '5': {} } },
+          indexes: {},
+        }),
       ).toEqual({
         pagination: { next: '', previous: '' },
         data: undefined,
       });
       expect(
-        new MemoCache().buildQueryKey(
-          schema,
-          [{ hover: 'bob' }],
-          {
-            [IndexedUser.key]: { '5': {} },
-          },
-          {},
-        ),
+        new MemoCache().buildQueryKey(schema, [{ hover: 'bob' }], {
+          entities: { [IndexedUser.key]: { '5': {} } },
+          indexes: {},
+        }),
       ).toEqual({
         pagination: { next: '', previous: '' },
         data: undefined,
@@ -943,14 +913,12 @@ describe('MemoCache', () => {
           }),
         });
         expect(
-          new MemoCache().buildQueryKey(
-            schema,
-            ['5'],
-            {
+          new MemoCache().buildQueryKey(schema, ['5'], {
+            entities: {
               [MyEntity.key]: { '5': {} },
             },
-            {},
-          ),
+            indexes: {},
+          }),
         ).toEqual({
           data: { article: '5' },
         });
@@ -963,16 +931,16 @@ describe('MemoCache', () => {
           }),
         });
         const memo = new MemoCache();
-        expect(memo.buildQueryKey(schema, ['5'], {}, {})).toEqual({
+        expect(
+          memo.buildQueryKey(schema, ['5'], { entities: {}, indexes: {} }),
+        ).toEqual({
           data: { article: undefined },
         });
         expect(
-          memo.buildQueryKey(
-            schema,
-            ['5'],
-            { [MyEntity.key]: { '5': { id: '5', title: 'hi' } } },
-            {},
-          ),
+          memo.buildQueryKey(schema, ['5'], {
+            entities: { [MyEntity.key]: { '5': { id: '5', title: 'hi' } } },
+            indexes: {},
+          }),
         ).toEqual({
           data: { article: '5' },
         });
@@ -989,59 +957,51 @@ describe('MemoCache', () => {
           entities: { [MyEntity.key]: {} },
           indexes: {},
         };
-        const first = memo.buildQueryKey(
-          schema,
-          ['5'],
-          state.entities,
-          state.indexes,
-        );
+        const first = memo.buildQueryKey(schema, ['5'], state);
         it('should maintain referential equality', () => {
-          expect(
-            memo.buildQueryKey(schema, ['5'], state.entities, state.indexes),
-          ).toBe(first);
+          expect(memo.buildQueryKey(schema, ['5'], state)).toBe(first);
         });
         it('should not change on index update if not used', () => {
           expect(
-            memo.buildQueryKey(schema, ['5'], state.entities, {
-              [MyEntity.key]: {},
+            memo.buildQueryKey(schema, ['5'], {
+              ...state,
+              indexes: {
+                [MyEntity.key]: {},
+              },
             }),
           ).toBe(first);
         });
         it('should be new when entity is updated', () => {
-          const withEntity = memo.buildQueryKey(
-            schema,
-            ['5'],
-            { [MyEntity.key]: { '5': { id: '5', title: 'hi' } } },
-            state.indexes,
-          );
+          const withEntity = memo.buildQueryKey(schema, ['5'], {
+            entities: {
+              [MyEntity.key]: { '5': { id: '5', title: 'hi' } },
+            },
+            indexes: state.indexes,
+          });
           expect(withEntity).not.toBe(first);
           expect(withEntity.data).toEqual({ article: '5' });
         });
         it('should be the same if other entities are updated', () => {
-          const withEntity = memo.buildQueryKey(
-            schema,
-            ['5'],
-            {
+          const withEntity = memo.buildQueryKey(schema, ['5'], {
+            entities: {
               ...state.entities,
               ['another']: { '5': { id: '5', title: 'hi' } },
             },
-            state.indexes,
-          );
+            indexes: state.indexes,
+          });
           expect(withEntity).toBe(first);
         });
         it('should be the same if other entities of the same type are updated', () => {
-          const withEntity = memo.buildQueryKey(
-            schema,
-            ['5'],
-            {
+          const withEntity = memo.buildQueryKey(schema, ['5'], {
+            entities: {
               ...state.entities,
               [MyEntity.key]: {
                 ...state.entities[MyEntity.key],
                 '500': { id: '500', title: 'second title' },
               },
             },
-            state.indexes,
-          );
+            indexes: state.indexes,
+          });
           expect(withEntity).toBe(first);
         });
       });
@@ -1078,40 +1038,20 @@ describe('MemoCache', () => {
     });
 
     test('works with indexes', () => {
-      const m = new MemoCache().query(
-        Cat,
-        [{ username: 'm' }],
-        state.entities,
-        state.indexes,
-      );
+      const m = new MemoCache().query(Cat, [{ username: 'm' }], state);
       expect(m).toBeDefined();
       expect(m).toMatchSnapshot();
       expect(
-        new MemoCache().query(
-          Cat,
-          [{ username: 'doesnotexist' }],
-          state.entities,
-          state.indexes,
-        ),
+        new MemoCache().query(Cat, [{ username: 'doesnotexist' }], state),
       ).toBeUndefined();
     });
 
     test('works with pk', () => {
-      const m = new MemoCache().query(
-        Cat,
-        [{ id: '1' }],
-        state.entities,
-        state.indexes,
-      );
+      const m = new MemoCache().query(Cat, [{ id: '1' }], state);
       expect(m).toBeDefined();
       expect(m).toMatchSnapshot();
       expect(
-        new MemoCache().query(
-          Cat,
-          [{ id: 'doesnotexist' }],
-          state.entities,
-          state.indexes,
-        ),
+        new MemoCache().query(Cat, [{ id: 'doesnotexist' }], state),
       ).toBeUndefined();
     });
   });

--- a/packages/normalizr/src/memo/Delegate.immutable.ts
+++ b/packages/normalizr/src/memo/Delegate.immutable.ts
@@ -10,10 +10,13 @@ export class DelegateImmutable implements IBaseDelegate {
   declare entities: ImmutableJSEntityTable;
   declare indexes: ImmutableJSEntityTable;
 
-  constructor(
-    entities: ImmutableJSEntityTable,
-    indexes: ImmutableJSEntityTable,
-  ) {
+  constructor({
+    entities,
+    indexes,
+  }: {
+    entities: ImmutableJSEntityTable;
+    indexes: ImmutableJSEntityTable;
+  }) {
     this.entities = entities;
     this.indexes = indexes;
   }

--- a/packages/normalizr/src/memo/Delegate.ts
+++ b/packages/normalizr/src/memo/Delegate.ts
@@ -30,7 +30,13 @@ export class BaseDelegate implements IBaseDelegate {
     };
   };
 
-  constructor(entities: EntityTable, indexes: NormalizedIndex) {
+  constructor({
+    entities,
+    indexes,
+  }: {
+    entities: EntityTable;
+    indexes: NormalizedIndex;
+  }) {
     this.entities = entities;
     this.indexes = indexes;
   }

--- a/packages/normalizr/src/normalize/NormalizeDelegate.ts
+++ b/packages/normalizr/src/normalize/NormalizeDelegate.ts
@@ -29,11 +29,7 @@ export class NormalizeDelegate
   protected newIndexes = new Map<string, Map<string, any>>();
 
   constructor(
-    {
-      entities,
-      indexes,
-      entitiesMeta,
-    }: {
+    state: {
       entities: EntityTable;
       indexes: NormalizedIndex;
       entitiesMeta: {
@@ -48,8 +44,8 @@ export class NormalizeDelegate
     },
     actionMeta: { fetchedAt: number; date: number; expiresAt: number },
   ) {
-    super(entities, indexes);
-    this.entitiesMeta = entitiesMeta;
+    super(state);
+    this.entitiesMeta = state.entitiesMeta;
     this.meta = actionMeta;
     this.checkLoop = getCheckLoop();
   }


### PR DESCRIPTION
BREAKING CHANGE: MemoCache.query() and MemoCache.buildQueryKey() take state as one argument

#### Before

```ts
this.memo.buildQueryKey(
  schema,
  args,
  state.entities,
  state.indexes,
  key,
);
```


#### After

```ts
this.memo.buildQueryKey(
  schema,
  args,
  state,
  key,
);
```

#### Before

```ts
this.memo.query(schema, args, state.entities, state.indexes);
```

#### After

```ts
this.memo.query(schema, args, state);
```