### PR TITLE
enhance: delegate.getEntities() returns restricted EntitiesInterface

### DIFF
--- a/.changeset/proud-taxes-bake.md
+++ b/.changeset/proud-taxes-bake.md
@@ -3,6 +3,26 @@
 '@data-client/endpoint': minor
 ---
 
-delegate.getEntity(this.key) -> delegate.getEntities(this.key)
+delegate.getEntity(key) -> delegate.forEntities(key, cb)
 
 This applies to both schema.queryKey and schema.normalize method delegates.
+
+#### Before
+
+```ts
+const entities = delegate.getEntity(this.key);
+if (entities)
+  Object.keys(entities).forEach(collectionPk => {
+    if (!filterCollections(JSON.parse(collectionPk))) return;
+    delegate.mergeEntity(this, collectionPk, normalizedValue);
+  });
+```
+
+#### After
+
+```ts
+delegate.forEntities(this.key, ([collectionKey]) => {
+  if (!filterCollections(JSON.parse(collectionKey))) return;
+  delegate.mergeEntity(this, collectionKey, normalizedValue);
+});
+```

--- a/.changeset/proud-taxes-bake.md
+++ b/.changeset/proud-taxes-bake.md
@@ -3,9 +3,21 @@
 '@data-client/endpoint': minor
 ---
 
-delegate.getEntity(key) -> delegate.forEntities(key, cb)
+delegate.getEntity(key) -> delegate.getEntities(this.key)
 
+Return value is a restricted interface with keys() and entries() iterator methods.
 This applies to both schema.queryKey and schema.normalize method delegates.
+
+```ts
+const entities = delegate.getEntities(key);
+
+// foreach on keys
+for (const key of entities.keys()) {}
+// Object.keys() (convert to array)
+return [...entities.keys()];
+// foreach on full entry
+for (const [key, entity] of entities.entries()) {}
+```
 
 #### Before
 
@@ -21,8 +33,10 @@ if (entities)
 #### After
 
 ```ts
-delegate.forEntities(this.key, ([collectionKey]) => {
-  if (!filterCollections(JSON.parse(collectionKey))) return;
-  delegate.mergeEntity(this, collectionKey, normalizedValue);
-});
+const entities = delegate.getEntities(this.key);
+if (entities)
+  for (const collectionKey of entities.keys()) {
+    if (!filterCollections(JSON.parse(collectionKey))) continue;
+    delegate.mergeEntity(this, collectionKey, normalizedValue);
+  }
 ```

