### PR TITLE
internal: Switch typescript to module resolution bundler

### DIFF
--- a/packages/react/src/hooks/__tests__/useController/expireAll.tsx
+++ b/packages/react/src/hooks/__tests__/useController/expireAll.tsx
@@ -1,6 +1,6 @@
 import { CacheProvider } from '@data-client/react';
 import { makeRenderDataClient, renderHook, act } from '@data-client/test';
-import { FixtureEndpoint } from '@data-client/test/mockState';
+import { FixtureEndpoint } from '@data-client/test';
 import { CoolerArticleResource, GetPhoto } from '__tests__/new';
 import nock from 'nock';
 import { useEffect } from 'react';

--- a/packages/react/src/hooks/__tests__/useController/invalidate.tsx
+++ b/packages/react/src/hooks/__tests__/useController/invalidate.tsx
@@ -1,5 +1,5 @@
 import { CacheProvider } from '@data-client/react';
-import { FixtureEndpoint } from '@data-client/test/mockState';
+import { FixtureEndpoint } from '@data-client/test';
 import { FutureArticleResource, GetPhoto } from '__tests__/new';
 import nock from 'nock';
 import { useEffect } from 'react';

--- a/packages/react/src/hooks/__tests__/useController/invalidateAll.tsx
+++ b/packages/react/src/hooks/__tests__/useController/invalidateAll.tsx
@@ -1,6 +1,6 @@
 import { CacheProvider } from '@data-client/react';
 import { makeRenderDataClient, renderHook, act } from '@data-client/test';
-import { FixtureEndpoint } from '@data-client/test/mockState';
+import { FixtureEndpoint } from '@data-client/test';
 import { CoolerArticleResource, GetPhoto } from '__tests__/new';
 import nock from 'nock';
 import { useEffect } from 'react';

--- a/packages/react/src/hooks/__tests__/useController/reset.tsx
+++ b/packages/react/src/hooks/__tests__/useController/reset.tsx
@@ -1,7 +1,7 @@
 import { CacheProvider } from '@data-client/react';
 import { makeRenderDataClient, renderHook } from '@data-client/test';
 import { act } from '@data-client/test';
-import { FixtureEndpoint } from '@data-client/test/mockState';
+import { FixtureEndpoint } from '@data-client/test';
 import { waitFor } from '@testing-library/react';
 import { CoolerArticleDetail, FutureArticleResource } from '__tests__/new';
 import nock from 'nock';

--- a/packages/react/src/hooks/__tests__/useController/setResponse.tsx
+++ b/packages/react/src/hooks/__tests__/useController/setResponse.tsx
@@ -1,5 +1,5 @@
 import { CacheProvider } from '@data-client/react';
-import { FixtureEndpoint } from '@data-client/test/mockState';
+import { FixtureEndpoint } from '@data-client/test';
 import { CoolerArticle, FutureArticleResource } from '__tests__/new';
 import nock from 'nock';
 

--- a/packages/react/src/hooks/__tests__/useController/subscribe.tsx
+++ b/packages/react/src/hooks/__tests__/useController/subscribe.tsx
@@ -1,5 +1,5 @@
 import { CacheProvider } from '@data-client/react';
-import { FixtureEndpoint } from '@data-client/test/mockState';
+import { FixtureEndpoint } from '@data-client/test';
 import { FutureArticleResource } from '__tests__/new';
 import nock from 'nock';
 

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -38,7 +38,7 @@
 
     /* Module Resolution Options */
     "resolveJsonModule": true,
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "bundler",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "moduleSuffixes": ["", ".native"],
     // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     //"typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes https://github.com/react-navigation/react-navigation/issues/12536 https://github.com/react-navigation/react-navigation/issues/12535

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Support modern-only packages that don't include legacy fallbacks

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
