### PR TITLE
internal: Uncap test workers in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,15 +118,15 @@ jobs:
           name: Running Jest
           command: |
             if [ "<< parameters.react-version >>" == "^17" ]; then
-              yarn test:ci --maxWorkers=3 --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
+              yarn test:ci --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "^18" ]; then
-              yarn test:ci --maxWorkers=4 --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
+              yarn test:ci --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "native" ]; then
-              yarn test:ci --maxWorkers=4 --selectProjects ReactNative
+              yarn test:ci --selectProjects ReactNative
             else
               curl -Os https://uploader.codecov.io/latest/linux/codecov;
               chmod +x codecov;
-              yarn run test:coverage --ci --maxWorkers=3 --selectProjects ReactDOM Node --coverageReporters=text-lcov > ./lcov.info;
+              yarn run test:coverage --ci --selectProjects ReactDOM Node --coverageReporters=text-lcov > ./lcov.info;
               if [ "$CODECOV_TOKEN" != "" ]; then
                 ./codecov -t ${CODECOV_TOKEN} < ./lcov.info || true;
               else

--- a/packages/core/src/manager/__tests__/pollingSubscription.ts
+++ b/packages/core/src/manager/__tests__/pollingSubscription.ts
@@ -394,6 +394,8 @@ describe('PollingSubscription', () => {
     });
 
     it('should not run when timeoutId is deleted after coming online', () => {
+      // Silence console.warn for this test
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const listener = new MockConnectionListener(false);
       const { dispatch, pollingSubscription } = createMocks(listener);
       expect(dispatch.mock.calls.length).toBe(0);
@@ -406,6 +408,8 @@ describe('PollingSubscription', () => {
       expect(dispatch.mock.calls.length).toBe(0);
       expect(listener.offlineHandlers.length).toBe(1);
       expect(listener.onlineHandlers.length).toBe(0);
+      expect(warnSpy.mock.calls.length).toBe(1);
+      warnSpy.mockRestore();
     });
 
     it('should stop dispatching when offline again', () => {

--- a/packages/endpoint/src/schemas/__tests__/All.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/All.test.ts
@@ -18,7 +18,6 @@ import { fromJSState } from './denormalize';
 let dateSpy: jest.Spied<typeof Date.now>;
 beforeAll(() => {
   dateSpy = jest
-
     .spyOn(global.Date, 'now')
     .mockImplementation(() => new Date('2019-05-14T11:01:58.135Z').valueOf());
 });
@@ -65,6 +64,7 @@ describe.each([[]])(`${schema.All.name} normalization (%s)`, () => {
     });
 
     test('normalizes multiple entities', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const inferSchemaFn = jest.fn(input => input.type || 'dogs');
       class Person extends IDEntity {}
       const listSchema = new schema.All(
@@ -84,6 +84,8 @@ describe.each([[]])(`${schema.All.name} normalization (%s)`, () => {
       expect(result).toBeUndefined();
       expect(entities).toMatchSnapshot();
       expect(inferSchemaFn.mock.calls).toMatchSnapshot();
+      expect(warnSpy.mock.calls).toMatchSnapshot();
+      warnSpy.mockRestore();
     });
 
     test('normalizes Objects using their values', () => {

--- a/packages/endpoint/src/schemas/__tests__/Array.test.js
+++ b/packages/endpoint/src/schemas/__tests__/Array.test.js
@@ -94,6 +94,7 @@ describe.each([
 
   describe('Class', () => {
     class Cats extends IDEntity {}
+    class Dogs extends IDEntity {}
     test('normalizes a single entity', () => {
       const listSchema = createSchema(Cats);
       expect(
@@ -108,6 +109,7 @@ describe.each([
         {
           Cat: Cats,
           people: Person,
+          dogs: Dogs,
         },
         inferSchemaFn,
       );
@@ -121,6 +123,31 @@ describe.each([
         ]),
       ).toMatchSnapshot();
       expect(inferSchemaFn.mock.calls).toMatchSnapshot();
+    });
+
+    test('normalizes multiple entities warning when type is not found', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const inferSchemaFn = jest.fn(input => input.type || 'dogs');
+      class Person extends IDEntity {}
+      const listSchema = new schema.Array(
+        {
+          Cat: Cats,
+          people: Person,
+        },
+        inferSchemaFn,
+      );
+
+      expect(
+        normalize(listSchema, [
+          { type: 'Cat', id: '123' },
+          { type: 'people', id: '123' },
+          { type: 'not found', id: '789' },
+          { type: 'Cat', id: '456' },
+        ]),
+      ).toMatchSnapshot();
+      expect(inferSchemaFn.mock.calls).toMatchSnapshot();
+      expect(warnSpy.mock.calls).toMatchSnapshot();
+      warnSpy.mockRestore();
     });
 
     test('normalizes Objects using their values', () => {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/All.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/All.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AllSchema normalization (%s) Class filters out undefined and null normalized values 1`] = `
 {
@@ -258,6 +258,20 @@ exports[`AllSchema normalization (%s) Class normalizes multiple entities 2`] = `
       },
     ],
     undefined,
+  ],
+]
+`;
+
+exports[`AllSchema normalization (%s) Class normalizes multiple entities 3`] = `
+[
+  [
+    "Schema attribute "dogs" is not expected.
+Expected one of: "Cat", "people"
+
+Value: {
+  "id": "789",
+  "name": "fido"
+}",
   ],
 ]
 `;

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ArraySchema normalization (plain) Class does not filter out undefined and null normalized values 1`] = `
 {
@@ -108,6 +108,12 @@ exports[`ArraySchema normalization (plain) Class normalizes multiple entities 1`
         "type": "Cat",
       },
     },
+    "Dogs": {
+      "789": {
+        "id": "789",
+        "name": "fido",
+      },
+    },
     "Person": {
       "123": {
         "id": "123",
@@ -123,6 +129,13 @@ exports[`ArraySchema normalization (plain) Class normalizes multiple entities 1`
         "fetchedAt": 0,
       },
       "456": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Dogs": {
+      "789": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
@@ -148,7 +161,7 @@ exports[`ArraySchema normalization (plain) Class normalizes multiple entities 1`
     },
     {
       "id": "789",
-      "name": "fido",
+      "schema": "dogs",
     },
     {
       "id": "456",
@@ -363,6 +376,288 @@ exports[`ArraySchema normalization (plain) Class normalizes multiple entities 2`
 ]
 `;
 
+exports[`ArraySchema normalization (plain) Class normalizes multiple entities warning when type is not found 1`] = `
+{
+  "entities": {
+    "Cats": {
+      "123": {
+        "id": "123",
+        "type": "Cat",
+      },
+      "456": {
+        "id": "456",
+        "type": "Cat",
+      },
+    },
+    "Person": {
+      "123": {
+        "id": "123",
+        "type": "people",
+      },
+    },
+  },
+  "entitiesMeta": {
+    "Cats": {
+      "123": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "456": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Person": {
+      "123": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    {
+      "id": "123",
+      "schema": "Cat",
+    },
+    {
+      "id": "123",
+      "schema": "people",
+    },
+    {
+      "id": "789",
+      "type": "not found",
+    },
+    {
+      "id": "456",
+      "schema": "Cat",
+    },
+  ],
+}
+`;
+
+exports[`ArraySchema normalization (plain) Class normalizes multiple entities warning when type is not found 2`] = `
+[
+  [
+    {
+      "id": "123",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "123",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "123",
+      "type": "people",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "123",
+      "type": "people",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "789",
+      "type": "not found",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "789",
+      "type": "not found",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "456",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "456",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+]
+`;
+
+exports[`ArraySchema normalization (plain) Class normalizes multiple entities warning when type is not found 3`] = `
+[
+  [
+    "Schema attribute "not found" is not expected.
+Expected one of: "Cat", "people"
+
+Value: {
+  "type": "not found",
+  "id": "789"
+}",
+  ],
+]
+`;
+
 exports[`ArraySchema normalization (plain) Object normalizes Objects using their values 1`] = `
 {
   "entities": {
@@ -573,6 +868,12 @@ exports[`ArraySchema normalization (schema) Class normalizes multiple entities 1
         "type": "Cat",
       },
     },
+    "Dogs": {
+      "789": {
+        "id": "789",
+        "name": "fido",
+      },
+    },
     "Person": {
       "123": {
         "id": "123",
@@ -588,6 +889,13 @@ exports[`ArraySchema normalization (schema) Class normalizes multiple entities 1
         "fetchedAt": 0,
       },
       "456": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Dogs": {
+      "789": {
         "date": 1557831718135,
         "expiresAt": Infinity,
         "fetchedAt": 0,
@@ -613,7 +921,7 @@ exports[`ArraySchema normalization (schema) Class normalizes multiple entities 1
     },
     {
       "id": "789",
-      "name": "fido",
+      "schema": "dogs",
     },
     {
       "id": "456",
@@ -824,6 +1132,288 @@ exports[`ArraySchema normalization (schema) Class normalizes multiple entities 2
       },
     ],
     undefined,
+  ],
+]
+`;
+
+exports[`ArraySchema normalization (schema) Class normalizes multiple entities warning when type is not found 1`] = `
+{
+  "entities": {
+    "Cats": {
+      "123": {
+        "id": "123",
+        "type": "Cat",
+      },
+      "456": {
+        "id": "456",
+        "type": "Cat",
+      },
+    },
+    "Person": {
+      "123": {
+        "id": "123",
+        "type": "people",
+      },
+    },
+  },
+  "entitiesMeta": {
+    "Cats": {
+      "123": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "456": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "Person": {
+      "123": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    {
+      "id": "123",
+      "schema": "Cat",
+    },
+    {
+      "id": "123",
+      "schema": "people",
+    },
+    {
+      "id": "789",
+      "type": "not found",
+    },
+    {
+      "id": "456",
+      "schema": "Cat",
+    },
+  ],
+}
+`;
+
+exports[`ArraySchema normalization (schema) Class normalizes multiple entities warning when type is not found 2`] = `
+[
+  [
+    {
+      "id": "123",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "123",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "123",
+      "type": "people",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "123",
+      "type": "people",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "789",
+      "type": "not found",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "789",
+      "type": "not found",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "456",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  [
+    {
+      "id": "456",
+      "type": "Cat",
+    },
+    [
+      {
+        "id": "123",
+        "type": "Cat",
+      },
+      {
+        "id": "123",
+        "type": "people",
+      },
+      {
+        "id": "789",
+        "type": "not found",
+      },
+      {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+]
+`;
+
+exports[`ArraySchema normalization (schema) Class normalizes multiple entities warning when type is not found 3`] = `
+[
+  [
+    "Schema attribute "not found" is not expected.
+Expected one of: "Cat", "people"
+
+Value: {
+  "type": "not found",
+  "id": "789"
+}",
   ],
 ]
 `;

--- a/packages/react/src/components/__tests__/AsyncBoundary.web.tsx
+++ b/packages/react/src/components/__tests__/AsyncBoundary.web.tsx
@@ -64,6 +64,7 @@ describe('<AsyncBoundary />', () => {
     expect(renderCount).toBeLessThan(10);
   });
   it('should render error case when thrown', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     function Throw(): ReactElement {
       throw new NetworkError(
         new Response('you failed', {
@@ -81,8 +82,10 @@ describe('<AsyncBoundary />', () => {
     const { getByText, queryByText } = render(tree);
     expect(getByText(/500/i)).not.toBeNull();
     expect(queryByText(/hi/i)).toBe(null);
+    errorSpy.mockRestore();
   });
   it('should render response.statusText using default fallback', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     function Throw(): ReactElement {
       const response = new Response('', {
         statusText: 'my status text',
@@ -99,5 +102,6 @@ describe('<AsyncBoundary />', () => {
     const { getByText, queryByText } = render(tree);
     expect(getByText(/my status text/i)).not.toBeNull();
     expect(queryByText(/hi/i)).toBe(null);
+    errorSpy.mockRestore();
   });
 });

--- a/packages/react/src/components/__tests__/ErrorBoundary.native.tsx
+++ b/packages/react/src/components/__tests__/ErrorBoundary.native.tsx
@@ -48,6 +48,8 @@ describe('<ErrorBoundary />', () => {
   });
 
   it('should render response.statusText using default fallback', () => {
+    const originalError = console.error;
+    console.error = jest.fn();
     function Throw(): ReactElement {
       const response = new Response('', {
         statusText: 'my status text',
@@ -64,8 +66,11 @@ describe('<ErrorBoundary />', () => {
     const { getByText, queryByText } = render(tree);
     expect(getByText(/my status text/i)).not.toBeNull();
     expect(queryByText(/hi/i)).toBe(null);
+    console.error = originalError;
   });
   it('should reset error when handler is called from fallback component', async () => {
+    const originalError = console.error;
+    console.error = jest.fn();
     let shouldThrow = true;
     function Throw(): ReactElement {
       const response = new Response('', {
@@ -98,10 +103,14 @@ describe('<ErrorBoundary />', () => {
     expect(getByText(/my status text/i)).not.toBeNull();
     const resetButton = queryByText('Clear Error');
     expect(resetButton).not.toBeNull();
-    if (!resetButton) return;
+    if (!resetButton) {
+      console.error = originalError;
+      return;
+    }
     shouldThrow = false;
     fireEvent.press(resetButton);
     expect(queryByText(/my status text/i)).toBe(null);
     expect(getByText(/hi/i)).not.toBeNull();
+    console.error = originalError;
   });
 });

--- a/packages/react/src/components/__tests__/ErrorBoundary.tsx
+++ b/packages/react/src/components/__tests__/ErrorBoundary.tsx
@@ -5,14 +5,17 @@ import { ReactElement } from 'react';
 import ErrorBoundary from '../ErrorBoundary';
 
 describe('<ErrorBoundary />', () => {
+  let errorSpy: jest.SpyInstance;
   function onError(e: any) {
     e.preventDefault();
   }
   beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     if (typeof addEventListener === 'function')
       addEventListener('error', onError);
   });
   afterEach(() => {
+    errorSpy.mockRestore();
     if (typeof removeEventListener === 'function')
       removeEventListener('error', onError);
   });
@@ -23,8 +26,6 @@ describe('<ErrorBoundary />', () => {
     expect(getByText(/hi/i)).not.toBeNull();
   });
   it('should catch non-network errors', () => {
-    const originalError = console.error;
-    console.error = jest.fn();
     let renderCount = 0;
     function Throw(): ReactElement {
       renderCount++;
@@ -38,7 +39,6 @@ describe('<ErrorBoundary />', () => {
     );
     const { getByText } = render(tree);
     expect(getByText(/you failed/i)).toBeDefined();
-    console.error = originalError;
     expect(renderCount).toBeLessThan(10);
   });
   it('should render error case when thrown', () => {

--- a/packages/react/src/hooks/__tests__/__snapshots__/useQuery.tsx.snap
+++ b/packages/react/src/hooks/__tests__/__snapshots__/useQuery.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`useQuery() should retrieve a nested collection 1`] = `
 [
@@ -41,6 +41,21 @@ exports[`useQuery() should select Collections 1`] = `
     "tags": [],
     "title": "the next time",
   },
+]
+`;
+
+exports[`useQuery() should work with unions 1`] = `
+[
+  [
+    "Schema attribute "another" is not expected.
+Expected one of: "first", "second"
+
+Value: {
+  "id": "6",
+  "body": "hi",
+  "type": "another"
+}",
+  ],
 ]
 `;
 

--- a/packages/react/src/hooks/__tests__/useController/reset.tsx
+++ b/packages/react/src/hooks/__tests__/useController/reset.tsx
@@ -150,6 +150,7 @@ describe('resetEntireStore', () => {
      *    promises still reject so external listeners know (abort signals do this as well)
      */
     it('should not set fetches that started before RESET', async () => {
+      const consoleSpy = jest.spyOn(console, 'log');
       const detail: FixtureEndpoint = {
         endpoint: CoolerArticleDetail,
         args: [{ id: 9999 }],
@@ -189,6 +190,16 @@ describe('resetEntireStore', () => {
 
       // should still not be resolved as we aren't useSuspense() and didn't manually fetch
       expect(result.current?.title).not.toEqual('latest and greatest title');
+
+      expect(consoleSpy.mock.calls).toMatchInlineSnapshot(`
+       [
+         [
+           "...",
+           [ResetError: Aborted due to RESET],
+         ],
+       ]
+      `);
+      consoleSpy.mockRestore();
     });
 
     /**

--- a/packages/use-enhanced-reducer/src/__tests__/__snapshots__/middleware.tsx.snap
+++ b/packages/use-enhanced-reducer/src/__tests__/__snapshots__/middleware.tsx.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`createEnhancedReducerHook warns when dispatching during middleware setup 1`] = `"Dispatching while constructing your middleware is not allowed. Other middleware would not be applied to this dispatch."`;

--- a/packages/use-enhanced-reducer/src/__tests__/middleware.tsx
+++ b/packages/use-enhanced-reducer/src/__tests__/middleware.tsx
@@ -210,18 +210,25 @@ describe('createEnhancedReducerHook', () => {
   });
 
   it('warns when dispatching during middleware setup', () => {
-    function dispatchingMiddleware({
-      dispatch,
-    }: {
-      dispatch: (...args: any) => any;
-    }) {
-      dispatch({ type: 'dispatch', payload: 5 });
-      return (next: (...args: any) => any) => (action: any) => next(action);
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      function dispatchingMiddleware({
+        dispatch,
+      }: {
+        dispatch: (...args: any) => any;
+      }) {
+        dispatch({ type: 'dispatch', payload: 5 });
+        return (next: (...args: any) => any) => (action: any) => next(action);
+      }
+      const { result } = renderHook(() => {
+        useEnhancedReducer(state => state, {}, [dispatchingMiddleware]);
+      });
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toMatchSnapshot();
+    } finally {
+      consoleErrorSpy.mockRestore();
     }
-    const { result } = renderHook(() => {
-      useEnhancedReducer(state => state, {}, [dispatchingMiddleware]);
-    });
-    expect(result.error).toBeDefined();
-    expect(result.error?.message).toMatchSnapshot();
   });
 });


### PR DESCRIPTION

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Significant memory usage for our tests by splitting typechecking out as well as other optimizations
