### PR TITLE
fix: git+ssh repository URLs so Node 26 can run yarn build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -127,7 +127,7 @@
   "homepage": "https://dataclient.io",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/core"
   },
   "bugs": {

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -127,7 +127,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/endpoint"
   },
   "bugs": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://dataclient.io/docs/graphql",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/graphql"
   },
   "bugs": {

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://dataclient.io/docs/guides/img-media#just-images",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/img"
   },
   "bugs": {

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -116,7 +116,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/normalizr"
   },
   "bugs": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://dataclient.io",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/react"
   },
   "bugs": {

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://dataclient.io/rest",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/rest"
   },
   "bugs": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://dataclient.io/docs/guides/storybook",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/test"
   },
   "bugs": {

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/reactive/data-client/tree/master/packages/use-enhanced-reducer#readme",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/use-enhanced-reducer"
   },
   "bugs": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://dataclient.io",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:reactive/data-client.git",
+    "url": "git+ssh://git@github.com/reactive/data-client.git",
     "directory": "packages/vue"
   },
   "bugs": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes environment build [bld-20260814-c311fca4-2c8f-43f8-ae7b-caecb63b847d](https://cursor.com/dashboard/cloud-agents/builds/bld-20260814-c311fca4-2c8f-43f8-ae7b-caecb63b847d) (`INSTALL_FAILED`).

### Motivation

Cloud Agent install runs `nvm install` (Node 26 from `.nvmrc`) then `yarn build`. That build failed in `@data-client/normalizr` and `@data-client/endpoint`:

```
ERROR: The argument 'url' git+ssh://git@github.com:reactive/data-client.git. Received 'Invalid port in url'
```

Package `repository.url` values used the SCP-style colon (`github.com:org/repo`). Node 26's `url.parse()` treats the segment after `:` as a port and throws `ERR_INVALID_ARG_VALUE`. `npm-run-all` (`run-s` via `yarn g:runs`) parses each package.json during `build:bundle`, so the workspace build exits 1.

CircleCI uses `ci:build*` (babel/types only), so this did not show up in PR CI. Node 22 only deprecates the same URL (`DEP0170`).

### Solution

Use the WHATWG-valid git+ssh form in every published package:

`git+ssh://git@github.com/reactive/data-client.git`

(slash after the host, matching `@anansi/generator-js`). No environment install-script change is required once this is on the default branch.

### Verification

On Node 26.7.0 (same as the failed build):

- `url.parse('git+ssh://git@github.com:reactive/data-client.git')` throws the exact install error
- `url.parse('git+ssh://git@github.com/reactive/data-client.git')` succeeds
- `yarn workspace @data-client/normalizr run build:bundle` and the endpoint equivalent succeed
- Full `yarn build` completes in 53s (the step that exited 1 in the environment install)

### Open questions

None. Recurring environment builds of `master` will keep failing until this merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f16078f-5941-45f4-b817-19ce751a0e87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f16078f-5941-45f4-b817-19ce751a0e87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

