### PR TITLE
feat: Add Collection.remove

### DIFF
--- a/.changeset/pink-waves-judge.md
+++ b/.changeset/pink-waves-judge.md
@@ -1,0 +1,17 @@
+---
+'@data-client/endpoint': patch
+'@data-client/graphql': patch
+'@data-client/rest': patch
+---
+
+Add Collection.remove
+
+```ts
+ctrl.set(MyResource.getList.schema.remove, { id });
+```
+
+```ts
+const removeItem = MyResource.delete.extend({
+  schema: MyResource.getList.schema.remove
+})
+```

--- a/docs/rest/api/Collection.md
+++ b/docs/rest/api/Collection.md
@@ -430,6 +430,20 @@ A creation schema that places at the _end_ of this collection
 
 A creation schema that places at the _start_ of this collection
 
+### remove
+
+Remove item[s] from a collection by value.
+
+```ts
+ctrl.set(MyResource.getList.schema.remove, { id });
+```
+
+```ts
+const removeItem = MyResource.delete.extend({
+  schema: MyResource.getList.schema.remove
+})
+```
+
 ### assign
 
 A creation schema that [assigns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)

--- a/packages/endpoint/src/schemaTypes.ts
+++ b/packages/endpoint/src/schemaTypes.ts
@@ -153,6 +153,11 @@ export interface CollectionInterface<
    */
   unshift: CollectionArrayAdder<S>;
 
+  /** Schema to remove (by value) from a Collection
+   * @see https://dataclient.io/rest/api/Collection#remove
+   */
+  remove: CollectionArrayAdder<S>;
+
   /** Schema to merge with a Values Collection
    * @see https://dataclient.io/rest/api/Collection#assign
    */

--- a/packages/endpoint/src/schemas/Collection.ts
+++ b/packages/endpoint/src/schemas/Collection.ts
@@ -19,6 +19,10 @@ const unshiftMerge = (existing: any, incoming: any) => {
 const valuesMerge = (existing: any, incoming: any) => {
   return { ...existing, ...incoming };
 };
+const removeMerge = (existing: Array<any>, incoming: any) => {
+  return existing.filter((item: any) => !incoming.includes(item));
+};
+
 const createArray = (value: any) => [...value];
 const createValue = (value: any) => ({ ...value });
 
@@ -47,6 +51,9 @@ export default class CollectionSchema<
   : undefined;
 
   declare assign: S extends ValuesType<any> ? CollectionSchema<S, Args, Parent>
+  : undefined;
+
+  declare remove: S extends ArrayType<any> ? CollectionSchema<S, Args, Parent>
   : undefined;
 
   addWith<P extends any[] = Args>(
@@ -118,6 +125,7 @@ export default class CollectionSchema<
       this.createIfValid = createArray;
       this.push = CreateAdder(this, pushMerge);
       this.unshift = CreateAdder(this, unshiftMerge);
+      this.remove = CreateAdder(this, removeMerge);
     } else if (schema instanceof Values) {
       this.createIfValid = createValue;
       this.assign = CreateAdder(this, valuesMerge);

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Collection.test.ts.snap
@@ -178,6 +178,199 @@ exports[`CollectionSchema normalization normalizes push onto the end 1`] = `
 }
 `;
 
+exports[`CollectionSchema normalization normalizes remove from collection 1`] = `
+{
+  "entities": {
+    "Todo": {
+      "5": {
+        "id": "5",
+        "title": "finish collections",
+      },
+      "6": {
+        "id": "6",
+        "title": "another todo",
+      },
+    },
+    "User": {
+      "1": {
+        "id": "1",
+        "todos": "{"userId":"1"}",
+        "username": "bob",
+      },
+    },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "6",
+      ],
+    },
+  },
+  "entitiesMeta": {
+    "Todo": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "6": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "User": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "[Todo]": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    "5",
+  ],
+}
+`;
+
+exports[`CollectionSchema normalization normalizes remove from collection with multiple items 1`] = `
+{
+  "entities": {
+    "Todo": {
+      "5": {
+        "id": "5",
+        "title": "finish collections",
+      },
+      "6": {
+        "id": "6",
+        "title": "another todo",
+      },
+      "7": {
+        "id": "7",
+        "title": "third todo",
+      },
+    },
+    "User": {
+      "1": {
+        "id": "1",
+        "todos": "{"userId":"1"}",
+        "username": "bob",
+      },
+    },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "5",
+        "7",
+      ],
+    },
+  },
+  "entitiesMeta": {
+    "Todo": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "6": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "7": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "User": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "[Todo]": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    "6",
+  ],
+}
+`;
+
+exports[`CollectionSchema normalization normalizes remove non-existent item from collection 1`] = `
+{
+  "entities": {
+    "Todo": {
+      "5": {
+        "id": "5",
+        "title": "finish collections",
+      },
+      "99": {
+        "id": "99",
+        "title": "non-existent todo",
+      },
+    },
+    "User": {
+      "1": {
+        "id": "1",
+        "todos": "{"userId":"1"}",
+        "username": "bob",
+      },
+    },
+    "[Todo]": {
+      "{"userId":"1"}": [
+        "5",
+      ],
+    },
+  },
+  "entitiesMeta": {
+    "Todo": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+      "99": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "User": {
+      "1": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+    "[Todo]": {
+      "{"userId":"1"}": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": [
+    "99",
+  ],
+}
+`;
+
 exports[`CollectionSchema normalization normalizes top level collections (no args) 1`] = `
 {
   "entities": {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Invalidate() removes everywhere, but what if we want to just remove from one collection and keep in others?

https://backbonejs.org/#Collection-remove

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Response: Take input like Invalidate (either pk directly or an object to run pk on)
- Usage: Operate like push/unshift/assign (TodoResource.getList.remove({ id: ‘5’ }))

```ts
ctrl.set(MyResource.getList.schema.remove, { id });
```

or

```ts
ctrl.fetch(MyResource.getList.remove, { id });
```

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
- What about Values?
- What about RestEndpoint extenders? (like getList.push)