--- a/.changeset/thirty-islands-hope.md
+++ b/.changeset/thirty-islands-hope.md
@@ -1,0 +1,8 @@
+---
+'@data-client/endpoint': patch
+---
+
+Fix: schema.All() polymorphic handling of Invalidated entities
+
+In case an Entity is invalidated, schema.All will continue to properly
+filter it out of its list.

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -127,15 +127,12 @@ export interface CheckLoop {
   (entityKey: string, pk: string, input: object): boolean;
 }
 
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-export interface GetEntityKeys {
-  (key: string): string[] | symbol;
+/** Interface specification for entities state accessor */
+export interface EntitiesInterface {
+  keys(): IterableIterator<string>;
+  entries(): IterableIterator<[string, any]>;
 }
 
-/** Loop over all entities of a given key */
-export interface ForEntities {
-  (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
-}
 /** Get normalized Entity from store */
 export interface GetEntity {
   (key: string, pk: string): any;
@@ -148,10 +145,8 @@ export interface GetIndex {
 
 /** Accessors to the currently processing state while building query */
 export interface IQueryDelegate {
-  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-  getEntityKeys: GetEntityKeys;
-  /** Loop over all entities of a given key */
-  forEntities: ForEntities;
+  /** Get all entities for a given schema key */
+  getEntities(key: string): EntitiesInterface | undefined;
   /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
   /** Get PK using an Entity Index */
@@ -164,10 +159,8 @@ export interface IQueryDelegate {
 export interface INormalizeDelegate {
   /** Action meta-data for this normalize call */
   readonly meta: { fetchedAt: number; date: number; expiresAt: number };
-  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-  getEntityKeys: GetEntityKeys;
-  /** Loop over all entities of a given key */
-  forEntities: ForEntities;
+  /** Get all entities for a given schema key */
+  getEntities(key: string): EntitiesInterface | undefined;
   /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
   /** Updates an entity using merge lifecycles when it has previously been set */

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -127,9 +127,14 @@ export interface CheckLoop {
   (entityKey: string, pk: string, input: object): boolean;
 }
 
-/** Get all normalized entities of one type from store */
-export interface GetEntities {
-  (key: string): { readonly [pk: string]: any } | undefined;
+/** Return all entity PKs for a given entity key or INVALID if no entity entries */
+export interface GetEntityKeys {
+  (key: string): string[] | symbol;
+}
+
+/** Loop over all entities of a given key */
+export interface ForEntities {
+  (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
 }
 /** Get normalized Entity from store */
 export interface GetEntity {
@@ -143,8 +148,13 @@ export interface GetIndex {
 
 /** Accessors to the currently processing state while building query */
 export interface IQueryDelegate {
-  getEntities: GetEntities;
+  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+  getEntityKeys: GetEntityKeys;
+  /** Loop over all entities of a given key */
+  forEntities: ForEntities;
+  /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
+  /** Get PK using an Entity Index */
   getIndex: GetIndex;
   /** Return to consider results invalid */
   INVALID: symbol;
@@ -154,8 +164,10 @@ export interface IQueryDelegate {
 export interface INormalizeDelegate {
   /** Action meta-data for this normalize call */
   readonly meta: { fetchedAt: number; date: number; expiresAt: number };
-  /** Get all normalized entities of one type from store */
-  getEntities: GetEntities;
+  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+  getEntityKeys: GetEntityKeys;
+  /** Loop over all entities of a given key */
+  forEntities: ForEntities;
   /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
   /** Updates an entity using merge lifecycles when it has previously been set */

--- a/packages/endpoint/src/schemas/All.ts
+++ b/packages/endpoint/src/schemas/All.ts
@@ -26,23 +26,23 @@ export default class AllSchema<
 
   queryKey(args: any, unvisit: any, delegate: IQueryDelegate): any {
     if (this.isSingleSchema) {
-      const entitiesEntry = delegate.getEntities(this.schema.key);
-      // we must wait until there are entries for any 'All' query to be Valid
-      if (entitiesEntry === undefined) return delegate.INVALID;
-      return Object.values(entitiesEntry).map(
-        entity => entity && this.schema.pk(entity),
-      );
+      return delegate.getEntityKeys(this.schema.key);
     }
     let found = false;
     const list = Object.values(this.schema as Record<string, any>).flatMap(
       (schema: EntityInterface) => {
-        const entitiesEntry = delegate.getEntities(schema.key);
-        if (entitiesEntry === undefined) return [];
-        found = true;
-        return Object.entries(entitiesEntry).map(([key, entity]) => ({
-          id: entity && schema.pk(entity, undefined, key, []),
-          schema: this.getSchemaAttribute(entity, undefined, key),
-        }));
+        const entities: any[] = [];
+        if (
+          delegate.forEntities(schema.key, ([pk, entity]) => {
+            if (!entity) return;
+            entities.push({
+              id: schema.pk(entity, undefined, pk, []),
+              schema: this.getSchemaAttribute(entity, undefined, pk),
+            });
+          })
+        )
+          found = true;
+        return entities;
       },
     );
     // we need at least one table entry of the Union for this to count as Valid.

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -326,12 +326,13 @@ function normalizeCreate(
   // parent is args when not nested
   const filterCollections = (this.createCollectionFilter as any)(...args);
   // add to any collections that match this
-  const entities = delegate.getEntities(this.key);
-  if (entities)
-    Object.keys(entities).forEach(collectionPk => {
-      if (!filterCollections(JSON.parse(collectionPk))) return;
-      delegate.mergeEntity(this, collectionPk, normalizedValue);
+  const keys = delegate.getEntityKeys(this.key);
+  if (typeof keys !== 'symbol') {
+    keys.forEach(collectionKey => {
+      if (!filterCollections(JSON.parse(collectionKey))) return;
+      delegate.mergeEntity(this, collectionKey, normalizedValue);
     });
+  }
   return normalizedValue as any;
 }
 

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -326,13 +326,12 @@ function normalizeCreate(
   // parent is args when not nested
   const filterCollections = (this.createCollectionFilter as any)(...args);
   // add to any collections that match this
-  const keys = delegate.getEntityKeys(this.key);
-  if (typeof keys !== 'symbol') {
-    keys.forEach(collectionKey => {
-      if (!filterCollections(JSON.parse(collectionKey))) return;
+  const entities = delegate.getEntities(this.key);
+  if (entities)
+    for (const collectionKey of entities.keys()) {
+      if (!filterCollections(JSON.parse(collectionKey))) continue;
       delegate.mergeEntity(this, collectionKey, normalizedValue);
-    });
-  }
+    }
   return normalizedValue as any;
 }
 

--- a/packages/endpoint/src/schemas/__tests__/Object.test.js
+++ b/packages/endpoint/src/schemas/__tests__/Object.test.js
@@ -6,8 +6,9 @@ import {
 import { denormalize as immDenormalize } from '@data-client/normalizr/imm';
 import { Temporal } from '@js-temporal/polyfill';
 import { IDEntity } from '__tests__/new';
-import { fromJS, Map } from 'immutable';
+import { fromJS } from 'immutable';
 
+import { fromJSEntities } from './denormalize';
 import { schema } from '../../';
 import Entity from '../Entity';
 
@@ -21,10 +22,6 @@ beforeAll(() => {
 afterAll(() => {
   dateSpy.mockRestore();
 });
-
-function fromJSEntities(entities) {
-  return Map(entities).map(v => Map(v));
-}
 
 describe(`${schema.Object.name} normalization`, () => {
   test('normalizes an object', () => {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/All.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/All.test.ts.snap
@@ -436,6 +436,31 @@ exports[`ArraySchema denormalization (direct) denormalizes removes undefined or 
 }
 `;
 
+exports[`ArraySchema denormalization (direct) denormalizes removes undefined or INVALID entities with polymorphism 1`] = `
+[
+  Cat {
+    "id": "1",
+    "name": "Milo",
+    "type": "Cat",
+  },
+  Cat {
+    "id": "2",
+    "name": "Jake",
+    "type": "Cat",
+  },
+  Dog {
+    "id": "1",
+    "name": "Rex",
+    "type": "dogs",
+  },
+  Person {
+    "id": "1",
+    "name": "Alice",
+    "type": "people",
+  },
+]
+`;
+
 exports[`ArraySchema denormalization (direct) returns the input value if is null 1`] = `
 Taco {
   "fillings": null,
@@ -574,6 +599,31 @@ exports[`ArraySchema denormalization (immutable) denormalizes removes undefined 
     },
   ],
 }
+`;
+
+exports[`ArraySchema denormalization (immutable) denormalizes removes undefined or INVALID entities with polymorphism 1`] = `
+[
+  Cat {
+    "id": "1",
+    "name": "Milo",
+    "type": "Cat",
+  },
+  Cat {
+    "id": "2",
+    "name": "Jake",
+    "type": "Cat",
+  },
+  Dog {
+    "id": "1",
+    "name": "Rex",
+    "type": "dogs",
+  },
+  Person {
+    "id": "1",
+    "name": "Alice",
+    "type": "people",
+  },
+]
 `;
 
 exports[`ArraySchema denormalization (immutable) returns the input value if is null 1`] = `

--- a/packages/normalizr/src/delegate/BaseDelegate.ts
+++ b/packages/normalizr/src/delegate/BaseDelegate.ts
@@ -2,8 +2,8 @@ import { INVALID } from '../denormalize/symbol.js';
 import type {
   QueryPath,
   IndexPath,
-  EntitiesPath,
   IQueryDelegate,
+  EntitiesInterface,
 } from '../interface.js';
 import type { Dep } from '../memo/WeakDependencyMap.js';
 
@@ -17,19 +17,15 @@ export abstract class BaseDelegate {
     this.indexes = indexes;
   }
 
-  abstract forEntities(
-    key: string,
-    callbackfn: (value: [string, unknown]) => void,
-  ): boolean;
-
-  // we must expose the entities object to track in our WeakDependencyMap
-  // however, this should not be part of the public API
-  protected abstract getEntities(key: string): object | undefined;
-  abstract getEntityKeys(key: string): string[] | symbol;
+  abstract getEntities(key: string): EntitiesInterface | undefined;
   abstract getEntity(key: string, pk: string): object | undefined;
   abstract getIndex(...path: IndexPath): object | undefined;
   abstract getIndexEnd(entity: any, value: string): string | undefined;
+  // we must expose the entities object to track in our WeakDependencyMap
+  // however, this should not be part of the public API
+  protected abstract getEntitiesObject(key: string): object | undefined;
 
+  // only used in buildQueryKey
   tracked(
     schema: any,
   ): [delegate: IQueryDelegate, dependencies: Dep<QueryPath>[]] {
@@ -48,21 +44,19 @@ export abstract class BaseDelegate {
         dependencies.push({ path, entity });
         return entity;
       },
-      forEntities(
-        key: string,
-        callbackfn: (value: [string, any]) => void,
-      ): boolean {
-        const entity = base.getEntities(key);
-        // always push even if entity is undefined
+      getEntities(key: string): EntitiesInterface | undefined {
+        const entity = base.getEntitiesObject(key);
         dependencies.push({ path: [key], entity });
-        return base.forEntities(key, callbackfn);
-      },
-      getEntityKeys(key: string): string[] | symbol {
-        const entity = base.getEntities(key);
-        dependencies.push({ path: [key], entity });
-        return base.getEntityKeys(key);
+        return base.getEntities(key);
       },
     };
     return [delegate, dependencies];
   }
 }
+
+export const getDependency =
+  (delegate: BaseDelegate) =>
+  (path: QueryPath): object | undefined =>
+    delegate[['', 'getEntitiesObject', 'getEntity', 'getIndex'][path.length]](
+      ...path,
+    );

--- a/packages/normalizr/src/delegate/BaseDelegate.ts
+++ b/packages/normalizr/src/delegate/BaseDelegate.ts
@@ -17,7 +17,15 @@ export abstract class BaseDelegate {
     this.indexes = indexes;
   }
 
-  abstract getEntities(...path: EntitiesPath): object | undefined;
+  abstract forEntities(
+    key: string,
+    callbackfn: (value: [string, unknown]) => void,
+  ): boolean;
+
+  // we must expose the entities object to track in our WeakDependencyMap
+  // however, this should not be part of the public API
+  protected abstract getEntities(key: string): object | undefined;
+  abstract getEntityKeys(key: string): string[] | symbol;
   abstract getEntity(key: string, pk: string): object | undefined;
   abstract getIndex(...path: IndexPath): object | undefined;
   abstract getIndexEnd(entity: any, value: string): string | undefined;
@@ -40,10 +48,19 @@ export abstract class BaseDelegate {
         dependencies.push({ path, entity });
         return entity;
       },
-      getEntities(...path: EntitiesPath) {
-        const entity = base.getEntities(...path);
-        dependencies.push({ path, entity });
-        return entity;
+      forEntities(
+        key: string,
+        callbackfn: (value: [string, any]) => void,
+      ): boolean {
+        const entity = base.getEntities(key);
+        // always push even if entity is undefined
+        dependencies.push({ path: [key], entity });
+        return base.forEntities(key, callbackfn);
+      },
+      getEntityKeys(key: string): string[] | symbol {
+        const entity = base.getEntities(key);
+        dependencies.push({ path: [key], entity });
+        return base.getEntityKeys(key);
       },
     };
     return [delegate, dependencies];

--- a/packages/normalizr/src/delegate/Delegate.imm.ts
+++ b/packages/normalizr/src/delegate/Delegate.imm.ts
@@ -1,16 +1,8 @@
 import { BaseDelegate } from './BaseDelegate.js';
-import { INVALID } from '../denormalize/symbol.js';
+import { EntitiesInterface } from '../interface.js';
 
 export type ImmutableJSEntityTable = {
-  get(key: string):
-    | {
-        forEach(
-          sideEffect: (value: any, key: string, iter: any) => unknown,
-          context?: unknown,
-        ): number;
-        keySeq(): { toArray(): string[] };
-      }
-    | undefined;
+  get(key: string): EntitiesInterface | undefined;
   getIn(k: [key: string, pk: string]): { toJS(): any } | undefined;
   setIn(k: [key: string, pk: string], value: any);
 };
@@ -27,33 +19,13 @@ export class ImmDelegate extends BaseDelegate {
     super(state);
   }
 
-  forEntities(
-    key: string,
-    callbackfn: (value: [string, unknown]) => void,
-  ): boolean {
-    const entities = this.getEntities(key);
-    if (!entities) return false;
-    entities.forEach((entity: any, pk: string) => {
-      callbackfn([pk, entity]);
-    });
-    return true;
+  // we must expose the entities object to track in our WeakDependencyMap
+  // however, this should not be part of the public API
+  protected getEntitiesObject(key: string): object | undefined {
+    return this.entities.get(key);
   }
 
-  getEntityKeys(key: string): string[] | symbol {
-    const entities = this.getEntities(key);
-    if (entities === undefined) return INVALID;
-    return entities.keySeq().toArray();
-  }
-
-  protected getEntities(key: string):
-    | {
-        forEach(
-          sideEffect: (value: any, key: string, iter: any) => unknown,
-          context?: unknown,
-        ): number;
-        keySeq(): { toArray(): string[] };
-      }
-    | undefined {
+  getEntities(key: string): EntitiesInterface | undefined {
     return this.entities.get(key);
   }
 

--- a/packages/normalizr/src/delegate/Delegate.ts
+++ b/packages/normalizr/src/delegate/Delegate.ts
@@ -1,5 +1,8 @@
-import { INVALID } from '../denormalize/symbol.js';
-import type { EntityTable, NormalizedIndex } from '../interface.js';
+import type {
+  EntitiesInterface,
+  EntityTable,
+  NormalizedIndex,
+} from '../interface.js';
 import { BaseDelegate } from './BaseDelegate.js';
 
 /** Basic POJO state interfaces for normalize side */
@@ -15,28 +18,23 @@ export class POJODelegate extends BaseDelegate {
     super(state);
   }
 
-  forEntities(
-    key: string,
-    callbackfn: (
-      value: [string, unknown],
-      index: number,
-      array: [string, unknown][],
-    ) => void,
-  ): boolean {
-    const entities = this.getEntities(key);
-    if (entities === undefined) return false;
-    Object.entries(entities).forEach(callbackfn);
-    return true;
-  }
-
-  getEntityKeys(key: string): string[] | symbol {
-    const entities = this.getEntities(key);
-    if (entities === undefined) return INVALID;
-    return Object.keys(entities);
-  }
-
-  protected getEntities(key: string): object | undefined {
+  // we must expose the entities object to track in our WeakDependencyMap
+  // however, this should not be part of the public API
+  protected getEntitiesObject(key: string): object | undefined {
     return this.entities[key];
+  }
+
+  getEntities(key: string): EntitiesInterface | undefined {
+    const entities = this.entities[key];
+    if (entities === undefined) return undefined;
+    return {
+      keys(): IterableIterator<string> {
+        return Object.keys(entities) as any;
+      },
+      entries(): IterableIterator<[string, any]> {
+        return Object.entries(entities) as any;
+      },
+    };
   }
 
   getEntity(key: string, pk: string): any {

--- a/packages/normalizr/src/delegate/Delegate.ts
+++ b/packages/normalizr/src/delegate/Delegate.ts
@@ -1,3 +1,4 @@
+import { INVALID } from '../denormalize/symbol.js';
 import type { EntityTable, NormalizedIndex } from '../interface.js';
 import { BaseDelegate } from './BaseDelegate.js';
 
@@ -14,7 +15,27 @@ export class POJODelegate extends BaseDelegate {
     super(state);
   }
 
-  getEntities(key: string): any {
+  forEntities(
+    key: string,
+    callbackfn: (
+      value: [string, unknown],
+      index: number,
+      array: [string, unknown][],
+    ) => void,
+  ): boolean {
+    const entities = this.getEntities(key);
+    if (entities === undefined) return false;
+    Object.entries(entities).forEach(callbackfn);
+    return true;
+  }
+
+  getEntityKeys(key: string): string[] | symbol {
+    const entities = this.getEntities(key);
+    if (entities === undefined) return INVALID;
+    return Object.keys(entities);
+  }
+
+  protected getEntities(key: string): object | undefined {
     return this.entities[key];
   }
 

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -114,9 +114,14 @@ export interface CheckLoop {
   (entityKey: string, pk: string, input: object): boolean;
 }
 
-/** Get all normalized entities of one type from store */
-export interface GetEntities {
-  (key: string): { readonly [pk: string]: any } | undefined;
+/** Return all entity PKs for a given entity key or INVALID if no entity entries */
+export interface GetEntityKeys {
+  (key: string): string[] | symbol;
+}
+
+/** Loop over all entities of a given key */
+export interface ForEntities {
+  (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
 }
 /** Get normalized Entity from store */
 export interface GetEntity {
@@ -130,8 +135,13 @@ export interface GetIndex {
 
 /** Accessors to the currently processing state while building query */
 export interface IQueryDelegate {
-  getEntities: GetEntities;
+  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+  getEntityKeys: GetEntityKeys;
+  /** Loop over all entities of a given key */
+  forEntities: ForEntities;
+  /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
+  /** Get PK using an Entity Index */
   getIndex: GetIndex;
   /** Return to consider results invalid */
   INVALID: symbol;
@@ -141,8 +151,10 @@ export interface IQueryDelegate {
 export interface INormalizeDelegate {
   /** Action meta-data for this normalize call */
   readonly meta: { fetchedAt: number; date: number; expiresAt: number };
-  /** Get all normalized entities of one type from store */
-  getEntities: GetEntities;
+  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+  getEntityKeys: GetEntityKeys;
+  /** Loop over all entities of a given key */
+  forEntities: ForEntities;
   /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
   /** Updates an entity using merge lifecycles when it has previously been set */

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -114,15 +114,12 @@ export interface CheckLoop {
   (entityKey: string, pk: string, input: object): boolean;
 }
 
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-export interface GetEntityKeys {
-  (key: string): string[] | symbol;
+/** Interface specification for entities state accessor */
+export interface EntitiesInterface {
+  keys(): IterableIterator<string>;
+  entries(): IterableIterator<[string, any]>;
 }
 
-/** Loop over all entities of a given key */
-export interface ForEntities {
-  (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
-}
 /** Get normalized Entity from store */
 export interface GetEntity {
   (key: string, pk: string): any;
@@ -135,10 +132,8 @@ export interface GetIndex {
 
 /** Accessors to the currently processing state while building query */
 export interface IQueryDelegate {
-  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-  getEntityKeys: GetEntityKeys;
-  /** Loop over all entities of a given key */
-  forEntities: ForEntities;
+  /** Get all entities for a given schema key */
+  getEntities(key: string): EntitiesInterface | undefined;
   /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
   /** Get PK using an Entity Index */
@@ -151,10 +146,8 @@ export interface IQueryDelegate {
 export interface INormalizeDelegate {
   /** Action meta-data for this normalize call */
   readonly meta: { fetchedAt: number; date: number; expiresAt: number };
-  /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-  getEntityKeys: GetEntityKeys;
-  /** Loop over all entities of a given key */
-  forEntities: ForEntities;
+  /** Get all entities for a given schema key */
+  getEntities(key: string): EntitiesInterface | undefined;
   /** Gets any previously normalized entity from store */
   getEntity: GetEntity;
   /** Updates an entity using merge lifecycles when it has previously been set */

--- a/packages/normalizr/src/memo/MemoCache.ts
+++ b/packages/normalizr/src/memo/MemoCache.ts
@@ -3,7 +3,7 @@ import WeakDependencyMap from './WeakDependencyMap.js';
 import buildQueryKey from '../buildQueryKey.js';
 import { GetEntityCache, getEntityCaches } from './entitiesCache.js';
 import { MemoPolicy } from './Policy.js';
-import type { BaseDelegate } from '../delegate/BaseDelegate.js';
+import { getDependency } from '../delegate/BaseDelegate.js';
 import type { INVALID } from '../denormalize/symbol.js';
 import getUnvisit from '../denormalize/unvisit.js';
 import type {
@@ -140,10 +140,3 @@ type StateInterface = {
         getIn(k: string[]): any;
       };
 };
-
-const getDependency =
-  (delegate: BaseDelegate) =>
-  (path: QueryPath): object | undefined =>
-    delegate[['', 'getEntities', 'getEntity', 'getIndex'][path.length]](
-      ...path,
-    );

--- a/website/src/components/Playground/editor-types/@data-client/core.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/core.d.ts
@@ -57,13 +57,10 @@ interface EntityPath {
 type IndexPath = [key: string, index: string, value: string];
 type EntitiesPath = [key: string];
 type QueryPath = IndexPath | [key: string, pk: string] | EntitiesPath;
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-interface GetEntityKeys {
-    (key: string): string[] | symbol;
-}
-/** Loop over all entities of a given key */
-interface ForEntities {
-    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
+/** Interface specification for entities state accessor */
+interface EntitiesInterface {
+    keys(): IterableIterator<string>;
+    entries(): IterableIterator<[string, any]>;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -76,10 +73,8 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Get PK using an Entity Index */
@@ -95,10 +90,8 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -239,12 +232,11 @@ declare abstract class BaseDelegate {
         entities: any;
         indexes: any;
     });
-    abstract forEntities(key: string, callbackfn: (value: [string, unknown]) => void): boolean;
-    protected abstract getEntities(key: string): object | undefined;
-    abstract getEntityKeys(key: string): string[] | symbol;
+    abstract getEntities(key: string): EntitiesInterface | undefined;
     abstract getEntity(key: string, pk: string): object | undefined;
     abstract getIndex(...path: IndexPath): object | undefined;
     abstract getIndexEnd(entity: any, value: string): string | undefined;
+    protected abstract getEntitiesObject(key: string): object | undefined;
     tracked(schema: any): [delegate: IQueryDelegate, dependencies: Dep<QueryPath>[]];
 }
 

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -264,11 +264,13 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Get all normalized entities of one type from store */
-interface GetEntities {
-    (key: string): {
-        readonly [pk: string]: any;
-    } | undefined;
+/** Return all entity PKs for a given entity key or INVALID if no entity entries */
+interface GetEntityKeys {
+    (key: string): string[] | symbol;
+}
+/** Loop over all entities of a given key */
+interface ForEntities {
+    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -281,8 +283,13 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
+    /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
+    /** Get PK using an Entity Index */
     getIndex: GetIndex;
     /** Return to consider results invalid */
     INVALID: symbol;
@@ -295,8 +302,10 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Get all normalized entities of one type from store */
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1194,4 +1203,4 @@ declare function validateRequired(processedEntity: any, requiredDefaults: Record
 /** https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type */
 type NI<T> = NoInfer<T>;
 
-export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, type GetEntities, type GetEntity, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };
+export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, type ForEntities, type GetEntity, type GetEntityKeys, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/endpoint.d.ts
@@ -264,13 +264,10 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-interface GetEntityKeys {
-    (key: string): string[] | symbol;
-}
-/** Loop over all entities of a given key */
-interface ForEntities {
-    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
+/** Interface specification for entities state accessor */
+interface EntitiesInterface {
+    keys(): IterableIterator<string>;
+    entries(): IterableIterator<[string, any]>;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -283,10 +280,8 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Get PK using an Entity Index */
@@ -302,10 +297,8 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1203,4 +1196,4 @@ declare function validateRequired(processedEntity: any, requiredDefaults: Record
 /** https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type */
 type NI<T> = NoInfer<T>;
 
-export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, type ForEntities, type GetEntity, type GetEntityKeys, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };
+export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesInterface, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, type GetEntity, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -264,13 +264,10 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-interface GetEntityKeys {
-    (key: string): string[] | symbol;
-}
-/** Loop over all entities of a given key */
-interface ForEntities {
-    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
+/** Interface specification for entities state accessor */
+interface EntitiesInterface {
+    keys(): IterableIterator<string>;
+    entries(): IterableIterator<[string, any]>;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -283,10 +280,8 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Get PK using an Entity Index */
@@ -302,10 +297,8 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1244,4 +1237,4 @@ interface GQLError {
     path: (string | number)[];
 }
 
-export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, type ForEntities, GQLEndpoint, GQLEntity, type GQLError, GQLNetworkError, type GQLOptions, type GetEntity, type GetEntityKeys, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };
+export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesInterface, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, GQLEndpoint, GQLEntity, type GQLError, GQLNetworkError, type GQLOptions, type GetEntity, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/graphql.d.ts
@@ -264,11 +264,13 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Get all normalized entities of one type from store */
-interface GetEntities {
-    (key: string): {
-        readonly [pk: string]: any;
-    } | undefined;
+/** Return all entity PKs for a given entity key or INVALID if no entity entries */
+interface GetEntityKeys {
+    (key: string): string[] | symbol;
+}
+/** Loop over all entities of a given key */
+interface ForEntities {
+    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -281,8 +283,13 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
+    /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
+    /** Get PK using an Entity Index */
     getIndex: GetIndex;
     /** Return to consider results invalid */
     INVALID: symbol;
@@ -295,8 +302,10 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Get all normalized entities of one type from store */
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1235,4 +1244,4 @@ interface GQLError {
     path: (string | number)[];
 }
 
-export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, GQLEndpoint, GQLEntity, type GQLError, GQLNetworkError, type GQLOptions, type GetEntities, type GetEntity, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };
+export { type AbstractInstanceType, Array$1 as Array, type CheckLoop, Collection, type DefaultArgs, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type FetchFunction, type ForEntities, GQLEndpoint, GQLEntity, type GQLError, GQLNetworkError, type GQLOptions, type GetEntity, type GetEntityKeys, type GetIndex, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type IndexPath, Invalidate, type KeyofEndpointInstance, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type Visit, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
@@ -70,11 +70,13 @@ type QueryPath = IndexPath | [key: string, pk: string] | EntitiesPath;
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Get all normalized entities of one type from store */
-interface GetEntities {
-    (key: string): {
-        readonly [pk: string]: any;
-    } | undefined;
+/** Return all entity PKs for a given entity key or INVALID if no entity entries */
+interface GetEntityKeys {
+    (key: string): string[] | symbol;
+}
+/** Loop over all entities of a given key */
+interface ForEntities {
+    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -87,8 +89,13 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
+    /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
+    /** Get PK using an Entity Index */
     getIndex: GetIndex;
     /** Return to consider results invalid */
     INVALID: symbol;
@@ -101,8 +108,10 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Get all normalized entities of one type from store */
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -270,7 +279,9 @@ declare abstract class BaseDelegate {
         entities: any;
         indexes: any;
     });
-    abstract getEntities(...path: EntitiesPath): object | undefined;
+    abstract forEntities(key: string, callbackfn: (value: [string, unknown]) => void): boolean;
+    protected abstract getEntities(key: string): object | undefined;
+    abstract getEntityKeys(key: string): string[] | symbol;
     abstract getEntity(key: string, pk: string): object | undefined;
     abstract getIndex(...path: IndexPath): object | undefined;
     abstract getIndexEnd(entity: any, value: string): string | undefined;
@@ -336,7 +347,9 @@ declare class POJODelegate extends BaseDelegate {
         entities: EntityTable;
         indexes: NormalizedIndex;
     });
-    getEntities(key: string): any;
+    forEntities(key: string, callbackfn: (value: [string, unknown], index: number, array: [string, unknown][]) => void): boolean;
+    getEntityKeys(key: string): string[] | symbol;
+    protected getEntities(key: string): object | undefined;
     getEntity(key: string, pk: string): any;
     getIndex(key: string, field: string): object | undefined;
     getIndexEnd(entity: object | undefined, value: string): any;
@@ -462,4 +475,4 @@ type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Pr
 
 declare function validateQueryKey(queryKey: unknown): boolean;
 
-export { type AbstractInstanceType, type ArrayElement, BaseDelegate, type CheckLoop, type DenormGetEntity, type Denormalize, type DenormalizeNullable, type EndpointExtraOptions, type EndpointInterface, type EndpointsCache, type EntitiesPath, type EntityCache, type EntityInterface, type EntityPath, type EntityTable, type ErrorTypes, ExpiryStatus, type ExpiryStatusInterface, type FetchFunction, type GetEntities, type GetEntity, type GetIndex, type IMemoPolicy, INVALID, type INormalizeDelegate, type IQueryDelegate, type IndexInterface, type IndexParams, type IndexPath, type InferReturn, MemoCache, MemoPolicy, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeReturnType, type NormalizedIndex, type NormalizedSchema, type OptimisticUpdateParams, type QueryPath, type Queryable, type ReadEndpoint, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type UpdateFunction, type Visit, WeakDependencyMap, denormalize, isEntity, normalize, validateQueryKey };
+export { type AbstractInstanceType, type ArrayElement, BaseDelegate, type CheckLoop, type DenormGetEntity, type Denormalize, type DenormalizeNullable, type EndpointExtraOptions, type EndpointInterface, type EndpointsCache, type EntitiesPath, type EntityCache, type EntityInterface, type EntityPath, type EntityTable, type ErrorTypes, ExpiryStatus, type ExpiryStatusInterface, type FetchFunction, type ForEntities, type GetEntity, type GetEntityKeys, type GetIndex, type IMemoPolicy, INVALID, type INormalizeDelegate, type IQueryDelegate, type IndexInterface, type IndexParams, type IndexPath, type InferReturn, MemoCache, MemoPolicy, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeReturnType, type NormalizedIndex, type NormalizedSchema, type OptimisticUpdateParams, type QueryPath, type Queryable, type ReadEndpoint, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type UpdateFunction, type Visit, WeakDependencyMap, denormalize, isEntity, normalize, validateQueryKey };

--- a/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/normalizr.d.ts
@@ -70,13 +70,10 @@ type QueryPath = IndexPath | [key: string, pk: string] | EntitiesPath;
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-interface GetEntityKeys {
-    (key: string): string[] | symbol;
-}
-/** Loop over all entities of a given key */
-interface ForEntities {
-    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
+/** Interface specification for entities state accessor */
+interface EntitiesInterface {
+    keys(): IterableIterator<string>;
+    entries(): IterableIterator<[string, any]>;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -89,10 +86,8 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Get PK using an Entity Index */
@@ -108,10 +103,8 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -279,12 +272,11 @@ declare abstract class BaseDelegate {
         entities: any;
         indexes: any;
     });
-    abstract forEntities(key: string, callbackfn: (value: [string, unknown]) => void): boolean;
-    protected abstract getEntities(key: string): object | undefined;
-    abstract getEntityKeys(key: string): string[] | symbol;
+    abstract getEntities(key: string): EntitiesInterface | undefined;
     abstract getEntity(key: string, pk: string): object | undefined;
     abstract getIndex(...path: IndexPath): object | undefined;
     abstract getIndexEnd(entity: any, value: string): string | undefined;
+    protected abstract getEntitiesObject(key: string): object | undefined;
     tracked(schema: any): [delegate: IQueryDelegate, dependencies: Dep<QueryPath>[]];
 }
 
@@ -347,9 +339,8 @@ declare class POJODelegate extends BaseDelegate {
         entities: EntityTable;
         indexes: NormalizedIndex;
     });
-    forEntities(key: string, callbackfn: (value: [string, unknown], index: number, array: [string, unknown][]) => void): boolean;
-    getEntityKeys(key: string): string[] | symbol;
-    protected getEntities(key: string): object | undefined;
+    protected getEntitiesObject(key: string): object | undefined;
+    getEntities(key: string): EntitiesInterface | undefined;
     getEntity(key: string, pk: string): any;
     getIndex(key: string, field: string): object | undefined;
     getIndexEnd(entity: object | undefined, value: string): any;
@@ -475,4 +466,4 @@ type FetchFunction<A extends readonly any[] = any, R = any> = (...args: A) => Pr
 
 declare function validateQueryKey(queryKey: unknown): boolean;
 
-export { type AbstractInstanceType, type ArrayElement, BaseDelegate, type CheckLoop, type DenormGetEntity, type Denormalize, type DenormalizeNullable, type EndpointExtraOptions, type EndpointInterface, type EndpointsCache, type EntitiesPath, type EntityCache, type EntityInterface, type EntityPath, type EntityTable, type ErrorTypes, ExpiryStatus, type ExpiryStatusInterface, type FetchFunction, type ForEntities, type GetEntity, type GetEntityKeys, type GetIndex, type IMemoPolicy, INVALID, type INormalizeDelegate, type IQueryDelegate, type IndexInterface, type IndexParams, type IndexPath, type InferReturn, MemoCache, MemoPolicy, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeReturnType, type NormalizedIndex, type NormalizedSchema, type OptimisticUpdateParams, type QueryPath, type Queryable, type ReadEndpoint, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type UpdateFunction, type Visit, WeakDependencyMap, denormalize, isEntity, normalize, validateQueryKey };
+export { type AbstractInstanceType, type ArrayElement, BaseDelegate, type CheckLoop, type DenormGetEntity, type Denormalize, type DenormalizeNullable, type EndpointExtraOptions, type EndpointInterface, type EndpointsCache, type EntitiesInterface, type EntitiesPath, type EntityCache, type EntityInterface, type EntityPath, type EntityTable, type ErrorTypes, ExpiryStatus, type ExpiryStatusInterface, type FetchFunction, type GetEntity, type GetIndex, type IMemoPolicy, INVALID, type INormalizeDelegate, type IQueryDelegate, type IndexInterface, type IndexParams, type IndexPath, type InferReturn, MemoCache, MemoPolicy, type Mergeable, type MutateEndpoint, type NI, type NetworkError, type Normalize, type NormalizeNullable, type NormalizeReturnType, type NormalizedIndex, type NormalizedSchema, type OptimisticUpdateParams, type QueryPath, type Queryable, type ReadEndpoint, type ResolveType, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type SnapshotInterface, type UnknownError, type UpdateFunction, type Visit, WeakDependencyMap, denormalize, isEntity, normalize, validateQueryKey };

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -266,13 +266,10 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-interface GetEntityKeys {
-    (key: string): string[] | symbol;
-}
-/** Loop over all entities of a given key */
-interface ForEntities {
-    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
+/** Interface specification for entities state accessor */
+interface EntitiesInterface {
+    keys(): IterableIterator<string>;
+    entries(): IterableIterator<[string, any]>;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -285,10 +282,8 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Get PK using an Entity Index */
@@ -304,10 +299,8 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1802,4 +1795,4 @@ declare class NetworkError extends Error {
     constructor(response: Response);
 }
 
-export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, type CheckLoop, Collection, type CustomResource, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type ForEntities, type FromFallBack, type GetEndpoint, type GetEntity, type GetEntityKeys, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };
+export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, type CheckLoop, Collection, type CustomResource, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesInterface, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type FromFallBack, type GetEndpoint, type GetEntity, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/@data-client/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@data-client/rest.d.ts
@@ -266,11 +266,13 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Get all normalized entities of one type from store */
-interface GetEntities {
-    (key: string): {
-        readonly [pk: string]: any;
-    } | undefined;
+/** Return all entity PKs for a given entity key or INVALID if no entity entries */
+interface GetEntityKeys {
+    (key: string): string[] | symbol;
+}
+/** Loop over all entities of a given key */
+interface ForEntities {
+    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -283,8 +285,13 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
+    /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
+    /** Get PK using an Entity Index */
     getIndex: GetIndex;
     /** Return to consider results invalid */
     INVALID: symbol;
@@ -297,8 +304,10 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Get all normalized entities of one type from store */
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1793,4 +1802,4 @@ declare class NetworkError extends Error {
     constructor(response: Response);
 }
 
-export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, type CheckLoop, Collection, type CustomResource, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type FromFallBack, type GetEndpoint, type GetEntities, type GetEntity, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };
+export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, type CheckLoop, Collection, type CustomResource, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type ForEntities, type FromFallBack, type GetEndpoint, type GetEntity, type GetEntityKeys, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, validateRequired };

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -270,11 +270,13 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Get all normalized entities of one type from store */
-interface GetEntities {
-    (key: string): {
-        readonly [pk: string]: any;
-    } | undefined;
+/** Return all entity PKs for a given entity key or INVALID if no entity entries */
+interface GetEntityKeys {
+    (key: string): string[] | symbol;
+}
+/** Loop over all entities of a given key */
+interface ForEntities {
+    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -287,8 +289,13 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
+    /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
+    /** Get PK using an Entity Index */
     getIndex: GetIndex;
     /** Return to consider results invalid */
     INVALID: symbol;
@@ -301,8 +308,10 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Get all normalized entities of one type from store */
-    getEntities: GetEntities;
+    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
+    getEntityKeys: GetEntityKeys;
+    /** Loop over all entities of a given key */
+    forEntities: ForEntities;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1973,4 +1982,4 @@ declare function useController(): Controller;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
 
-export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, _default as AsyncBoundary, type CheckLoop, Collection, type CustomResource, DataProvider, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes$1 as ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type FromFallBack, type GetEndpoint, type GetEntities, type GetEntity, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };
+export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, _default as AsyncBoundary, type CheckLoop, Collection, type CustomResource, DataProvider, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes$1 as ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type ForEntities, type FromFallBack, type GetEndpoint, type GetEntity, type GetEntityKeys, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };

--- a/website/src/components/Playground/editor-types/globals.d.ts
+++ b/website/src/components/Playground/editor-types/globals.d.ts
@@ -270,13 +270,10 @@ type EntitiesPath = [key: string];
 interface CheckLoop {
     (entityKey: string, pk: string, input: object): boolean;
 }
-/** Return all entity PKs for a given entity key or INVALID if no entity entries */
-interface GetEntityKeys {
-    (key: string): string[] | symbol;
-}
-/** Loop over all entities of a given key */
-interface ForEntities {
-    (key: string, callbackfn: (value: [string, unknown]) => void): boolean;
+/** Interface specification for entities state accessor */
+interface EntitiesInterface {
+    keys(): IterableIterator<string>;
+    entries(): IterableIterator<[string, any]>;
 }
 /** Get normalized Entity from store */
 interface GetEntity {
@@ -289,10 +286,8 @@ interface GetIndex {
 }
 /** Accessors to the currently processing state while building query */
 interface IQueryDelegate {
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Get PK using an Entity Index */
@@ -308,10 +303,8 @@ interface INormalizeDelegate {
         date: number;
         expiresAt: number;
     };
-    /** Return all entity PKs for a given entity key or INVALID if no entity entries */
-    getEntityKeys: GetEntityKeys;
-    /** Loop over all entities of a given key */
-    forEntities: ForEntities;
+    /** Get all entities for a given schema key */
+    getEntities(key: string): EntitiesInterface | undefined;
     /** Gets any previously normalized entity from store */
     getEntity: GetEntity;
     /** Updates an entity using merge lifecycles when it has previously been set */
@@ -1982,4 +1975,4 @@ declare function useController(): Controller;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>]): E['schema'] extends undefined | null ? ResolveType$1<E> : Denormalize$1<E['schema']>;
 declare function useLive<E extends EndpointInterface$1<FetchFunction$1, Schema$1 | undefined, undefined | false>>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E['schema'] extends undefined | null ? ResolveType$1<E> | undefined : DenormalizeNullable$1<E['schema']>;
 
-export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, _default as AsyncBoundary, type CheckLoop, Collection, type CustomResource, DataProvider, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes$1 as ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type ForEntities, type FromFallBack, type GetEndpoint, type GetEntity, type GetEntityKeys, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };
+export { type AbstractInstanceType, type AddEndpoint, Array$1 as Array, _default as AsyncBoundary, type CheckLoop, Collection, type CustomResource, DataProvider, type DefaultArgs, type Defaults, type Denormalize, type DenormalizeNullable, type DenormalizeNullableObject, type DenormalizeObject, Endpoint, type EndpointExtendOptions, type EndpointExtraOptions, type EndpointInstance, type EndpointInstanceInterface, type EndpointInterface, type EndpointOptions, type EndpointParam, type EndpointToFunction, type EntitiesInterface, type EntitiesPath, Entity, type EntityFields, type EntityInterface, type EntityMap, EntityMixin, type EntityPath, type EntityTable, type ErrorTypes$1 as ErrorTypes, type ExpiryStatusInterface, ExtendableEndpoint, type ExtendedResource, type FetchFunction, type FetchGet, type FetchMutate, type FromFallBack, type GetEndpoint, type GetEntity, type GetIndex, type HookResource, type HookableEndpointInterface, type IEntityClass, type IEntityInstance, type INormalizeDelegate, type IQueryDelegate, type RestEndpoint$1 as IRestEndpoint, type IndexPath, Invalidate, type KeyofEndpointInstance, type KeyofRestEndpoint, type KeysToArgs, type Mergeable, type MethodToSide, type MutateEndpoint, type NI, NetworkError, ErrorBoundary as NetworkErrorBoundary, type Normalize, type NormalizeNullable, type NormalizeObject, type NormalizedEntity, type NormalizedIndex, type NormalizedNullableObject, type ObjectArgs, type OptionsToFunction, type PaginationEndpoint, type PaginationFieldEndpoint, type ParamFetchNoBody, type ParamFetchWithBody, type ParamToArgs, type PartialRestGenerics, type PathArgs, type PathArgsAndSearch, type PathKeys, type PolymorphicInterface, type Queryable, type ReadEndpoint, type RecordClass, type ResolveType, type Resource, type ResourceEndpointExtensions, type ResourceExtension, type ResourceGenerics, type ResourceInterface, type ResourceOptions, RestEndpoint, type RestEndpointConstructor, type RestEndpointConstructorOptions, type RestEndpointExtendOptions, type RestEndpointOptions, type RestExtendedEndpoint, type RestFetch, type RestGenerics, type RestInstance, type RestInstanceBase, type RestType, type RestTypeNoBody, type RestTypeWithBody, type Schema, type SchemaArgs, type SchemaClass, type SchemaSimple, type Serializable, type ShortenPath, type SnapshotInterface, type UnknownError, type Visit, resource as createResource, getUrlBase, getUrlTokens, hookifyResource, resource, schema_d as schema, useCache, useController, useDLE, useError, useFetch, useLive, useQuery, useSubscription, useSuspense, validateRequired };


### PR DESCRIPTION
Follow-up to #3468

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Exposing the full entities data structure is potentially unsafe, and has unbounced interface implications for its implementation.

Restrict exposed surface area to looping behavior.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Return value is a restricted interface with `keys()` and `entries()` iterator methods.
Update both `IQueryDelegate`, and `INormalizeDelegate` as we try to match their interfaces as much as possible.

```ts
const entities = delegate.getEntities(key);

// foreach on keys
for (const key of entities.keys()) {}
// Object.keys() (convert to array)
return [...entities.keys()];
// foreach on full entry
for (const [key, entity] of entities.entries()) {}
```

#### Before

```ts
const entities = delegate.getEntity(this.key);
if (entities)
  Object.keys(entities).forEach(collectionPk => {
    if (!filterCollections(JSON.parse(collectionPk))) return;
    delegate.mergeEntity(this, collectionPk, normalizedValue);
  });
```

#### After

```ts
const entities = delegate.getEntities(this.key);
if (entities)
  for (const collectionKey of entities.keys()) {
    if (!filterCollections(JSON.parse(collectionKey))) continue;
    delegate.mergeEntity(this, collectionKey, normalizedValue);
  }
```

500% performance improvement in schema.All().buildQueryKey