### PR TITLE
fix: export types needed for EntityMixin

### DIFF
--- a/.changeset/shiny-olives-behave.md
+++ b/.changeset/shiny-olives-behave.md
@@ -1,0 +1,5 @@
+---
+'@data-client/endpoint': patch
+---
+
+fix: export types needed for EntityMixin

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -15,6 +15,7 @@ export * as schema from './schema.js';
 export type { Array, Invalidate, Collection, DefaultArgs } from './schema.js';
 export { default as Entity } from './schemas/Entity.js';
 export { default as EntityMixin } from './schemas/EntityMixin.js';
+export type { IEntityClass, IEntityInstance } from './schemas/EntityTypes.js';
 export { default as validateRequired } from './validateRequired.js';
 export type {
   EndpointInterface,


### PR DESCRIPTION
Fixes the following TypeScript error when using `EntityMixin`:

`The inferred type of ... cannot be named without a reference to '../../node_modules/@data-client/endpoint/lib/schemas/EntityTypes'. This is likely not portable. A type annotation is necessary.ts(2742)`