### PR TITLE
internal: Pin principal-advisor to Claude Fable 5.1 xhigh

### DIFF
--- a/.cursor/agents/principal-advisor.md
+++ b/.cursor/agents/principal-advisor.md
@@ -1,7 +1,7 @@
 ---
 name: principal-advisor
 description: Principal-level advisor for the single highest-stakes decision in a task - architecture choices, subtle concurrency/correctness reasoning, security-critical review, or contested designs where cheaper advisors disagreed or hedged. Slow and expensive; use at most once per task and launch in the background so implementation of independent parts continues while it thinks. Provide a complete context packet.
-model: claude-fable-5-thinking-high
+model: claude-fable-5-1[effort=xhigh]
 readonly: true
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes # .

### Motivation

`principal-advisor` was pinned to Fable 5 high thinking (`claude-fable-5-thinking-high`). Fable 5.1 is the current Mythos-class model, with cheaper prompt-cache reads, and thinking is always-on adaptive — extra-high effort is the documented control for deepest reasoning.

### Solution

Pin the subagent frontmatter to Cursor’s model-parameter form:

```yaml
model: claude-fable-5-1[effort=xhigh]
```

This follows [subagent model configuration](https://cursor.com/docs/subagents) (`id[effort=…]`) and Anthropic’s Fable 5.1 ID (`claude-fable-5-1`).

### Open questions

None.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3ef6dd8-fe0e-4b46-b819-9c7bb105df56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3ef6dd8-fe0e-4b46-b819-9c7bb105df56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

